### PR TITLE
More precise typing rule for shortcut operators (andalso and orelse)

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1575,7 +1575,13 @@ type_check_logic_op(Env, Op, P, Arg1, Arg2) ->
                 false ->
                     throw({type_error, boolop, Op, P, Ty2});
                 {true, Cs4} ->
-                    {normalize({type, erl_anno:new(0), union, [Ty1, Ty2]}, Env#env.tenv)
+                    Inferred =
+                        case Op of
+                            'andalso' -> type(union, [Ty1, {atom, erl_anno:new(0), false}]);
+                            'orelse'  -> type(union, [Ty1, {atom, erl_anno:new(0), true}]);
+                            _         -> type(boolean)
+                        end,
+                    {normalize(Inferred, Env#env.tenv)
                     ,union_var_binds(VB1, VB2, Env#env.tenv)
                     ,constraints:combine([Cs1,Cs2,Cs3,Cs4])}
             end

--- a/test/should_fail/no_idempotent_xor.erl
+++ b/test/should_fail/no_idempotent_xor.erl
@@ -1,0 +1,11 @@
+-module(no_idempotent_xor).
+
+-compile(export_all).
+
+-spec bla(true, true) -> _.
+bla(X, Y) ->
+    Z = X xor Y,    %% We should not infer Z :: true
+    zz(Z).
+
+-spec zz(true) -> true.
+zz(X) -> X.

--- a/test/should_fail/shortcut_ops.erl
+++ b/test/should_fail/shortcut_ops.erl
@@ -1,0 +1,16 @@
+-module(shortcut_ops).
+
+-compile(export_all).
+
+-spec andalso_too_precise1(true, number()) -> number().
+andalso_too_precise1(True, N) -> True andalso N.
+
+-spec andalso_too_precise2(false, number()) -> false.
+andalso_too_precise2(False, N) -> False andalso N.
+
+-spec orelse_too_precise1(false, number()) -> number().
+orelse_too_precise1(False, N) -> False orelse N.
+
+-spec orelse_too_precise2(true, number()) -> true.
+orelse_too_precise2(True, N) -> True orelse N.
+

--- a/test/should_pass/shortcut_ops.erl
+++ b/test/should_pass/shortcut_ops.erl
@@ -1,0 +1,40 @@
+-module(shortcut_ops).
+
+-compile(export_all).
+
+-spec andalso_check1(boolean(), number()) -> false | number().
+andalso_check1(B, N) -> B andalso N.
+
+-spec andalso_check2(boolean(), false | number()) -> false | number().
+andalso_check2(B, N) -> B andalso N.
+
+-spec andalso_check3(boolean(), boolean()) -> boolean() | number().
+andalso_check3(B, X) -> B andalso X.
+
+-spec orelse_check1(boolean(), number()) -> true | number().
+orelse_check1(B, N) -> B orelse N.
+
+-spec orelse_check2(boolean(), true | number()) -> true | number().
+orelse_check2(B, N) -> B orelse N.
+
+-spec orelse_check3(boolean(), boolean()) -> boolean() | number().
+orelse_check3(B, X) -> B orelse X.
+
+-spec andalso_infer1(boolean(), number()) -> _.
+andalso_infer1(B, N) -> B andalso N.
+
+-spec andalso_infer2(boolean(), false | number()) -> _.
+andalso_infer2(B, N) -> B andalso N.
+
+-spec andalso_infer3(boolean(), boolean()) -> _.
+andalso_infer3(B, X) -> B andalso X.
+
+-spec orelse_infer1(boolean(), number()) -> _.
+orelse_infer1(B, N) -> B orelse N.
+
+-spec orelse_infer2(boolean(), true | number()) -> _.
+orelse_infer2(B, N) -> B orelse N.
+
+-spec orelse_infer3(boolean(), boolean()) -> _.
+orelse_infer3(B, X) -> B orelse X.
+

--- a/test/should_pass/shortcut_ops.erl
+++ b/test/should_pass/shortcut_ops.erl
@@ -38,3 +38,28 @@ orelse_infer2(B, N) -> B orelse N.
 -spec orelse_infer3(boolean(), boolean()) -> _.
 orelse_infer3(B, X) -> B orelse X.
 
+-spec is_false_number(false | number()) -> ok.
+is_false_number(_) -> ok.
+
+-spec is_true_number(true | number()) -> ok.
+is_true_number(_) -> ok.
+
+-spec is_bool(boolean()) -> ok.
+is_bool(_) -> ok.
+
+-spec check_inferred(boolean(), number()) -> _.
+check_inferred(B, N) ->
+    And1 = andalso_infer1(B, N),
+    ok   = is_false_number(And1),
+    And2 = andalso_infer2(B, N),
+    ok   = is_false_number(And2),
+    And3 = andalso_infer3(B, B),
+    ok   = is_bool(And3),
+    Or1  = orelse_infer1(B, N),
+    ok   = is_true_number(Or1),
+    Or2  = orelse_infer2(B, N),
+    ok   = is_true_number(Or2),
+    Or3  = orelse_infer3(B, B),
+    ok   = is_bool(Or3),
+    ok.
+


### PR DESCRIPTION
Essentially
```erlang
-spec andalso(boolean(), false | T) -> false | T.
```
and same but with `true` for `orelse`.

See discussion in #23