### PR TITLE
Extend API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DIALYZER_OPTS = -Werror_handling
 include erlang.mk
 
 gradualize: app
-	$(ERL) -pa $(CURDIR)/ebin -eval 'typechecker:type_check_file("src/typechecker.erl"), halt().'
+	$(ERL) -pa $(CURDIR)/ebin -eval 'gradualizer:type_check_file("src/typechecker.erl"), halt().'
 check:: gradualize
 
 # We want warnings to be warnings, not errors.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Right now the user experience is not very polished. Here's how to get started:
 
 * From the prompt you can run the type checker as follows:
 
-  `typechecker:type_check_file(<path/to/some_file.erl>).`
+  `gradualizer:type_check_file(<path/to/some_file.erl>).`
 
   You can try typechecking some of the example modules in the `test` directory.
 

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -1,0 +1,110 @@
+%%% @doc Main external API of the Gradualizer
+%%%
+%%% The functions `type_check(file|module|dir)' accept the following options:
+%%% - `stop_on_first_error': if `true' stop type checking at the first error,
+%%%   if `false' continue checking all functions in the given file and all files
+%%%   in the given directory.
+%%% - `print_file': if `true' prefix error printouts with the file name the
+%%%   error is from.
+-module(gradualizer).
+
+-export([type_check_file/1,
+         type_check_file/2,
+         type_check_module/1,
+         type_check_module/2,
+         type_check_dir/1,
+         type_check_dir/2
+        ]).
+
+-type options() :: proplists:proplist().
+
+%% API functions
+
+%% @doc Type check a source or beam file
+-spec type_check_file(file:filename()) -> ok | nok.
+type_check_file(File) ->
+    type_check_file(File, []).
+
+%% @doc Type check a source or beam file
+-spec type_check_file(file:filename(), options()) -> ok | nok.
+type_check_file(File, Opts) ->
+    Forms =
+        case filename:extension(File) of
+            ".erl" ->
+                get_forms_from_erl(File);
+            ".beam" ->
+                get_forms_from_beam(File);
+            Ext ->
+                throw({unknown_file_extension, Ext})
+        end,
+    Opts2 = proplists:expand([{print_file, [{print_file, File}]}], Opts),
+    typechecker:type_check_forms(Forms, Opts2).
+
+
+%% @doc Type check a module
+-spec type_check_module(module()) -> ok | nok.
+type_check_module(Module) ->
+    type_check_module(Module, []).
+
+%% @doc Type check a module
+-spec type_check_module(module(), options()) -> ok | nok.
+type_check_module(Module, Opts) when is_atom(Module) ->
+    case code:which(Module) of
+        File when is_list(File) ->
+            type_check_file(File, Opts);
+        Error when is_atom(Error) ->
+            throw({beam_not_found, Error})
+    end.
+
+%% @doc Type check all source or beam files in a directory.
+%% (Option `print_file' is implicitely true)
+-spec type_check_dir(file:filename()) -> ok | nok.
+type_check_dir(Dir) ->
+    type_check_dir(Dir, []).
+
+%% @doc Type check all source or beam files in a directory.
+%% (Option `print_file' is implicitely true)
+-spec type_check_dir(file:filename(), options()) -> ok | nok.
+type_check_dir(Dir, Opts) ->
+    case filelib:is_dir(Dir) of
+        true ->
+            StopOnFirstError = proplists:get_bool(stop_on_first_error, Opts),
+            lists:foldl(
+              fun(File, Res) when Res =:= ok;
+                                  not StopOnFirstError ->
+                      case type_check_file(File, [print_file|Opts]) of
+                          ok -> Res;
+                          nok -> nok
+                      end;
+                 (_, Error) ->
+                      Error
+              end, ok, filelib:wildcard(filename:join(Dir, "*.{erl,beam}")));
+        false ->
+            throw({dir_not_found, Dir})
+    end.
+
+%% Helper functions
+
+get_forms_from_erl(File) ->
+    case epp:parse_file(File, []) of
+        {ok, Forms} ->
+            Forms;
+        {error, enoent} ->
+            throw({file_not_found, File});
+        {error, Reason} ->
+            throw({file_open_error, {Reason, File}})
+    end.
+
+get_forms_from_beam(File) ->
+    case beam_lib:chunks(File, [abstract_code]) of
+        {ok, {_Module, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
+            Forms;
+        {ok, {_Module, [{abstract_code,no_abstract_code}]}} ->
+            throw({forms_not_found, File});
+        {error, beam_lib, {file_error, _, enoent}} ->
+            throw({file_not_found, File});
+        {error, beam_lib, {file_error, _, Reason}} ->
+            throw({file_open_error, {Reason, File}});
+        {error, beam_lib, Reason} ->
+            throw({forms_error, Reason})
+    end.

--- a/test/gradualizer_tests.erl
+++ b/test/gradualizer_tests.erl
@@ -1,0 +1,42 @@
+-module(gradualizer_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+api_test_() ->
+    [?_assertEqual(ok, gradualizer:type_check_file("test/should_pass/any.erl")),
+     ?_assertEqual(ok, gradualizer:type_check_file("test/any.beam")),
+     fun() ->
+             {module, Mod} = code:load_abs("test/any"),
+             ?assertEqual(ok, gradualizer:type_check_module(Mod))
+     end,
+     ?_assertEqual(ok, gradualizer:type_check_dir("test/should_pass/")),
+
+     %% Failure cases
+     {"Not found",
+      [?_assertThrow({file_not_found, "test/not_found.erl"},
+                     gradualizer:type_check_file("test/not_found.erl")),
+       ?_assertThrow({file_not_found, "test/not_found.beam"},
+                     gradualizer:type_check_file("test/not_found.beam")),
+       ?_assertThrow({beam_not_found, non_existing},
+                     gradualizer:type_check_module(not_found)),
+       ?_assertThrow({dir_not_found, "test/not_found/"},
+                     gradualizer:type_check_dir("test/not_found/"))
+      ]},
+     {setup,
+      fun() -> file:write_file("test/bad_content.beam", "bad content") end,
+      fun(_) -> file:delete("test/bad_content.beam") end,
+      ?_assertThrow({forms_error,{not_a_beam_file, 'test/bad_content.beam'}},
+                    gradualizer:type_check_file("test/bad_content.beam"))},
+     {setup,
+      fun() ->
+              {ok, any} = compile:file("test/should_pass/any.erl",
+                                       [{outdir, "test/should_pass/"}])
+      end,
+      fun(_) -> file:delete("test/should_pass/any.beam") end,
+      ?_assertThrow({forms_not_found, "test/should_pass/any.beam"},
+                    gradualizer:type_check_file("test/should_pass/any.beam"))},
+     ?_assertThrow({unknown_file_extension, ".bad_ext"},
+                   gradualizer:type_check_file("test/not_found.bad_ext")),
+     ?_assertThrow({beam_not_found, preloaded},
+                   gradualizer:type_check_module(erlang))
+    ].

--- a/test/test.erl
+++ b/test/test.erl
@@ -14,6 +14,6 @@ run_tests_in(Dir, ExpectedRes) ->
     [{filename:basename(Dir) ++ ": " ++ File,
       fun() ->
               FullFile = filename:join(Dir, File),
-              ?assert(ExpectedRes =:= typechecker:type_check_file(FullFile))
+              ?assert(ExpectedRes =:= gradualizer:type_check_file(FullFile))
       end}
      || File <- Files].


### PR DESCRIPTION
Introduce `gradualizer` module which exports following API functions:
- `type_check_module/1/2` (useful for eg. mix task)
- `type_check_file/1/2` that works both for source and beam files
  depending on extension
- `type_check_dir/1/2` that type checks all source and/or beam files in
  the given directory

The main entry point of the core `typechecker` module is `type_check_forms/2`.

@josefs, please let me know what do you think about this reorganization, options
@tim2CF I took your idea, and expanded it a bit, does this look good for a mix task?