### PR TITLE
BEAM files support for gradualizer_db

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# Editor configuration file
+# For Emacs install package `editorconfig`
+# For Atom install package `editorconfig`
+# For Sublime Text install package `EditorConfig`
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[*.md]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ rel/example_project
 .erlang.mk
 gradualizer.d
 cover/
+eunit.coverdata
+test/ct.cover.spec

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -28,7 +28,7 @@ type_check_file(File) ->
 %% @doc Type check a source or beam file
 -spec type_check_file(file:filename(), options()) -> ok | nok.
 type_check_file(File, Opts) ->
-    Forms =
+    ParsedFile =
         case filename:extension(File) of
             ".erl" ->
                 gradualizer_file_utils:get_forms_from_erl(File);
@@ -37,8 +37,13 @@ type_check_file(File, Opts) ->
             Ext ->
                 throw({unknown_file_extension, Ext})
         end,
-    Opts2 = proplists:expand([{print_file, [{print_file, File}]}], Opts),
-    typechecker:type_check_forms(Forms, Opts2).
+    case ParsedFile of
+        {ok, Forms} ->
+            Opts2 = proplists:expand([{print_file, [{print_file, File}]}], Opts),
+            typechecker:type_check_forms(Forms, Opts2);
+        Error ->
+            throw(Error)
+    end.
 
 
 %% @doc Type check a module

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -13,7 +13,8 @@
          type_check_module/1,
          type_check_module/2,
          type_check_dir/1,
-         type_check_dir/2
+         type_check_dir/2,
+         get_forms_from_beam/1
         ]).
 
 -type options() :: proplists:proplist().

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -4,6 +4,10 @@
 %% as the type for all parameters and return values.
 -module(gradualizer_db).
 
