### PR TITLE
Fix normalizing local user types

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -324,7 +324,8 @@ normalize({user_type, P, Name, Args} = Type, TEnv) ->
             case TEnv#tenv.types of
                 #{TypeId := {Vars, Type0}} ->
                     VarMap = maps:from_list(lists:zip(Vars, Args)),
-                    typelib:substitute_type_vars(Type0, VarMap);
+                    Type1 = typelib:substitute_type_vars(Type0, VarMap),
+                    normalize(Type1, TEnv);
                 _NotFound ->
                     throw({undef, user_type, {Name, length(Args)}})
             end

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -126,6 +126,16 @@ normalize_test_() ->
      ?_assertEqual(?t( 1..6 ), typechecker:normalize(?t( 1..3|4..6 )))
     ].
 
+normalize_e2e_test_() ->
+    [
+     {"Normalize local user types",
+      %% arg and return type should be both resolved to list(atom())
+      ?_assert(type_check_forms(["-type inner(T) :: list(T).",
+                                 "-type outer(T) :: inner(T).",
+                                 "-spec f(inner(atom())) -> outer(atom()).",
+                                 "f(A) -> A."]))}
+    ].
+
 handle_type_error_test_() ->
     [
      %% {type_error, nil, Line, Ty}


### PR DESCRIPTION
When a user type in the same module as type checked was encountered it
was not normalized further recursively. This was not a problem for user
types in other modules or remote types.

Fixes self-typecheck issue:
> The variable 'Ty1' on line 60 has type type() but is expected to have type type()

closes #15