### PR TITLE
Short-circuit logic ops propagate variable bindings from their first arg to their second one.

### DIFF
--- a/test/should_pass/bool.erl
+++ b/test/should_pass/bool.erl
@@ -5,3 +5,16 @@
 -spec b(boolean(), bool()) -> bool().
 b(B1, B2) ->
     B1 andalso B2.
+
+%% variable bindings should propagate from first to second arg of orelse
+-spec b2() -> boolean().
+b2() ->
+    begin
+        A = f(),
+        is_integer(A)
+    end
+        orelse
+        is_float(A).
+
+-spec f() -> number().
+f() -> 1.


### PR DESCRIPTION
Also
- use `subtype` function when type-checking logic op (that is more generic and future proof)
- support type checking matches and blocks