### PR TITLE
Unfold when-clauses for `fun M:F/A` and `fun F/A` expressions

### DIFF
--- a/src/absform.erl
+++ b/src/absform.erl
@@ -2,8 +2,7 @@
 -module(absform).
 
 -export([normalize_record_field/1,
-         normalize_function_type_list/1,
-         function_type_list_to_fun_types/1]).
+         normalize_function_type_list/1]).
 
 %% @doc Turns all record fields into typed record fields. Adds default
 %% 'undefined' if default value is missing.
@@ -38,18 +37,3 @@ normalize_function_type({type, _, 'bounded_fun',
                          [_FunType, _FunConst]} = BoundedFun) ->
     BoundedFun.
 
-%% @doc Convert a function type list (as retrieved from a spec) into a type and
-%% constraints. The type of a function as in a spec can be richer (with
-%% constraints and multiple clauses) than the type of a fun object in a type
-%% declaration. The returned type is a union of fun object types (one for each
-%% clause) plus the combination of the constraints separately. This assumes that
-%% each type variable is only used in one of the clauses. Useful to preserve
-%% rich type info of fun objects like `fun mod:fn/1'.
-%% TODO: Warn if same type variable is used in multiple fun spec clauses.
-function_type_list_to_fun_types(FunTypeList) ->
-    L = element(2, hd(FunTypeList)),
-    {FunTypes, Css} =
-        lists:unzip(
-          [{FunType, constraints:convert(FunConst)}
-           || {type, _, bounded_fun, [FunType, FunConst]} <- FunTypeList]),
-    {{type, L, union, FunTypes}, constraints:combine(Css)}.

--- a/src/constraints.erl
+++ b/src/constraints.erl
@@ -1,6 +1,6 @@
 -module(constraints).
 
--export([empty/0, upper/2, lower/2, combine/1, combine/2, convert/1, add_var/2]).
+-export([empty/0, upper/2, lower/2, combine/1, combine/2, add_var/2]).
 
 -export_type([constraints/0]).
 
@@ -52,12 +52,3 @@ combine([C1, C2 | Cs]) ->
                     },
     combine([C | Cs]).
 
-convert(Cs) when is_list(Cs) ->
-    combine(lists:map(fun convert/1, Cs));
-
-convert({type, _,constraint,[{atom, _,is_subtype},[TV = {var, _, V}
-                                                  ,TW = {var, _, W}]]}) ->
-    #constraints{ upper_bounds = #{ V => [TW] }
-                , lower_bounds = #{ W => [TV] } };
-convert({type, _,constraint,[{atom, _,is_subtype},[{var, _, V},Ty]]}) ->
-    #constraints{ upper_bounds = #{ V => [Ty] } }.

--- a/test/absform_tests.erl
+++ b/test/absform_tests.erl
@@ -7,14 +7,12 @@ function_type_list_to_fun_types_test() ->
         merl:quote("-spec f(T)-> boolean() when T :: tuple();"
                    "       (atom()) -> any()."),
     BoundedFunTypeList = absform:normalize_function_type_list(FunTypeList),
-    {Ty, Cs} = absform:function_type_list_to_fun_types(BoundedFunTypeList),
-    ?assertMatch({type, 1, union,
+    Ty = typechecker:bounded_type_list_to_type({tenv, [], []}, BoundedFunTypeList),
+    ?assertMatch({type, 0, union,
                   [{type,1,'fun',
-                    [{type,1,product,[{var,1,'T'}]},
+                    [{type,1,product,[{type,0,tuple,any}]},
                      {type,1,boolean,[]}]},
                    {type,1,'fun',
                     [{type,1,product,[{type,1,atom,[]}]},
                      {type,1,any,[]}]}]}, Ty),
-    ExpCs = constraints:upper('T', typelib:parse_type("tuple()")),
-    ?assertMatch(ExpCs, Cs),
     ok.

--- a/test/should_pass/type_variable.erl
+++ b/test/should_pass/type_variable.erl
@@ -7,6 +7,20 @@ fff() -> 0.
 
 ggg() -> -fff().
 
+%% Use string:words/1 since its type spec in OTP is
+%% -spec words(String) -> Count when
+%%       String :: string(),
+%%       Count :: pos_integer().
+
+ggg_ext() -> -string:words("a b c d").
+
+ggg_fun1() -> -(fun fff/0)().
+ggg_fun2() -> F = fun fff/0, -F().
+
+ggg_mfa() ->
+    F = fun string:words/1,
+    -F("a b c d").
+
 %% Result should be pos_integer() in the end.
 -spec ff() -> Result when
     Result       :: integer() | Intermediate,


### PR DESCRIPTION
Follow up PR to #93.

This gets rid of the code converting bounded_fun constraints to type checker constraints.

cc #84