### PR TITLE
Various small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Right now the user experience is not very polished. Here's how to get started:
 
   You can try typechecking some of the example modules in the `tests`directory.
 
-The Gradualizer requires at least OTP 18.
+The Gradualizer requires at least OTP 19.
 
 # Status
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Right now the user experience is not very polished. Here's how to get started:
 
   You can try typechecking some of the example modules in the `tests`directory.
 
+The Gradualizer requires at least OTP 18.
+
 # Status
 
 The Gradualizer is in alpha. There are plenty of things that don't work right

--- a/typelib.erl
+++ b/typelib.erl
@@ -109,8 +109,8 @@ substitute_type_vars({Tag, L, T, Params}, TVars) when Tag == type orelse
 						      Tag == user_type,
 						      is_list(Params) ->
     {Tag, L, T, [substitute_type_vars(P, TVars) || P <- Params]};
-substitute_type_vars({remote_type, L, M, T, Params}, TVars) ->
-    {remote_type, L, M, T, [substitute_type_vars(P, TVars) || P <- Params]};
+substitute_type_vars({remote_type, L, [M, T, Params]}, TVars) ->
+    {remote_type, L, [M, T, [substitute_type_vars(P, TVars) || P <- Params]]};
 substitute_type_vars({var, L, Var}, TVars) ->
     case TVars of
         #{Var := Type} -> Type;

--- a/typelib.erl
+++ b/typelib.erl
@@ -15,7 +15,7 @@
 pp_type(Type) ->
     %% erl_pp can handle type definitions, so wrap Type in a type definition
     %% and then take the type from that.
-    Form = {attribute, 0, type, {t, Type, []}},
+    Form = {attribute, erl_anno:new(0), type, {t, Type, []}},
     TypeDef = erl_pp:form(Form),
     {match, [S]} = re:run(TypeDef, <<"::\\s*(.*)\\.\\n*">>,
 			  [{capture, all_but_first, list}, dotall]),


### PR DESCRIPTION
- Consistent naming of varbinds variables
- address Dialyzer warnings
- address some crashes during self-type checking
  current output is:
```
> typechecker:type_check_file("typechecker.erl").
The variable 'Ty1' on line 47 has type type() but is expected to have type type() in typelib.erl
```
I don't know if it is expected or I introduced a regression. The type `type()` both in `typechecker.erl` and `typelib.erl` should be subtype of `erl_parse:abstract_type().`