+-ifdef(OTP_RELEASE).
+-compile([{nowarn_deprecated_function,{erlang,get_stacktrace,0}}]).
+-endif.
+
 %% API functions
 -export([start_link/0,
          get_spec/3,

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -280,29 +280,29 @@ autoimport(M, #state{opts = #{autoimport := true},
     end.
 
 import_module(Mod, State) ->
-  case State#state.beammap of
-    #{Mod := Filename} ->
-      State1 = import_files([Filename], State),
-      {ok, State1};
-    _ ->
-      case State#state.srcmap of
-          #{Mod := Filename} ->
-              State1 = import_files([Filename], State),
-              {ok, State1};
-          _ ->
-              not_found
-      end
-  end.
+    case State#state.beammap of
+        #{Mod := Filename} ->
+            State1 = import_files([Filename], State),
+            {ok, State1};
+        _ ->
+          case State#state.srcmap of
+              #{Mod := Filename} ->
+                  State1 = import_files([Filename], State),
+                  {ok, State1};
+              _ ->
+                  not_found
+          end
+    end.
 
 import_files([File | Files], State) ->
     {ok, Forms} =
-      case re:run(File, beam_file_regexp()) of
-        {match, _} ->
-          {ok, gradualizer:get_forms_from_beam(File)};
-        nomatch ->
-          EppOpts = [{includes, guess_include_dirs(File)}],
-          epp:parse_file(File, EppOpts)
-      end,
+        case re:run(File, beam_file_regexp()) of
+            {match, _} ->
+                {ok, gradualizer:get_forms_from_beam(File)};
+            nomatch ->
+                EppOpts = [{includes, guess_include_dirs(File)}],
+                epp:parse_file(File, EppOpts)
+        end,
     [{attribute, _, file, _},
      {attribute, _, module, Module} | Forms1] = Forms,
     check_epp_errors(File, Forms1),
@@ -481,20 +481,21 @@ get_src_map() ->
 
 -spec get_beam_map() -> #{module() => file:filename()}.
 get_beam_map() ->
-  BeamDirs = code:get_path(),
-  BeamFiles = lists:flatmap(fun (Dir) -> filelib:wildcard(Dir ++ "/*.beam") end, BeamDirs),
-  BeamPairs = lists:map(fun (Filename) ->
-    {match, [Mod]} = re:run(Filename, beam_file_regexp(), [{capture, all_but_first, list}]),
-    {list_to_atom(Mod), Filename}
-  end, BeamFiles),
-  maps:from_list(BeamPairs).
+    BeamDirs = code:get_path(),
+    BeamFiles = lists:flatmap(fun (Dir) -> filelib:wildcard(Dir ++ "/*.beam") end, BeamDirs),
+    BeamPairs = lists:map(fun (Filename) ->
+            {match, [Mod]} = re:run(Filename, beam_file_regexp(), [{capture, all_but_first, list}]),
+            {list_to_atom(Mod), Filename}
+        end,
+        BeamFiles),
+    maps:from_list(BeamPairs).
 
 -spec beam_file_regexp() -> {re_pattern, _, _, _}.
 beam_file_regexp() ->
-  {ok, RE} = re:compile(<<"^.+\/([^/]+)\.beam$">>),
-  RE.
+    {ok, RE} = re:compile(<<"^.+\/([^/]+)\.beam$">>),
+    RE.
 
 -spec erl_file_regexp() -> {re_pattern, _, _, _}.
 erl_file_regexp() ->
-  {ok, RE} = re:compile(<<"([^/.]*)\.erl$">>),
-  RE.
+    {ok, RE} = re:compile(<<"([^/.]*)\.erl$">>),
+    RE.

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -333,7 +333,7 @@ import_erl_files([], St) ->
 
 -spec import_beam_files([file:filename()], state()) -> {ok, state()} | gradualizer_file_utils:parsed_file_error().
 import_beam_files([File | Files], State) ->
-    case gradualizer_file_utils:get_forms_from_beam_safe(File) of
+    case gradualizer_file_utils:get_forms_from_beam(File) of
         {ok, [{attribute, _, file, _}, {attribute, _, module, Module} | Forms1]} ->
             import_beam_files(Files, import_absform(Module, Forms1, State));
         Error = {Status, _} when (Status /= ok) ->

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -91,9 +91,11 @@ save(Filename) ->
 load(Filename) ->
     call({load, Filename}).
 
+-spec import_erl_files([file:filename()]) -> ok.
 import_erl_files(Files) ->
     call({import_erl_files, Files}, infinity).
 
+-spec import_beam_files([file:filename()]) -> ok | gradualizer_file_utils:parsed_file_error().
 import_beam_files(Files) ->
     call({import_beam_files, Files}, infinity).
 
@@ -288,6 +290,7 @@ autoimport(M, #state{opts = #{autoimport := true},
             end
     end.
 
+-spec import_module(module(), state()) -> {ok, state()} | not_found.
 import_module(Mod, State) ->
     case State#state.beammap of
         #{Mod := Filename} ->
@@ -299,6 +302,7 @@ import_module(Mod, State) ->
             import_module_from_erl(Mod, State)
     end.
 
+-spec import_module_from_erl(module(), state()) -> {ok, state()} | not_found.
 import_module_from_erl(Mod, State) ->
     case State#state.srcmap of
         #{Mod := Filename} ->
@@ -308,6 +312,7 @@ import_module_from_erl(Mod, State) ->
             not_found
     end.
 
+-spec import_erl_files([file:filename()], state()) -> state().
 import_erl_files([File | Files], State) ->
     EppOpts = [{includes, guess_include_dirs(File)}],
     {ok, Forms} = epp:parse_file(File, EppOpts),
@@ -318,6 +323,7 @@ import_erl_files([File | Files], State) ->
 import_erl_files([], St) ->
     St.
 
+-spec import_beam_files([file:filename()], state()) -> {ok, state()} | gradualizer_file_utils:parsed_file_error().
 import_beam_files([File | Files], State) ->
     case gradualizer_file_utils:get_forms_from_beam_safe(File) of
         {ok, [{attribute, _, file, _}, {attribute, _, module, Module} | Forms1]} ->
@@ -328,6 +334,7 @@ import_beam_files([File | Files], State) ->
 import_beam_files([], St) ->
     {ok, St}.
 
+-spec import_absform(module(), gradualizer_file_utils:abstract_form(), state()) -> state().
 import_absform(Module, Forms1, State) ->
     Specs    = collect_specs(Module, Forms1),
     SpecMap1 = add_entries_to_map(Specs, State#state.specs),

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -189,8 +189,8 @@ handle_call({load, Filename}, _From, State) ->
                                        types  = maps:merge(Ty1, Ty2),
                                        loaded = maps:merge(Loaded1, Loaded2)},
                 {reply, ok, NewState}
-            catch error:E ->
-                {reply, {error, E, erlang:get_stacktrace()}, State}
+            catch _:Exception:Stacktrace ->
+                {reply, {error, Exception, Stacktrace}, State}
             end;
         {error, Reason} ->
             {reply, {error, Reason}, State}

--- a/src/gradualizer_file_utils.erl
+++ b/src/gradualizer_file_utils.erl
@@ -1,0 +1,60 @@
+%%% @doc Module with utility functions to work with files.
+
+-module(gradualizer_file_utils).
+
+-export([
+            get_forms_from_erl_safe/1,
+            get_forms_from_beam_safe/1,
+            get_forms_from_erl/1,
+            get_forms_from_beam/1
+        ]).
+
+-type abstract_form() :: [erl_parse:abstract_form() | erl_parse:form_info()].
+
+-type parsed_file() :: {ok, abstract_form()} |
+                       {file_not_found, file:filename()} |
+                       {file_open_error, {file:posix() | badarg | system_limit, file:filename()}}.
+
+-spec get_forms_from_erl_safe(file:filename()) -> parsed_file().
+get_forms_from_erl_safe(File) ->
+    case epp:parse_file(File, []) of
+        {ok, Forms} ->
+            {ok, Forms};
+        {error, enoent} ->
+            {file_not_found, File};
+        {error, Reason} ->
+            {file_open_error, {Reason, File}}
+    end.
+
+-spec get_forms_from_beam_safe(file:filename()) -> parsed_file().
+get_forms_from_beam_safe(File) ->
+    case beam_lib:chunks(File, [abstract_code]) of
+        {ok, {_Module, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
+            {ok, Forms};
+        {ok, {_Module, [{abstract_code,no_abstract_code}]}} ->
+            {forms_not_found, File};
+        {error, beam_lib, {file_error, _, enoent}} ->
+            {file_not_found, File};
+        {error, beam_lib, {file_error, _, Reason}} ->
+            {file_open_error, {Reason, File}};
+        {error, beam_lib, Reason} ->
+            {forms_error, Reason}
+    end.
+
+-spec get_forms_from_erl(file:filename()) -> abstract_form() | no_return().
+get_forms_from_erl(File) ->
+    case get_forms_from_erl_safe(File) of
+        {ok, Forms} ->
+            Forms;
+        Error ->
+            throw(Error)
+    end.
+
+-spec get_forms_from_beam(file:filename()) -> abstract_form() | no_return().
+get_forms_from_beam(File) ->
+    case get_forms_from_beam_safe(File) of
+        {ok, Forms} ->
+            Forms;
+        Error ->
+            throw(Error)
+    end.

--- a/src/gradualizer_file_utils.erl
+++ b/src/gradualizer_file_utils.erl
@@ -3,8 +3,6 @@
 -module(gradualizer_file_utils).
 
 -export([
-            get_forms_from_erl_safe/1,
-            get_forms_from_beam_safe/1,
             get_forms_from_erl/1,
             get_forms_from_beam/1
         ]).
@@ -19,8 +17,8 @@
 
 -export_type([parsed_file_error/0, abstract_forms/0]).
 
--spec get_forms_from_erl_safe(file:filename()) -> parsed_file().
-get_forms_from_erl_safe(File) ->
+-spec get_forms_from_erl(file:filename()) -> parsed_file().
+get_forms_from_erl(File) ->
     case epp:parse_file(File, []) of
         {ok, Forms} ->
             {ok, Forms};
@@ -30,8 +28,8 @@ get_forms_from_erl_safe(File) ->
             {file_open_error, {Reason, File}}
     end.
 
--spec get_forms_from_beam_safe(file:filename()) -> parsed_file().
-get_forms_from_beam_safe(File) ->
+-spec get_forms_from_beam(file:filename()) -> parsed_file().
+get_forms_from_beam(File) ->
     case beam_lib:chunks(File, [abstract_code]) of
         {ok, {_Module, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
             {ok, Forms};
@@ -43,22 +41,4 @@ get_forms_from_beam_safe(File) ->
             {file_open_error, {Reason, File}};
         {error, beam_lib, Reason} ->
             {forms_error, Reason}
-    end.
-
--spec get_forms_from_erl(file:filename()) -> abstract_forms() | no_return().
-get_forms_from_erl(File) ->
-    case get_forms_from_erl_safe(File) of
-        {ok, Forms} ->
-            Forms;
-        Error ->
-            throw(Error)
-    end.
-
--spec get_forms_from_beam(file:filename()) -> abstract_forms() | no_return().
-get_forms_from_beam(File) ->
-    case get_forms_from_beam_safe(File) of
-        {ok, Forms} ->
-            Forms;
-        Error ->
-            throw(Error)
     end.

--- a/src/gradualizer_file_utils.erl
+++ b/src/gradualizer_file_utils.erl
@@ -11,9 +11,13 @@
 
 -type abstract_form() :: [erl_parse:abstract_form() | erl_parse:form_info()].
 
+-type parsed_file_error() :: {file_not_found, file:filename()} |
+                             {file_open_error, {file:posix() | badarg | system_limit, file:filename()}}.
+
 -type parsed_file() :: {ok, abstract_form()} |
-                       {file_not_found, file:filename()} |
-                       {file_open_error, {file:posix() | badarg | system_limit, file:filename()}}.
+                       parsed_file_error().
+
+-export_type([parsed_file_error/0, abstract_form/0]).
 
 -spec get_forms_from_erl_safe(file:filename()) -> parsed_file().
 get_forms_from_erl_safe(File) ->

--- a/src/gradualizer_file_utils.erl
+++ b/src/gradualizer_file_utils.erl
@@ -9,15 +9,15 @@
             get_forms_from_beam/1
         ]).
 
--type abstract_form() :: [erl_parse:abstract_form() | erl_parse:form_info()].
+-type abstract_forms() :: [erl_parse:abstract_form() | erl_parse:form_info()].
 
 -type parsed_file_error() :: {file_not_found, file:filename()} |
                              {file_open_error, {file:posix() | badarg | system_limit, file:filename()}}.
 
--type parsed_file() :: {ok, abstract_form()} |
+-type parsed_file() :: {ok, abstract_forms()} |
                        parsed_file_error().
 
--export_type([parsed_file_error/0, abstract_form/0]).
+-export_type([parsed_file_error/0, abstract_forms/0]).
 
 -spec get_forms_from_erl_safe(file:filename()) -> parsed_file().
 get_forms_from_erl_safe(File) ->
@@ -45,7 +45,7 @@ get_forms_from_beam_safe(File) ->
             {forms_error, Reason}
     end.
 
--spec get_forms_from_erl(file:filename()) -> abstract_form() | no_return().
+-spec get_forms_from_erl(file:filename()) -> abstract_forms() | no_return().
 get_forms_from_erl(File) ->
     case get_forms_from_erl_safe(File) of
         {ok, Forms} ->
@@ -54,7 +54,7 @@ get_forms_from_erl(File) ->
             throw(Error)
     end.
 
--spec get_forms_from_beam(file:filename()) -> abstract_form() | no_return().
+-spec get_forms_from_beam(file:filename()) -> abstract_forms() | no_return().
 get_forms_from_beam(File) ->
     case get_forms_from_beam_safe(File) of
         {ok, Forms} ->

--- a/test/gradualizer_db_tests.erl
+++ b/test/gradualizer_db_tests.erl
@@ -1,0 +1,7 @@
+-module(gradualizer_db_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+import_module_test() ->
+    ?assertMatch(not_found, gradualizer_db:import_module(hello)),
+    ?assertMatch(ok, gradualizer_db:import_module(lists)).

--- a/test/gradualizer_tests.erl
+++ b/test/gradualizer_tests.erl
@@ -12,7 +12,7 @@ api_test_() ->
      fun() ->
              %% user_types.erl references remote_types.erl
              %% it is not in the sourcemap of the DB so let's import it manually
-             gradualizer_db:import_files(["test/should_pass/user_types.erl"]),
+             gradualizer_db:import_erl_files(["test/should_pass/user_types.erl"]),
              ?assertEqual(ok, gradualizer:type_check_dir("test/should_pass/"))
      end,
 

--- a/test/test.erl
+++ b/test/test.erl
@@ -5,7 +5,7 @@
 should_pass_test_() ->
     %% user_types.erl references remote_types.erl
     %% it is not in the sourcemap of the DB so let's import it manually
-    gradualizer_db:import_files(["test/should_pass/user_types.erl"]),
+    gradualizer_db:import_erl_files(["test/should_pass/user_types.erl"]),
     run_tests_in("test/should_pass", ok).
 
 should_fail_test_() ->


### PR DESCRIPTION
- `gradualizer_db` can read forms from `.beam` files
- with `.beam` files support `gradualizer_db` can work with Elixir projects
- `.editorconfig` file for code styles consistency