### PR TITLE
Override incorrect or inexact OTP specs

### DIFF
--- a/priv/otp_spec_fix.erl
+++ b/priv/otp_spec_fix.erl
@@ -1,0 +1,6 @@
+-module(otp_spec_fix).
+
+%% This module contains specs to replace incorrect or inexact specs in OTP.
+
+-spec erlang:hd([A, ...]) -> A.
+-spec erlang:tl([A, ...]) -> [A].


### PR DESCRIPTION
The file priv/otp_spec_fix.erl contains specs that will be loaded
before any other specs. Later, when loading specs, already defined
specs are not overwritten.