### PR TITLE
Add gradualizer.sh to normalise line number position

### DIFF
--- a/gradualizer.sh
+++ b/gradualizer.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+#set -x
+
+pushd `dirname $0` > /dev/null 2>&1
+BASEDIR=`pwd`
+popd > /dev/null 2>&1
+
+if [ x`uname` = x"Darwin" ]; then
+    SED=gsed
+else
+    SED=sed
+fi
+
+$BASEDIR/gradualizer $@ | $SED '/\(.*on line \([0-9]*\)\)/ {s//\2:\1/}' | sort -n | uniq


### PR DESCRIPTION
Following #48 this PR adds a script to reformat Gradualizer messages for easier consumption (until #49 is addressed). The NeoMake part is almost ready and waiting for CI/review at https://github.com/neomake/neomake/pull/2115.

Once Gradualizer itself changes the message format it will be possible to drop this script and adjust the NeoMake maker to just use `gradualizer` escript directly.

Of course, in order for NeoMake to find `gradualizer.sh` the script has to be available in PATH.