### PR TITLE
Dont crash on cyclic deps

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1025,8 +1025,8 @@ expect_fun_type(Env, Type) ->
                                | {fun_ty_intersection, [type()], constraints:constraints()}
                                | {fun_ty_union, [any()], constraints:constraints()}
                                .
-expect_fun_type1(Env, {type, _, bounded_fun, [Ft, Fc]}) ->
-    Sub = solve_bounds(Env#env.tenv, Fc),
+expect_fun_type1(Env, BTy = {type, _, bounded_fun, [Ft, _Fc]}) ->
+    Sub = bounded_type_subst(Env#env.tenv, BTy),
     case expect_fun_type1(Env, Ft) of
         {fun_ty, ArgsTy, ResTy, Cs} ->
             {fun_ty, subst_ty(Sub, ArgsTy), subst_ty(Sub, ResTy), Cs};
@@ -1146,10 +1146,19 @@ bounded_type_list_to_type(TEnv, Types) ->
         Tys  -> type(union, Tys)
     end.
 
-unfold_bounded_type(TEnv, {type, _, bounded_fun, [Ty, Bounds]}) ->
-    Sub = solve_bounds(TEnv, Bounds),
+unfold_bounded_type(TEnv, BTy = {type, _, bounded_fun, [Ty, _]}) ->
+    Sub = bounded_type_subst(TEnv, BTy),
     subst_ty(Sub, Ty);
 unfold_bounded_type(_Env, Ty) -> Ty.
+
+-spec bounded_type_subst(#tenv{}, {type, erl_anno:anno(), bounded_fun, [_]}) ->
+        #{ atom() => type() }.
+bounded_type_subst(TEnv, BTy = {type, P, bounded_fun, [_, Bounds]}) ->
+    try
+        solve_bounds(TEnv, Bounds)
+    catch throw:{cyclic_dependencies, Xs} ->
+        throw({type_error, cyclic_type_vars, P, BTy, Xs})
+    end.
 
 -spec solve_bounds(#tenv{}, [type()]) -> #{ atom() := type() }.
 solve_bounds(TEnv, Cs) ->
@@ -3617,6 +3626,11 @@ handle_type_error({type_error, receive_after, P, TyClauses, TyBlock}) ->
              "The type of the after block is : ~s~n"
             ,[erl_anno:line(P), typelib:pp_type(TyClauses)
                                , typelib:pp_type(TyBlock)]);
+handle_type_error({type_error, cyclic_type_vars, _P, Ty, Xs}) ->
+    io:format("The type spec ~s has a cyclic dependency in variable~s ~s~n",
+              [typelib:pp_type(Ty),
+               [ "s" || length(Xs) > 1 ],
+               string:join(lists:map(fun atom_to_list/1, lists:sort(Xs)), ", ")]);
 handle_type_error(type_error) ->
     io:format("TYPE ERROR~n").
 

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -12,6 +12,13 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 -spec pp_type(type()) -> string().
+pp_type(Type = {type, _, bounded_fun, _}) ->
+    %% erl_pp can't handle bounded_fun in type definitions
+    Form = {attribute, erl_anno:new(0), spec, {{foo, 0}, [Type]}},
+    TypeDef = erl_pp:form(Form),
+    {match, [S]} = re:run(TypeDef, <<"-spec foo\\s*(.*)\\.\\n*">>,
+                          [{capture, all_but_first, list}, dotall]),
+    "fun(" ++ S ++ ")";
 pp_type(Type) ->
     %% erl_pp can handle type definitions, so wrap Type in a type definition
     %% and then take the type from that.

--- a/test/known_problems/should_pass/cyclic_otp_specs.erl
+++ b/test/known_problems/should_pass/cyclic_otp_specs.erl
@@ -1,0 +1,9 @@
+-module(cyclic_otp_specs).
+
+-compile(export_all).
+
+%% We shouldn't fail on cyclic dependencies in OTP specs.
+%% Either make them work, or override the specs.
+
+-spec flatten([term()]) -> [term()].
+flatten(Xs) -> lists:flatten(Xs).

--- a/test/should_fail/cyclic_type_vars.erl
+++ b/test/should_fail/cyclic_type_vars.erl
@@ -1,0 +1,8 @@
+-module(cyclic_type_vars).
+
+-compile(export_all).
+
+-spec foo(A) -> B when
+    A :: true | B,
+    B :: [A].
+foo(_) -> [].


### PR DESCRIPTION
Give a nice error message instead of crashing on cyclic dependencies.

Future work:
- resolve some cyclic dependencies (by solving the recursive equations, or simplifying the types)
- find cyclic OTP specs and override them (or make them work)