### PR TITLE
Issue 72

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -2240,8 +2240,7 @@ arith_op_arg_types(Op, Ty = {type, _, float, []}) ->
     case Op of
         _ when Op == '+'; Op == '*'; Op == '-' ->
             {Ty, Ty};
-        '/' -> {type(number), type(number)};
-        _   -> false
+        '/' -> {type(number), type(number)}
     end;
 
 %% Singleton types are not closed under any operations

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3234,7 +3234,7 @@ type(Name) -> type(Name, []).
 return(X) ->
     { X, #{}, constraints:empty() }.
 
-is_power_of_two(0) -> true;
+is_power_of_two(0) -> false;
 is_power_of_two(1) -> true;
 is_power_of_two(N) when N rem 2 == 0 ->
     is_power_of_two(N div 2);

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -345,7 +345,7 @@ get_record_fields(RecName, Anno, #tenv{records = REnv}) ->
 
 -spec glb(type(), type(), TEnv :: #tenv{}) -> type().
 glb(T1, T2, TEnv) ->
-    normalize(glb(T1, T2, #{}, TEnv), TEnv).
+    glb(T1, T2, #{}, TEnv).
 
 glb(T1, T2, A, TEnv) ->
     Ty1 = typelib:remove_pos(normalize(T1, TEnv)),
@@ -356,7 +356,7 @@ glb(T1, T2, A, TEnv) ->
         %% actual use case.
         true -> type(none);
         false ->
-            glb_ty(Ty1, Ty2, A#{ {Ty1, Ty2} => 0 }, TEnv)
+            normalize(glb_ty(Ty1, Ty2, A#{ {Ty1, Ty2} => 0 }, TEnv), TEnv)
     end.
 
 %% If either type is any() we don't know anything

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -223,33 +223,15 @@ compat_ty({type, _, record, _}, {type, _, tuple, any}, A, _TEnv) ->
     ret(A);
 
 %% Lists
-compat_ty({type, _, list, [_Ty]}, {type, _, list, []}, A, _TEnv) ->
-    ret(A);
-compat_ty({type, _, list, []}, {type, _, list, [_Ty]}, A, _TEnv) ->
-    ret(A);
-compat_ty({type, _, list, [Ty1]}, {type, _, list, [Ty2]}, A, TEnv) ->
-    compat(Ty1, Ty2, A, TEnv);
-compat_ty({type, _, nil, []}, {type, _, list, _Any}, A, _TEnv) ->
-    ret(A);
-compat_ty({type, _, nonempty_list, []}, {type, _, list, _Any}, A, _TEnv) ->
-    ret(A);
-compat_ty({type, _, nonempty_list, [_Ty]}, {type, _, nonempty_list, []}, A, _TEnv) ->
-    ret(A);
-compat_ty({type, _, nonempty_list, []}, {type, _, nonempty_list, [_Ty]}, A, _TEnv) ->
-    ret(A);
-compat_ty({type, _, nonempty_list, [Ty1]}, {type, _, nonempty_list, [Ty2]}, A, TEnv) ->
-    compat(Ty1, Ty2, A, TEnv);
-compat_ty({type, _, nonempty_list, [Ty1]}, {type, _, list, [Ty2]}, A, TEnv) ->
-    compat(Ty1, Ty2, A, TEnv);
-compat_ty({type, _, nonempty_list, [_Ty]}, {type, _, list, []}, A, _TEnv) ->
-    ret(A);
-compat_ty({type, nil, _, []}, {type, _, maybe_improper_list, [_Ty2]}, A, _TEnv) ->
-    ret(A);
-compat_ty({type, _, list, [Ty1]}, {type, _, maybe_improper_list, [Ty2]}, A, TEnv) ->
-    compat(Ty1, Ty2, A, TEnv);
-compat_ty({type, _, nonempty_list, [Ty1]}, {type, _, maybe_improper_list, [Ty2]}, A, TEnv) ->
-    compat(Ty1, Ty2, A, TEnv);
-%% TODO: improper lists
+compat_ty(Ty1, Ty2, A, TEnv) when ?is_list_type(Ty1), ?is_list_type(Ty2) ->
+    {Empty1, Elem1, Term1} = list_view(Ty1),
+    {Empty2, Elem2, Term2} = list_view(Ty2),
+    case {Empty1, Empty2} of
+        {E, E}   -> ok;
+        {_, any} -> ok;
+        _        -> throw(nomatch)
+    end,
+    compat_tys([Elem1, Term1], [Elem2, Term2], A, TEnv);
 
 %% Tuples
 compat_ty({type, _, tuple, any}, {type, _, tuple, _Args}, A, _TEnv) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -2807,7 +2807,7 @@ check_clauses_union(Env, [Ty|Tys], Clauses) ->
         check_clauses_fun(Env, Ty, Clauses)
     catch
         Error when element(1,Error) == type_error ->
-            check_clauses(env, Tys, Clauses)
+            check_clauses(Env, Tys, Clauses)
     end.
 
 

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -387,16 +387,30 @@ glb_ty(Ty1, Ty2, _A, _TEnv) when ?is_int_type(Ty1), ?is_int_type(Ty2) ->
     {Lo2, Hi2} = int_type_to_range(Ty2),
     type(union, int_range_to_types({int_max(Lo1, Lo2), int_min(Hi1, Hi2)}));
 
-%% TODO: At the moment we only take glb with number() or integer() (when
-%% checking operator applications), so we never hit these cases. They should be
-%% implemented though.
+%% List types
+
+glb_ty(Ty1, Ty2, A, TEnv) when ?is_list_type(Ty1), ?is_list_type(Ty2) ->
+    {Empty1, Elem1, Term1} = list_view(Ty1),
+    {Empty2, Elem2, Term2} = list_view(Ty2),
+    Empty =
+        case {Empty1, Empty2} of
+            {E, E}            -> E;
+            {any, E}          -> E;
+            {E, any}          -> E;
+            {empty, nonempty} -> none;
+            {nonempty, empty} -> none
+        end,
+    Elem = glb(Elem1, Elem2, A, TEnv),
+    Term = glb(Term1, Term2, A, TEnv),
+    from_list_view({Empty, Elem, Term});
+
+%% TODO: At the moment we only take glb when checking operator applications, so
+%% we never hit these cases. They should be implemented though.
 %% Tuple types
 %% Type variables
 %% Function types
-%% Atoms
 %% Map types
 %% Record types
-%% List types
 %% Binary types
 
 %% Incompatible

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -425,6 +425,8 @@ glb_ty(Ty1 = {type, _, record, _}, {type, _, tuple, any}, _A, _TEnv) ->
     Ty1;
 glb_ty({type, _, tuple, any}, Ty2 = {type, _, record, _}, _A, _TEnv) ->
     Ty2;
+glb_ty({type, _, record, _}, {type, _, record, _}, _A, _TEnv) ->
+    type(none);
 
 %% Map types. These are a bit tricky and we can't reach this case in the
 %% current code. For now going with a very crude approximation.
@@ -476,6 +478,12 @@ glb_ty({ann_type, _, [{var, _, _}, Ty1]}, Ty2, A, TEnv) ->
     glb(Ty1, Ty2, A, TEnv);
 glb_ty(Ty1, {ann_type, _, [{var, _, _}, Ty2]}, A, TEnv) ->
     glb(Ty1, Ty2, A, TEnv);
+
+%% normalize and remove_pos only does the top layer
+glb_ty({type, _, Name, Args1}, {type, _, Name, Args2}, A, TEnv)
+        when length(Args1) == length(Args2) ->
+    Args = [ glb(Arg1, Arg2, A, TEnv) || {Arg1, Arg2} <- lists:zip(Args1, Args2) ],
+    type(Name, Args);
 
 %% Incompatible
 glb_ty(_Ty1, _Ty2, _A, _TEnv) -> type(none).

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3505,6 +3505,9 @@ handle_type_error({type_error, relop, RelOp, P, Ty1, Ty2}) ->
               "compatible types.~nHowever, it has arguments "
               "of type ~s and ~s~n", [RelOp, P, typelib:pp_type(Ty1)
                                               , typelib:pp_type(Ty2)]);
+handle_type_error({type_error, op_type_too_precise, '/' = Op, P, Ty}) when ?is_int_type(Ty) ->
+    io:format("The operator ~p on line ~p is expected to have type "
+              "~s which is not a supertype of float()~n", [Op, P, typelib:pp_type(Ty)]);
 handle_type_error({type_error, op_type_too_precise, Op, P, Ty}) ->
     io:format("The operator ~p on line ~p is expected to have type "
               "~s which is too precise to be statically checked~n", [Op, P, typelib:pp_type(Ty)]);

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -489,6 +489,8 @@ expand_builtin_aliases(Type) ->
 flatten_unions(Tys, TEnv) ->
     [ FTy || Ty <- Tys, FTy <- flatten_type(normalize(Ty, TEnv), TEnv) ].
 
+flatten_type({type, _, none, []}, _) ->
+    [];
 flatten_type({type, _, union, Tys}, TEnv) ->
     flatten_unions(Tys, TEnv);
 flatten_type({ann_type, _, [_, Ty]}, TEnv) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3448,6 +3448,14 @@ handle_type_error({type_error, relop, RelOp, P, Ty1, Ty2}) ->
 handle_type_error({type_error, op_type_too_precise, Op, P, Ty}) ->
     io:format("The operator ~p on line ~p is expected to have type "
               "~s which is too precise to be statically checked~n", [Op, P, typelib:pp_type(Ty)]);
+handle_type_error({type_error, arith_error, ArithOp, P, Ty1, Ty2}) ->
+    io:format("The operator ~p on line ~p is requires numeric arguments, but "
+              "has arguments of type ~s and ~s~n",
+              [ArithOp, P, typelib:pp_type(Ty1), typelib:pp_type(Ty2)]);
+handle_type_error({type_error, int_error, ArithOp, P, Ty1, Ty2}) ->
+    io:format("The operator ~p on line ~p is requires integer arguments, but "
+              " has arguments of type ~s and ~s~n",
+              [ArithOp, P, typelib:pp_type(Ty1), typelib:pp_type(Ty2)]);
 handle_type_error({type_error, arith_error, ArithOp, P, Ty}) ->
     io:format("The operator ~p on line ~p is expected to have type "
               "~s which has no numeric subtypes~n", [ArithOp, P, typelib:pp_type(Ty)]);

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -2526,7 +2526,7 @@ type_check_bc_in(Env, ResTy, Expr, P, [{generate, P_Gen, Pat, Gen} | Quals]) ->
         {type_error, Ty} ->
             throw({type_error, generator, P_Gen, Ty})
     end;
-type_check_bc_in(Env, ResTy, Expr, P, [{b_generate, P_Gen, Pat, Gen} | Quals]) ->
+type_check_bc_in(Env, ResTy, Expr, P, [{b_generate, _P_Gen, Pat, Gen} | Quals]) ->
     %% Binary generator: Pat <= Gen
     %% Gen and Pat should be bitstrings (of any size).
     BitTy = {type, erl_anno:new(0), binary,

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -350,8 +350,14 @@ glb(T1, T2, TEnv) ->
 glb(T1, T2, A, TEnv) ->
     Ty1 = typelib:remove_pos(normalize(T1, TEnv)),
     Ty2 = typelib:remove_pos(normalize(T2, TEnv)),
-    %% TODO: memoisation
-    glb_ty(Ty1, Ty2, A, TEnv).
+    case maps:is_key({T1, T2}, A) of
+        %% If we hit a recursive case we approximate with none(). Conceivably
+        %% you could do some fixed point iteration here, but let's wait for an
+        %% actual use case.
+        true -> type(none);
+        false ->
+            glb_ty(Ty1, Ty2, A#{ {Ty1, Ty2} => 0 }, TEnv)
+    end.
 
 %% If either type is any() we don't know anything
 glb_ty({type, _, any, []} = Ty1, _Ty2, _A, _TEnv) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -744,7 +744,8 @@ int_type_to_range({type, _, range, [{integer, _, I1},
                                         when I1 =< I2  -> {I1, I2};
 int_type_to_range({integer, _, I})                     -> {I, I}.
 
-%% Converts a range back to a type. Creates two types in some cases.
+%% Converts a range back to a type. Creates two types in some cases and zero
+%% types if lower bound is greater than upper bound.
 -spec int_range_to_types(int_range()) -> [type()].
 int_range_to_types({neg_inf, pos_inf}) ->
     [type(integer)];
@@ -770,7 +771,9 @@ int_range_to_types({I, I}) ->
     [{integer, erl_anno:new(0), I}];
 int_range_to_types({I, J}) when I < J ->
     [{type, erl_anno:new(0), range, [{integer, erl_anno:new(0), I}
-                                    ,{integer, erl_anno:new(0), J}]}].
+                                    ,{integer, erl_anno:new(0), J}]}];
+int_range_to_types({I, J}) when I > J ->
+    [].
 
 %% Input arg must be already normalized
 negate_num_type({type, _, TyName, []} = Ty) when

--- a/src/typelib.hrl
+++ b/src/typelib.hrl
@@ -12,3 +12,13 @@
         orelse
           (tuple_size(T) =:= 3 andalso
            element(1, T) =:= integer)).
+
+%% same as typechecker:is_list_type/1 but can be used as a guard
+-define(is_list_type(T),
+        (tuple_size(T) =:= 4 andalso
+         element(1, T) =:= type andalso
+         (element(3, T) =:= list orelse
+          element(3, T) =:= nil orelse
+          element(3, T) =:= nonempty_list orelse
+          element(3, T) =:= maybe_improper_list orelse
+          element(3, T) =:= nonempty_improper_list))).

--- a/test/should_fail/arith_op_1.erl
+++ b/test/should_fail/arith_op_1.erl
@@ -1,0 +1,4 @@
+-module(arith_op_1).
+
+-spec fail(_) -> tuple().
+fail(X) -> X + X.

--- a/test/should_fail/arith_op_2.erl
+++ b/test/should_fail/arith_op_2.erl
@@ -1,0 +1,4 @@
+-module(arith_op_2).
+
+-spec fail(_) -> boolean().
+fail(X) -> X div X.

--- a/test/should_fail/arith_op_3.erl
+++ b/test/should_fail/arith_op_3.erl
@@ -1,0 +1,4 @@
+-module(arith_op_3).
+
+-spec fail(boolean()) -> any() | boolean().
+fail(X) -> X div 2.

--- a/test/should_fail/arith_op_4.erl
+++ b/test/should_fail/arith_op_4.erl
@@ -1,0 +1,4 @@
+-module(arith_op_4).
+
+-spec fail(integer()) -> neg_integer().
+fail(X) -> X / X.

--- a/test/should_fail/arith_op_5.erl
+++ b/test/should_fail/arith_op_5.erl
@@ -1,0 +1,4 @@
+-module(arith_op_5).
+
+-spec fail(1..10) -> 1..10 | atom.
+fail(X) -> X div X.

--- a/test/should_fail/arith_op_6.erl
+++ b/test/should_fail/arith_op_6.erl
@@ -1,0 +1,4 @@
+-module(arith_op_6).
+
+-spec fail(5, 2 | 4) -> 7 | 9.
+fail(X, Y) -> X + Y.

--- a/test/should_fail/arith_op_7.erl
+++ b/test/should_fail/arith_op_7.erl
@@ -1,0 +1,4 @@
+-module(arith_op_7).
+
+-spec fail(pos_integer(), neg_integer()) -> pos_integer().
+fail(X, Y) -> X - Y.

--- a/test/should_fail/arith_op_8.erl
+++ b/test/should_fail/arith_op_8.erl
@@ -1,0 +1,4 @@
+-module(arith_op_8).
+
+-spec fail(non_neg_integer(), neg_integer()) -> non_neg_integer().
+fail(X, Y) -> X - Y.

--- a/test/should_fail/arith_op_9.erl
+++ b/test/should_fail/arith_op_9.erl
@@ -1,0 +1,4 @@
+-module(arith_op_9).
+
+-spec fail(neg_integer(), non_neg_integer()) -> neg_integer().
+fail(X, Y) -> X - Y.

--- a/test/should_fail/list_op_1.erl
+++ b/test/should_fail/list_op_1.erl
@@ -1,0 +1,4 @@
+-module(list_op_1).
+
+-spec fail([a]) -> {ok, [a]}.
+fail(Xs) -> Xs -- Xs.

--- a/test/should_fail/list_op_2.erl
+++ b/test/should_fail/list_op_2.erl
@@ -1,0 +1,5 @@
+-module(list_op_2).
+
+-spec fail(integer()) -> _ | integer().
+fail(X) -> [1] ++ X.
+

--- a/test/should_fail/list_op_3.erl
+++ b/test/should_fail/list_op_3.erl
@@ -1,0 +1,5 @@
+-module(list_op_3).
+
+-spec fail([a, ...], [a]) -> [a, ...].
+fail(Xs, Ys) -> Xs -- Ys.
+

--- a/test/should_fail/logic_op_1.erl
+++ b/test/should_fail/logic_op_1.erl
@@ -1,0 +1,4 @@
+-module(logic_op_1).
+
+-spec fail(boolean()) -> tuple().
+fail(X) -> X and X.

--- a/test/should_fail/logic_op_2.erl
+++ b/test/should_fail/logic_op_2.erl
@@ -1,0 +1,4 @@
+-module(logic_op_2).
+
+-spec fail(boolean()) -> tuple().
+fail(X) -> X andalso {}.

--- a/test/should_fail/rel_op_1.erl
+++ b/test/should_fail/rel_op_1.erl
@@ -1,0 +1,4 @@
+-module(rel_op_1).
+
+-spec fail(term()) -> tuple().
+fail(X) -> X > X.

--- a/test/should_fail/rel_op_2.erl
+++ b/test/should_fail/rel_op_2.erl
@@ -1,0 +1,4 @@
+-module(rel_op_2).
+
+-spec fail(a | b, b | c) -> boolean() | tuple().
+fail(X, Y) -> X == Y.

--- a/test/should_fail/unary_op_1.erl
+++ b/test/should_fail/unary_op_1.erl
@@ -1,0 +1,5 @@
+-module(unary_op_1).
+
+-spec fail(number()) -> boolean().
+fail(X) -> -X.
+

--- a/test/should_pass/operator_subtypes.erl
+++ b/test/should_pass/operator_subtypes.erl
@@ -1,0 +1,96 @@
+
+-module(operator_subtypes).
+
+-compile([export_all, nowarn_export_all]).
+
+%% Arithmetic operations
+
+-spec arith_op1(integer(), integer()) -> integer() | error.
+arith_op1(_, 0) -> error;
+arith_op1(X, Y) -> X div Y.
+
+-spec arith_op2(integer()) -> boolean() | _.
+arith_op2(X) -> X + X.
+
+-spec float_op1(float(), float()) -> number().
+float_op1(X, Y) -> X * Y.
+
+-spec float_op2(integer(), float()) -> float().
+float_op2(X, Y) -> X / Y.
+
+-spec pos_op1(pos_integer(), 1..10) -> pos_integer().
+pos_op1(X, Y) -> X * Y + 777 bor Y.
+
+-spec nonneg_op1(0..100, non_neg_integer()) -> non_neg_integer() | error.
+nonneg_op1(X, Y) -> X + Y * X div Y rem X band Y bor X bxor Y bsl X bsr Y.
+
+-spec neg_op1(neg_integer(), -10..-5 | -2..-1) -> neg_integer() | 0..10.
+neg_op1(X, Y) -> X + Y + (-10).
+
+-type word16() :: 0..65535.
+
+-spec word_op1(non_neg_integer()) -> word16().
+word_op1(N) -> N rem 65536.
+
+-spec word_op2(word16(), word16()) -> word16().
+word_op2(X, Y) -> X band Y bor 32768 bxor Y.
+
+-spec word_op3(word16(), non_neg_integer(), pos_integer()) -> word16().
+word_op3(X, Y, Z) -> (X bsr Y) div Z.
+
+%% Logic operations
+
+-spec logic_op1(boolean(), false) -> boolean() | not_boolean.
+logic_op1(X, Y) -> X and Y or true.
+
+-spec logic_op2(boolean(), a, boolean() | b) -> {boolean() | a, boolean() | b}.
+logic_op2(X, Y, Z) -> {X andalso Y, X orelse Z}.
+
+%% Relational operations
+
+-spec rel_op1(term(), {foo, integer(), atom()}) -> boolean() | other.
+rel_op1(other, _) -> other;
+rel_op1(X, Y) -> X == Y.
+
+%% List operations
+
+-spec list_op1([integer()], [integer()]) -> [integer() | error] | error.
+list_op1(Xs, []) -> [error | Xs];
+list_op1([], _)  -> error;
+list_op1(Xs, Ys) -> Xs ++ Ys.
+
+-spec list_op2([], []) -> [].
+list_op2(Xs, Ys) -> Xs ++ Ys.
+
+-spec list_op3([number()], [integer()]) -> [number()].
+list_op3(Xs, Ys) -> Xs -- Ys.
+
+-spec list_op4([], [tuple()]) -> [].
+list_op4(Xs, Ys) -> Xs -- Ys.
+
+-spec list_op5([a, ...], [a, ...]) -> [a, ...].
+list_op5(Xs, Ys) -> Xs ++ Ys.
+
+-spec list_op6([integer()], maybe_improper_list(integer(), tl)) -> maybe_improper_list(integer(), tl | 5).
+list_op6(Xs, Ys) -> Xs ++ Ys.
+
+-spec list_op7([integer(), ...], nonempty_improper_list(integer(), tl)) -> nonempty_improper_list(integer(), tl).
+list_op7(Xs, Ys) -> Xs ++ Ys.
+
+-spec list_op8() -> _ | integer().
+list_op8() -> [1] ++ [2].
+
+%% Unary operators
+
+-spec unary_op1(boolean(), false) -> {false | error, boolean(), true}.
+unary_op1(X, Y) -> {not true, not X, not Y}.
+
+-spec unary_op2(0..10) -> integer().
+unary_op2(X) -> - (bnot X).
+
+-spec unary_op3(0..10) -> 1..11.
+unary_op3(X) -> - (bnot X).
+
+-spec unary_op4(float()) -> number().
+unary_op4(X) -> -X.
+


### PR DESCRIPTION
~~Work in progress on #72. Do not merge, but please offer feedback.~~
Done!

Still to do:
- [x] List operations (`++` and `--`)
- [x] Inference mode (`type_check_expr`)
- [x] Finish `glb` (at the very least, needs to handle lists for list operations)
- [x] Tests
- [x] Memoisation in `glb` (currently loops on untagged recursive types)
- [x] Replace uses of old `glb_types` (and check that this makes sense)
- [x] Think about `int + float :: float` problem. Backtracking or union types? Leave as is for now.

Some food for discussion
- I changed the rule for `andalso` (and `orelse`) to
  ```
  subtype(boolean(), R)
  A :: boolean()
  B :: R
  ---
  A andalso B :: R
  ```
  allowing an arbitrary type in the second argument. This may or may not be a good idea, but it's safe.
- I implemented some cleverness for arithmetic on ranged types:
  ```
  op in {band, bor, bxor, bsr}
  A :: 0..2^(N-1)
  B :: 0..2^(N-1)
  ---
  A op B :: 0..2^(N-1)
  ```
  and
  ```
  A :: non_neg_integer()
  B :: 0..N+1
  ---
  A rem B :: 0..N
  ```
  This lets you work with fixed-width word types in a typed manned, which I think is nice. More could be added, but I'm not sure there's a nice non-ad hoc amount of cleverness to add that won't just make the type system unpredictable.
- I haven't looked into how type variables work (are they rigid or flexible?) and consequently ignore them in `glb`.

