### PR TITLE
Integrate with Travis CI and Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "src/rebar_prv_gradualizer.erl$"
+  - "src/ty.erl$"
+  - "src/gradualizer_cli.erl$"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+sudo: false
+
+language: erlang
+
+matrix:
+  fast_finish: true
+    
+  # Jobs that are allowed to fail:
+  allow_failures:
+    - env: TEST=".travis/travis_has_latest_otp_version"
+    - env: TEST="make gradualize"
+
+  include:
+
+  # Check that the latest Erlang version is tested
+
+  # This test will fail with 'X' when a new version is available via kerl.
+  # At that point, update THIS test's otp_release to the new one.
+  # The test will keep failing with '!', until Travis has the new version.
+  # When the test starts failing with 'X' again, Travis has the new version.
+  # At that point, update otp_release in the corresponding list below
+
+  - env: TEST=".travis/travis_has_latest_otp_version"
+    otp_release: 21.1
+
+  # Run coverage report for the latest OTP release
+  - env: TEST="make tests COVER=1" ENABLE_COVER=true
+    otp_release: 21.1
+  
+  - env: TEST="make gradualize"
+    otp_release: 21.1
+
+# otp releases that we test in the same way.
+# The latest OTP version is special and therefore explicitly
+# included above instead.
+otp_release:
+  
+  - 21.0
+  # Last minor version of older OTP releases
+  - 20.3
+  - 19.3
+
+env:
+  - TEST="make tests"
+
+before_script:
+  - .travis/before_script
+
+script:
+ - $TEST
+
+after_success:
+  - .travis/after_success

--- a/.travis/after_success
+++ b/.travis/after_success
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ "$ENABLE_COVER" = true ]; then
+  echo "Exporting coverage report..."
+  make all.coverdata
+  covertool/covertool -cover all.coverdata -appname gradualizer
+  bash <(curl -s https://codecov.io/bash) -f "./coverage.xml"
+  echo "Report sent!"
+fi

--- a/.travis/before_script
+++ b/.travis/before_script
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ "$ENABLE_COVER" = true ]; then
+  echo "Preparing to collect coverage data."
+  git clone https://github.com/covertool/covertool.git
+  cd covertool
+  make compile
+  echo "Ready to collect coverage data!"
+fi

--- a/.travis/travis_has_latest_otp_version
+++ b/.travis/travis_has_latest_otp_version
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+curl -sO https://raw.githubusercontent.com/kerl/kerl/master/kerl
+chmod a+x kerl
+LATEST=`./kerl update releases | tr ' ' '\n' | tail -n1`
+rm ./kerl
+
+if [ "$LATEST" != "$TRAVIS_OTP_RELEASE" ]; then
+    printf "\nA newer OTP release is available via kerl ($LATEST)!\n"
+    printf " (.travis.yml uses $TRAVIS_OTP_RELEASE for this test)\n\n"
+    printf "See .travis.yml for instructions about how to fix this.\n"
+    false
+fi


### PR DESCRIPTION
Runs make tests on Travis for these OTP versions: 21.1, 21.0, 20.3, 19.3,
Version 21.1 additionally generates code coverage on codecov (the first code coverage site I managed to integrate to).
There are two additional tests (which are allowed to fail): self gradualizing and checking that we are testing using the latest available OTP version.

Output: [travis](https://travis-ci.org/Zalastax/Gradualizer), [codecov](https://codecov.io/gh/Zalastax/Gradualizer/commits).

Closes #41 