### PR TITLE
Known problem: not yet supported union of maps == map of unions 

### DIFF
--- a/test/known_problems/should_pass/map_union.erl
+++ b/test/known_problems/should_pass/map_union.erl
@@ -1,0 +1,6 @@
+-module(map_union).
+
+-compile(export_all).
+
+-spec union_value2(#{a => b | c}) -> #{a => b} | #{a => c}.
+union_value2(M) -> M.

--- a/test/should_fail/map_fail.erl
+++ b/test/should_fail/map_fail.erl
@@ -1,0 +1,6 @@
+-module(map_fail).
+
+-compile(export_all).
+
+-spec mandatory_fail(#{a => b}) -> #{a := b}.
+mandatory_fail(M) -> M.

--- a/test/should_pass/map.erl
+++ b/test/should_pass/map.erl
@@ -11,5 +11,5 @@ unknown_map2(M) -> M.
 -spec mandatory_ok(#{a := b}) -> #{a => b}.
 mandatory_ok(M) -> M.
 
--spec mandatory_fail(#{a => b}) -> #{a := b}.
-mandatory_fail(M) -> M.
+-spec union_value(#{a => b} | #{a => c}) -> #{a => b | c}.
+union_value(M) -> M.

--- a/test/test.erl
+++ b/test/test.erl
@@ -7,12 +7,12 @@ should_pass_test_() ->
     %% it is not in the sourcemap of the DB so let's import it manually
     gradualizer_db:import_erl_files(["test/should_pass/user_types.erl"]),
     map_erl_files(fun(File) ->
-            ?_assertEqual(ok, gradualizer:type_check_file(File))
+            ?_assertMatch({ok, _}, {gradualizer:type_check_file(File), File})
         end, "test/should_pass").
 
 should_fail_test_() ->
     map_erl_files(fun(File) ->
-            ?_assertEqual(nok, gradualizer:type_check_file(File))
+            ?_assertMatch({nok, _}, {gradualizer:type_check_file(File), File})
         end, "test/should_fail").
 
 % Test succeeds if Gradualizer crashes or if it doesn't type check.
@@ -24,7 +24,7 @@ known_problem_should_pass_test_() ->
                 V -> V
             catch E -> nok
             end,
-        ?_assertEqual(nok, Result)
+        ?_assertMatch({nok, _}, {Result, File})
         end, "test/known_problems/should_pass").
 
 % Test succeeds if Gradualizer crashes or if it does type check.
@@ -36,7 +36,7 @@ known_problem_should_fail_test_() ->
                 V -> V
             catch E -> ok
             end,
-        ?_assertEqual(ok, Result)
+        ?_assertMatch({ok, _}, {Result, File})
         end, "test/known_problems/should_fail").
 
 map_erl_files(Fun, Dir) ->


### PR DESCRIPTION
Also move already existing map examples from `misc` to `should_pass`/`should_fail`.
And show file name when should_pass/should_fail/known_problem fails.

I just had this example lying around and with the advent of known_problems there is now a place to add it.