### PR TITLE
Fix infering type of bool/numeric negation

### DIFF
--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -221,7 +221,8 @@ propagate_types_test_() ->
      ?_assertMatch("any()",
                    type_check_expr(_Env = "-spec f() -> any().",
                                    _Expr = "not f()")),
-     ?_assertMatch("boolean()",
+     %% (returns a normalised type, in this case of boolean())
+     ?_assertMatch("true | false",
                    type_check_expr(_Env = "-spec f() -> boolean().",
                                    _Expr = "not f()")),
      ?_assertMatch("false",
@@ -243,6 +244,9 @@ propagate_types_test_() ->
                                    _Expr = "- f()")),
      ?_assertMatch("-3..1",
                    type_check_expr(_Env = "-spec f() -> -1..(1+2).",
+                                   _Expr = "- f()")),
+     ?_assertMatch("neg_integer() | 0",
+                   type_check_expr(_Env = "-spec f() -> non_neg_integer().",
                                    _Expr = "- f()"))
     ].
 

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -215,8 +215,35 @@ propagate_types_test_() ->
 				   _Expr = "fun (A, B) -> i(B) end")),
      ?_assertMatch("fun((any(), any()) -> integer())",
 		   type_check_expr(_Env = "-spec i(integer()) -> integer().",
-				   _Expr = "fun F(A, B) -> i(B) end"))
+				   _Expr = "fun F(A, B) -> i(B) end")),
 
+     %% inferred type of boolean negation
+     ?_assertMatch("any()",
+                   type_check_expr(_Env = "-spec f() -> any().",
+                                   _Expr = "not f()")),
+     ?_assertMatch("boolean()",
+                   type_check_expr(_Env = "-spec f() -> boolean().",
+                                   _Expr = "not f()")),
+     ?_assertMatch("false",
+                   type_check_expr(_Env = "-spec f() -> true.",
+                                   _Expr = "not f()")),
+
+     %% infered type of number negation
+     ?_assertMatch("any()",
+                   type_check_expr(_Env = "-spec f() -> any().",
+                                   _Expr = "- f()")),
+     ?_assertMatch("float()",
+                   type_check_expr(_Env = "-spec f() -> float().",
+                                   _Expr = "- f()")),
+     ?_assertMatch("integer()",
+                   type_check_expr(_Env = "-spec f() -> integer().",
+                                   _Expr = "- f()")),
+     ?_assertMatch("1",
+                   type_check_expr(_Env = "-spec f() -> -1.",
+                                   _Expr = "- f()")),
+     ?_assertMatch("-3..1",
+                   type_check_expr(_Env = "-spec f() -> -1..(1+2).",
+                                   _Expr = "- f()"))
     ].
 
 type_check_in_test_() ->

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -247,6 +247,12 @@ propagate_types_test_() ->
                                    _Expr = "- f()")),
      ?_assertMatch("neg_integer() | 0",
                    type_check_expr(_Env = "-spec f() -> non_neg_integer().",
+                                   _Expr = "- f()")),
+     ?_assertMatch("-7..-5 | -3..-1",
+                   type_check_expr(_Env = "-spec f() -> 1..3 | 5..7.",
+                                   _Expr = "- f()")),
+     ?_assertMatch("-2..-1 | non_neg_integer()",
+                   type_check_expr(_Env = "-spec f() -> neg_integer() | 0..2.",
                                    _Expr = "- f()"))
     ].
 


### PR DESCRIPTION
Arg of not should be sutype of `boolean()` and not the other way
around. Same goes for arg of '-', which should be a subtype of
`number()`.

At the same time negation of literal bool/int and range types is
improved. (Maybe this should only work in case `--infer` is true and
otherwise fall back to eg. -(1) => integer()?)