### PR TITLE
Only infer tuple type if it has a subexpr typed by the user 

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -605,7 +605,7 @@ int_range_to_types({I, J}) when I < J ->
 %%
 %% Type information should always stem from user type annotation (function specs
 %% and type annotated record definitions). If an expression does not have a
-%% subexression that has a type inferred from these sources, its inferred type
+%% subexpression that has a type inferred from these sources, its inferred type
 %% will be `any()'.
 %%
 %% Arguments: An environment for functions, an environment for variables


### PR DESCRIPTION
As discussed in https://github.com/josefs/Gradualizer/issues/26

I am a bit hesitant if I did the correct thing. I implemented along the lines: "tries its best to propagate the return type of functions which are called within an expression" that is if ***any*** of the elements of the tuple has a non-any type then the tuple will also have non-any type inferred.

However the intended behaviour might be if ***all*** elements of the tuple have non-any type...
The second behaviour is visible in the implementation eg. for lists (cons) where currently both the head and the tail must be non-any to infer a non-any type for the cons cell.
Also `not Expr` will always be inferred as `any()` even `not f()` where `f/0` is spec'ed.