### PR TITLE
Fix loading file from within escript

### DIFF
--- a/src/gradualizer_file_utils.erl
+++ b/src/gradualizer_file_utils.erl
@@ -30,7 +30,8 @@ get_forms_from_erl(File) ->
             {file_open_error, {Reason, File}}
     end.
 
--spec get_forms_from_beam(file:filename()) -> parsed_file() | parsed_file_error().
+%% Accepts a filename or the beam code as a binary
+-spec get_forms_from_beam(file:filename() | binary()) -> parsed_file() | parsed_file_error().
 get_forms_from_beam(File) ->
     case beam_lib:chunks(File, [abstract_code]) of
         {ok, {_Module, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->

--- a/src/gradualizer_prelude.erl
+++ b/src/gradualizer_prelude.erl
@@ -1,4 +1,4 @@
--module(otp_spec_fix).
+-module(gradualizer_prelude).
 
 %% This module contains specs to replace incorrect or inexact specs in OTP.
 


### PR DESCRIPTION
Using the code loading mechanism that the code server uses. In this way we can get the file from within the escript archive. The "prelude" file is moved to src/ so nothing special is needed to make rebar include it in the escript archive.