### PR TITLE
Check remote calls and load remote module types on demand

### DIFF
--- a/gradualizer_db.erl
+++ b/gradualizer_db.erl
@@ -1,0 +1,391 @@
+%% Copyright 2018 Viktor Söderqvist
+%% See the LICENSE file shipped with this file.
+
+%% @doc Collect exported functions and types from multiple files.
+%%
+%% For exported functions with missing spec, a spec is generated with any()
+%% as the type for all parameters and return values.
+-module(gradualizer_db).
+
+%% API functions
+-export([start_link/0,
+         get_spec/3, get_type/3,
+         save/1, load/1,
+         import_files/1, import_app/1, import_otp/0]).
+
+%% Callbacks
+-behaviour(gen_server).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
+         code_change/3]).
+
+%% Types for the Erlang Abstract Format
+-type line() :: non_neg_integer().
+
+-type type() :: {type, line(), atom(), [type()] | any} |
+                {var, line(), atom()} |
+                {integer, line(), integer()} |
+                {atom, line(), atom()}.
+
+%% Gen server local registered name
+-define(name, ?MODULE).
+
+%% Internal data
+-record(typeinfo, {exported :: boolean(),
+                   opaque   :: boolean(),
+                   params   :: [{var, _, atom()}],
+                   body     :: type()}).
+
+%% Public API functions
+
+start_link() ->
+    gen_server:start_link({local, ?name}, ?MODULE, #{}, []).
+
+-spec get_spec(M :: module(), F :: atom(), A :: arity()) ->
+        {ok, [type()]} | not_found.
+get_spec(M, F, A) ->
+    gen_server:call(?name, {get_spec, M, F, A}).
+
+-spec get_type(Module :: module(), Type :: atom(), Params :: [type()]) ->
+        {ok, type()} | not_found.
+get_type(M, T, A) ->
+    gen_server:call(?name, {get_type, M, T, A}).
+
+-spec save(Filename :: any()) -> ok | {error, any()}.
+save(Filename) ->
+    gen_server:call(?name, {save, Filename}).
+
+-spec load(Filename :: any()) -> ok | {error, any()}.
+load(Filename) ->
+    gen_server:call(?name, {load, Filename}).
+
+import_files(Files) ->
+    gen_server:call(?name, {import_files, Files}, infinity).
+
+-spec import_app(App :: atom()) -> ok.
+import_app(App) ->
+    gen_server:call(?name, {import_app, App}, infinity).
+
+-spec import_otp() -> ok.
+import_otp() ->
+    gen_server:call(?name, import_otp, infinity).
+
+%% ----------------------------------------------------------------------------
+
+%% Gen_server
+
+-type opts() :: #{autoimport => boolean()}.
+-define(default_opts, #{autoimport => true}).
+
+-record(state, {specs  = #{} :: #{mfa() => [type()]},
+                types  = #{} :: #{mfa() => #typeinfo{}},
+                opts   = ?default_opts :: opts(),
+                srcmap = #{} :: #{module() => string()},
+                loaded = #{} :: #{module() => boolean()}}).
+
+-type state() :: #state{}.
+
+-spec init(opts()) -> {ok, state()}.
+init(Opts0) ->
+    Opts = maps:merge(?default_opts, Opts0),
+    State1 = #state{opts = Opts},
+    State2 = case Opts of
+                 #{autoimport := true} ->
+                    State1#state{srcmap = get_src_map()};
+                 _ ->
+                    State1
+             end,
+    {ok, State2}.
+
+-spec handle_call(any(), pid(), state()) -> {reply, state()}.
+handle_call({get_spec, M, F, A}, _From, State) ->
+    State1 = autoimport(M, State),
+    K = {M, F, A},
+    case State#state.specs of
+        #{K := Types} -> {reply, {ok, Types}, State1};
+        _NoMatch      -> {reply, not_found, State1}
+    end;
+handle_call({get_type, M, T, A}, _From, State) ->
+    State1 = autoimport(M, State),
+    K = {M, T, length(A)},
+    case State1#state.types of
+        #{K := TypeInfo} ->
+            Type1 = case TypeInfo of
+                        #typeinfo{opaque = true} ->
+                            %% Don't expand opaques (toggle option?)
+                            {opaque, M, T, A};
+                        #typeinfo{params = Vars,
+                                  body = Type} ->
+                            %% TODO: Add another function 'get_exported_type'
+                            %%       that checks the 'exported' flag
+                            VarMap = maps:from_list(lists:zip(Vars, A)),
+                            substitute_type_vars(Type, VarMap)
+                    end,
+            {reply, {ok, Type1}, State1};
+        _NoMatch ->
+            {reply, not_found, State}
+    end;
+handle_call({save, Filename}, _From, State) ->
+    Str = io_lib:format("~p.~n", [State]),
+    Gz  = zlib:gzip(Str),
+    Res = file:write_file(Filename, Gz),
+    {reply, Res, State};
+handle_call({load, Filename}, _From, State) ->
+    case file:read_file(Filename) of
+        {ok, Gz} ->
+            try
+                Bin = zlib:gunzip(Gz),
+                S = binary_to_list(Bin),
+                {ok, Tokens, _} = erl_scan:string(S),
+                {ok, {Sp2, Ty2}} = erl_parse:parse_term(Tokens),
+                true = is_map(Sp2) and is_map(Ty2),
+                #state{specs = Sp1, types = Ty1} = State,
+                NewState = State#state{specs = maps:merge(Sp1, Sp2),
+                                       types = maps:merge(Ty1, Ty2)},
+                {reply, ok, NewState}
+            catch error:E ->
+                {reply, {error, E, erlang:get_stacktrace()}, State}
+            end;
+        {error, Reason} ->
+            {reply, {error, Reason}, State}
+    end;
+handle_call({import_module, Mod}, _From, State) ->
+    case import_module(Mod, State) of
+        {ok, State1} ->
+            {reply, ok, State1};
+        not_found ->
+            {reply, not_found, State}
+    end;
+handle_call({import_files, Files}, _From, State) ->
+    State1 = import_files(Files, State),
+    {reply, ok, State1};
+handle_call({import_app, App}, _From, State) ->
+    Pattern = code:lib_dir(App) ++ "/src/*.erl",
+    Files = filelib:wildcard(Pattern),
+    State1 = import_files(Files, State),
+    {reply, ok, State1};
+handle_call(import_otp, _From, State) ->
+    Pattern = code:lib_dir() ++ "/*/src/*.erl",
+    Files = filelib:wildcard(Pattern),
+    State1 = import_files(Files, State),
+    {reply, ok, State1}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    %when Reason == normal; Reason == shutdown
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ----------------------------------------------------------------------------
+
+%% Helpers
+
+-spec autoimport(module(), state()) -> state().
+autoimport(_M, #state{opts = #{autoimport := false}} = State) ->
+    State;
+autoimport(M, #state{opts = #{autoimport := true},
+                     loaded = Loaded} = State) ->
+    case Loaded of
+        #{M := _} ->
+            %% Alrady loaded or attempted
+            State;
+        _ ->
+            case import_module(M, State) of
+                {ok, State1} -> State1;
+                not_found    -> State
+            end
+    end.
+
+import_module(Mod, State) ->
+    case State#state.srcmap of
+        #{Mod := Filename} ->
+            State1 = import_files([Filename], State),
+            {ok, State1};
+        _ ->
+            not_found
+    end.
+
+import_files([File | Files], State) ->
+    {ok, Forms} = epp:parse_file(File, []),
+    [{attribute, _, file, _},
+     {attribute, _, module, Module} | Forms1] = Forms,
+    Specs    = collect_specs(Module, Forms1),
+    SpecMap1 = add_entries_to_map(Specs, State#state.specs),
+    Types    = collect_types(Module, Forms1),
+    TypeMap1 = add_entries_to_map(Types, State#state.types),
+    Loaded1  = (State#state.loaded)#{Module => true},
+    State1   = State#state{specs  = SpecMap1,
+                           types  = TypeMap1,
+                           loaded = Loaded1},
+    import_files(Files, State1);
+import_files([], St) ->
+    St.
+
+-spec add_entries_to_map([{Key, Value}], #{K => V}) -> #{K => V}
+                                             when Key :: K, Value :: V.
+add_entries_to_map(Entries, Map) ->
+    lists:foldl(fun ({MFA, Types}, MapAcc) ->
+                    %% Maybe TODO: Warn if an element is overwritten
+                    MapAcc#{MFA => Types}
+                end,
+                Map,
+                Entries).
+
+-spec collect_types(module(), Forms :: [tuple()]) -> [{mfa(), #typeinfo{}}].
+%% Collect exported types, including opaques, record definitions,
+%% exported and unexported types
+collect_types(Module, Forms) ->
+    %% ExportedTypes :: [{atom(), arity()}]
+    ExportedTypes = lists:concat([Tys || {attribute, _, export_type,
+                                          Tys} <- Forms]),
+
+    %% Records are represented as types with name = {record, RecordName}
+    TypeDefs = normalize_type_defs(Forms),
+
+    %% Now all type definitions are easy to extract.
+    Types = [begin
+                 Id       = {Module, Name, length(Vars)},
+                 Exported = lists:member(Id, ExportedTypes),
+                 Params   = [VarName || {var, _, VarName} <- Vars],
+                 Info     = #typeinfo{exported = Exported,
+                                      opaque   = (Attr == opaque),
+                                      params   = Params,
+                                      body     = Body},
+                 {Id, Info}
+             end || {attribute, _, Attr, {Name, Body, Vars}} <- TypeDefs,
+                    Attr == type orelse Attr == opaque],
+    Types.
+
+%% Normalize Type Defs
+%% -------------------
+%%
+%% Extracts and normalizes type definitions from a list of forms.
+%%
+%% Normalise record definitions into types (i.e. typed record definitions).
+%% That is, if there is no typed definition of a record among the
+%% forms, create one from the untyped one and normalize so that they
+%% all have a default value.
+%%
+-spec normalize_type_defs(Forms :: [tuple()]) -> Typedefs :: [tuple()].
+normalize_type_defs([{attribute, L, record, {Name, _UntypedFields}},
+                     {attribute, L, type, {{record, Name}, Fields, []}} = R |
+                     Rest]) ->
+    TypedFields = lists:map(fun normalize_record_field/1, Fields),
+    R = {attribute, L, type, {{record, Name}, TypedFields, []}},
+    [R | normalize_type_defs(Rest)];
+normalize_type_defs([{attribute, L, record, {Name, UntypedFields}} | Rest]) ->
+    %% Convert type typed record
+    TypedFields = lists:map(fun normalize_record_field/1, UntypedFields),
+    R = {attribute, L, type, {{record, Name}, TypedFields, []}},
+    [R | normalize_type_defs(Rest)];
+normalize_type_defs([{attribute, _, Attr, {_Name, _Body, _Params}} = T | Rest])
+                                        when Attr == type; Attr == opaque ->
+    %% Normal type or opaque definition
+    [T | normalize_type_defs(Rest)];
+normalize_type_defs([_ | Rest]) ->
+    %% Skip forms that are not type definitions
+    normalize_type_defs(Rest);
+normalize_type_defs([]) ->
+    [].
+
+%% Turns all records into typed records and all record fields into typed
+%% record fields. Adds default 'undefined' if default is missing.
+normalize_record_field({record_field, L, Name = {atom, _, _}}) ->
+    {typed_record_field,
+     {record_field, L, Name, {atom, L, undefined}},
+     {type, L, any, []}};
+normalize_record_field({record_field, L, Name = {atom, _, _}, Default}) ->
+    {typed_record_field,
+     {record_field, L, Name, Default},
+     {type, L, any, []}};
+normalize_record_field({typed_record_field,
+                        {record_field, L, Name = {atom, _, _}},
+                        Type}) ->
+    {typed_record_field,
+     {record_field, L, Name, {atom, L, undefined}},
+     Type};
+normalize_record_field({typed_record_field,
+                        {record_field, _L, {atom, _, _Name}, _Default},
+                        _Type} = Complete) ->
+    Complete.
+
+-spec substitute_type_vars(type(),
+                           %[{{atom(), arity()}, typeinfo()}],
+                           #{atom() => type()}) -> type().
+substitute_type_vars({type, L, T, Params}, TVars) when is_list(Params) ->
+    {type, L, T, [substitute_type_vars(P, TVars) || P <- Params]};
+substitute_type_vars({var, L, Var}, TVars) ->
+    case TVars of
+        #{Var := Type} -> Type;
+        _              -> {var, L, Var}
+    end;
+substitute_type_vars(Other, _) ->
+    Other.
+
+%% Returns specs for all exported functions, generating any-types for unspeced
+%% functions.
+-spec collect_specs(module(), [tuple()]) -> [{mfa(), [type()]}].
+collect_specs(Module, Forms) ->
+    Specs = [normalize_spec(Spec, Module) ||
+                 {attribute, _, spec, Spec} <- Forms],
+    ExportAll = lists:any(fun ({attribute, _, compile, CompileOpts})
+                                when is_list(CompileOpts) ->
+                                  lists:member(export_all, CompileOpts);
+                              ({attribute, _, compile, export_all}) ->
+                                  true;
+                              (_) ->
+                                  false
+                          end,
+                          Forms),
+    Exports =
+        if ExportAll ->
+               [{Name, Arity} || {function, _, Name, Arity, _} <- Forms];
+           true ->
+               lists:concat([Exs || {attribute, _, export, Exs} <- Forms])
+        end,
+
+    SpecedFunsSet = sets:from_list([{F, A} || {{M, F, A}, _} <- Specs,
+                                              M == Module]),
+    ImplicitSpecs = [make_spec(Module, F, A) ||
+            {F, A} <- Exports,
+            not sets:is_element({F, A},
+                        SpecedFunsSet)],
+    Specs ++ ImplicitSpecs.
+
+normalize_spec({{Func, Arity}, Types}, Module) ->
+    {{Module, Func, Arity}, Types};
+normalize_spec(Spec = {{M, F, A}, _Types}, Module) ->
+    M /= Module andalso error_logger:info_report([{spec_for, {M,F,A}},
+                                                  {found_in, Module}]),
+    Spec.
+
+-spec make_spec(module(), atom(), arity()) -> {mfa(), [type()]}.
+make_spec(Module, Name, Arity) ->
+    {{Module, Name, Arity}, [make_function_type(Arity)]}.
+
+%% Creates the function type (any(), any(), ...) -> any().
+make_function_type(Arity) ->
+    {type, 0, 'fun',
+     [{type, 0, product, lists:duplicate(Arity, {type, 0, any, []})},
+      {type, 0, any, []}]}.
+
+-spec get_src_map() -> #{module() => file:filename()}.
+get_src_map() ->
+    SrcDirs = [case lists:reverse(Path) of
+                   "nibe/" ++ Tail -> lists:reverse("lre.*/crs/" ++ Tail);
+                   RevPath         -> lists:reverse("lre.*/" ++ RevPath)
+               end || Path <- code:get_path()],
+    SrcFiles = lists:flatmap(fun filelib:wildcard/1, SrcDirs),
+    {ok, RE} = re:compile(<<"([^/.]*)\.erl$">>),
+    Pairs = [begin
+                 {match, [Mod]} = re:run(Filename, RE,
+                                         [{capture, all_but_first, list}]),
+                 {list_to_atom(Mod), Filename}
+             end || Filename <- SrcFiles],
+    maps:from_list(Pairs).

--- a/gradualizer_db.erl
+++ b/gradualizer_db.erl
@@ -100,7 +100,7 @@ init(Opts0) ->
 handle_call({get_spec, M, F, A}, _From, State) ->
     State1 = autoimport(M, State),
     K = {M, F, A},
-    case State#state.specs of
+    case State1#state.specs of
         #{K := Types} -> {reply, {ok, Types}, State1};
         _NoMatch      -> {reply, not_found, State1}
     end;
@@ -196,6 +196,7 @@ autoimport(M, #state{opts = #{autoimport := true},
             %% Alrady loaded or attempted
             State;
         _ ->
+            %io:format("Loading types from ~p~n", [M]),
             case import_module(M, State) of
                 {ok, State1} -> State1;
                 not_found    -> State

--- a/typechecker.erl
+++ b/typechecker.erl
@@ -573,7 +573,7 @@ type_check_fun(Env, {atom, P, Name}, Arity) ->
 type_check_fun(_Env, {remote, P, {atom,_,Module}, {atom,_,Fun}}, Arity) ->
     % Module:function call
     case gradualizer_db:get_spec(Module, Fun, Arity) of
-	{ok, Types} -> Types;
+	{ok, Types} -> {Types, #{}};
 	not_found   -> throw({call_undef, P, Module, Fun, Arity})
     end;
 type_check_fun(Env, Expr, _Arity) ->
@@ -812,9 +812,8 @@ type_check_file(File) ->
 	collect_specs_types_opaques_and_functions(Forms),
     FEnv = create_fenv(Specs, Funs),
     REnv = create_renv(Records),
-    FEnvWithBuiltins = add_builtin_functions(FEnv),
     lists:foldr(fun (Function, ok) ->
-			try type_check_function(FEnvWithBuiltins, REnv, Function) of
+			try type_check_function(FEnv, REnv, Function) of
 			    {_Ty, _VarBinds} ->
 				ok
 			catch

--- a/typechecker.erl
+++ b/typechecker.erl
@@ -800,6 +800,10 @@ glb_types(_, _) ->
 
 
 type_check_file(File) ->
+    case gradualizer_db:start_link() of
+	{ok, _Pid}                    -> ok;
+	{error, {already_started, _}} -> ok
+    end,
     {ok, Forms} = epp:parse_file(File,[]),
     #parsedata{specs     = Specs
 	      ,functions = Funs

--- a/typechecker.erl
+++ b/typechecker.erl
@@ -231,7 +231,8 @@ type_check_expr(Env, {call, P, Name, Args}) ->
     case  FunTy of
 	{type, _, any, []} ->
 	    { {type, 0, any, []}, VarBind };
-	{type, _, 'fun', [{type, _, product, TyArgs}, ResTy]} ->
+	[{type, _, 'fun', [{type, _, product, TyArgs}, ResTy]}] ->
+	    % TODO: Handle multi-clause function types
 	    % TODO: Push types inwards here, rather than inferring and
 	    % checking
 	    case subtypes(TyArgs, ArgTys) of
@@ -361,6 +362,7 @@ type_check_expr(Env, {op, _, RelOp, Arg1, Arg2}) when
 type_check_expr(Env, {'catch', _, Arg}) ->
     type_check_expr(Env, Arg);
 % TODO: Unclear why there is a list of expressions in try
+% This is why: try f(), g() catch _:_ -> x end.
 type_check_expr(Env, {'try', _, [Expr], CaseCs, CatchCs, AfterCs}) ->
     {Ty,  VB}  = type_check_expr(Env, Expr),
     Env2 = Env#env{ venv = add_var_binds(VB, Env#env.venv) },
@@ -456,7 +458,8 @@ type_check_expr_in(Env, ResTy, {call, _, Name, Args}) ->
 
 	    VarBind = union_var_binds([VarBinds1 |  VarBinds2]),
 	    { {type, 0, any, []}, VarBind };
-	{type, _, 'fun', [{type, _, product, TyArgs}, FunResTy]} ->
+	[{type, _, 'fun', [{type, _, product, TyArgs}, FunResTy]}] ->
+	    % TODO: Handle multi-clause function types
 	    {_, VarBinds2} =
 		lists:unzip([ type_check_expr_in(Env, TyArg, Arg)
 			      || {TyArg, Arg} <- lists:zip(TyArgs, Args) ]),
@@ -553,13 +556,26 @@ type_check_assocs(_Env, []) ->
 
 
 
-type_check_fun(Env, {atom, _, Name}, Arity) ->
+type_check_fun(Env, {atom, P, Name}, Arity) ->
     % Local function call
-    {maps:get({Name, Arity}, Env#env.fenv), #{}};
-type_check_fun(Env, {remote, _, {atom,_,Module}, {atom,_,Fun}}, Arity) ->
+    case maps:find({Name, Arity}, Env#env.fenv) of
+	{ok, Types} ->
+	    {Types, #{}};
+	error ->
+	    case erl_internal:bif(Name, Arity) of
+		true ->
+		    {ok, Types} = gradualizer_db:get_spec(erlang, Name, Arity),
+		    {Types, #{}};
+		false ->
+		    throw({call_undef, P, Name, Arity})
+	    end
+    end;
+type_check_fun(_Env, {remote, P, {atom,_,Module}, {atom,_,Fun}}, Arity) ->
     % Module:function call
-    {maps:get({Module,Fun, Arity}, Env#env.fenv, {type, 0, any, []}), #{}};
-    % TODO: Once we have interfaces, we should not have the default value above.
+    case gradualizer_db:get_spec(Module, Fun, Arity) of
+	{ok, Types} -> Types;
+	not_found   -> throw({call_undef, P, Module, Fun, Arity})
+    end;
 type_check_fun(Env, Expr, _Arity) ->
     type_check_expr(Env, Expr).
 
@@ -637,7 +653,8 @@ check_guards(Env, Guards) ->
 
 type_check_function(FEnv, REnv, {function,_, Name, NArgs, Clauses}) ->
     case maps:find({Name, NArgs}, FEnv) of
-	{ok, {type, _, 'fun', [{type, _, product, ArgsTy}, ResTy]}} ->
+	{ok, [{type, _, 'fun', [{type, _, product, ArgsTy}, ResTy]}]} ->
+	    % TODO: Handle multi-clause function types
 	    {_, VarBinds} = check_clauses(#env{ fenv = FEnv, renv = REnv },
 					  ArgsTy, ResTy, Clauses),
 	    {ResTy, VarBinds};
@@ -784,33 +801,27 @@ glb_types(_, _) ->
 
 type_check_file(File) ->
     {ok, Forms} = epp:parse_file(File,[]),
-    CollectedForms = #parsedata{specs     = Specs
-			       ,functions = Funs
-			       ,records   = Records
-			       } =
+    #parsedata{specs     = Specs
+	      ,functions = Funs
+	      ,records   = Records
+	      } =
 	collect_specs_types_opaques_and_functions(Forms),
     FEnv = create_fenv(Specs, Funs),
     REnv = create_renv(Records),
     FEnvWithBuiltins = add_builtin_functions(FEnv),
-    Res = lists:foldr(fun (Function, ok) ->
-			      try type_check_function(FEnvWithBuiltins, REnv, Function) of
-				  {_Ty, _VarBinds} ->
-				      ok
-			      catch
-				  Throw ->
-				      erlang:display(erlang:get_stacktrace()),
-				      handle_type_error(Throw),
-				      nok
-			      end;
-			  (_Function, Err) ->
-			      Err
-		      end, ok, Funs),
-    case Res of
-	ok ->
-	    store_interface_file(FEnv, CollectedForms);
-	nok ->
-	    nok
-    end.
+    lists:foldr(fun (Function, ok) ->
+			try type_check_function(FEnvWithBuiltins, REnv, Function) of
+			    {_Ty, _VarBinds} ->
+				ok
+			catch
+			    Throw ->
+				erlang:display(erlang:get_stacktrace()),
+				handle_type_error(Throw),
+				nok
+			end;
+		    (_Function, Err) ->
+			Err
+		end, ok, Funs).
 
 create_renv(Records) ->
     maps:from_list(lists:map(fun ({Rec,Fields}) ->
@@ -836,24 +847,9 @@ create_fenv(Specs, Funs) ->
     maps:from_list([ {{Name, NArgs}, {type, 0, any, []}}
 		     || {function,_, Name, NArgs, _Clauses} <- Funs
 		   ] ++
-		   [ {{Name, NArgs}, Type} || {{Name, NArgs}, [Type]} <- Specs
+		   [ {{Name, NArgs}, Types} || {{Name, NArgs}, Types} <- Specs
 		   ]
 		  ).
-
-%% Adds builtin functions to an FEnv
-add_builtin_functions(FEnv) ->
-    FEnv#{
-      {spawn, 1} => {type, 0, 'fun',[{type, 0, product, [{type, 0, any, []}]}
-				    ,{type, 0, any, []}] },
-      {length, 1} => {type, 0, 'fun', [{type, 0, product, [{type, 0, any, []}]}
-				      ,{type, 0, integer, []}] },
-      {throw, 1} => {type, 0, 'fun', [{type, 0, product, [{type, 0, any, []}]}
-				     ,{type, 0, any, []}] },
-      {is_list, 1} => {type, 0, 'fun', [{type, 0, product, [{type, 0, any, []}]}
-				       ,{type, 0, any, []}] },
-      {is_atom, 1} => {type, 0, 'fun', [{type, 0, product, [{type, 0, any, []}]}
-				       ,{type, 0, any, []}] }
-     }.
 
 %% Collect the top level parse tree stuff returned by epp:parse_file/2.
 -spec collect_specs_types_opaques_and_functions(Forms :: list()) -> #parsedata{}.
@@ -889,6 +885,12 @@ aux([{attribute, _, compile, CompileOpts} | Forms], Acc) ->
 aux([_|Forms], Acc) ->
     aux(Forms, Acc).
 
+handle_type_error({call_undef, LINE, Func, Arity}) ->
+    io:format("Call to undefined function ~p/~p on line ~p~n",
+              [Func, Arity, LINE]);
+handle_type_error({call_undef, LINE, Module, Func, Arity}) ->
+    io:format("Call to undefined function ~p:~p/~p on line ~p~n",
+              [Module, Func, Arity, LINE]);
 handle_type_error({type_error, tyVar, LINE, Var, VarTy, Ty}) ->
     io:format("The variable ~p on line ~p has type ~s "
 	      "but is expected to have type ~s~n",


### PR DESCRIPTION
Adds a module `gradualizer_db`, whichs extracts specs and types from other modules, apps or the whole OTP.

A gen_server is used which needs to be started using gradualizer_db:start_link().

The main operation is to load a module on-demand, when a module is needed. Functions to load and save types and specs to files are included but they are not very fast. Perhaps on-demand parsing is the best so far.

Integrated in typechecker and used for remote calls. Not used yet for references to remote types.

Mostly tested by itself, manually. Not very well-tested with the typechecker, since something you added (maps:update_with/4) makes it not run on my old Erlang 18 installation anymore.