### PR TITLE
Fix forgotten variable bindings in case scrutinees

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1856,7 +1856,8 @@ type_check_comprehension(Env, Compr, Expr, [Guard | Quals]) ->
     %% We don't require guards to return a boolean.
     %% This decision is up for debate.
     {_Ty, VarBinds1, Cs1} = type_check_expr(Env, Guard),
-    {TyL, VarBinds2, Cs2} = type_check_comprehension(Env, Compr, Expr, Quals),
+    NewEnv = Env#env{ venv = add_var_binds(Env#env.venv, VarBinds1, Env#env.tenv) },
+    {TyL, VarBinds2, Cs2} = type_check_comprehension(NewEnv, Compr, Expr, Quals),
     {TyL, union_var_binds(VarBinds1, VarBinds2, Env#env.tenv), constraints:combine(Cs1, Cs2)}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1232,7 +1232,7 @@ type_check_expr(Env, {'case', _, Expr, Clauses}) ->
     {_ExprTy, VarBinds, Cs1} = type_check_expr(Env, Expr),
     VEnv = add_var_binds(Env#env.venv, VarBinds, Env#env.tenv),
     {Ty, VB, Cs2} = infer_clauses(Env#env{ venv = VEnv}, Clauses),
-    {Ty, VB, constraints:combine(Cs1, Cs2)};
+    {Ty, union_var_binds(VarBinds, VB, Env#env.tenv), constraints:combine(Cs1, Cs2)};
 type_check_expr(Env, {tuple, P, TS}) ->
     { Tys, VarBindsList, Css} = lists:unzip3([ type_check_expr(Env, Expr)
                                               || Expr <- TS ]),
@@ -2049,7 +2049,7 @@ do_type_check_expr_in(Env, ResTy, {'case', _, Expr, Clauses}) ->
     {ExprTy, VarBinds, Cs1} = type_check_expr(Env, Expr),
     Env2 = Env#env{ venv = add_var_binds(Env#env.venv, VarBinds, Env#env.tenv) },
     {VB, Cs2} = check_clauses(Env2, [ExprTy], ResTy, Clauses),
-    {VB, constraints:combine(Cs1,Cs2)};
+    {union_var_binds(VarBinds, VB, Env#env.tenv), constraints:combine(Cs1,Cs2)};
 do_type_check_expr_in(Env, ResTy, {'if', _, Clauses}) ->
     check_clauses(Env, [], ResTy, Clauses);
 do_type_check_expr_in(Env, ResTy, {call, P, Name, Args}) ->

--- a/test/should_pass/varbind_in_case.erl
+++ b/test/should_pass/varbind_in_case.erl
@@ -1,0 +1,22 @@
+-module(varbind_in_case).
+
+-compile([export_all, nowarn_export_all]).
+
+%% Don't forget variable bindings in case scrutinee.
+
+%% Inference mode
+-spec foo() -> ok.
+foo() ->
+    case Ok = ok of
+        ok -> ok
+    end,
+    Ok.
+
+%% Checking mode
+-spec ok(ok) -> ok.
+ok(ok) -> ok.
+
+-spec bar() -> ok.
+bar() ->
+    ok(case Ok = ok of ok -> ok end),
+    Ok.

--- a/test/should_pass/varbind_in_lc.erl
+++ b/test/should_pass/varbind_in_lc.erl
@@ -1,0 +1,21 @@
+-module(varbind_in_lc).
+
+-compile([export_all, nowarn_export_all]).
+
+-spec is_true(true) -> true.
+is_true(true) -> true.
+
+%% Don't forget variable bindings in lc guard.
+
+lc1() ->
+    [ X || X = true, X == true ].
+
+lc2() ->
+    [ X || X = true, is_true(X) ].
+
+bc1() ->
+    << <<0>> || X = true, X == true >>.
+
+bc2() ->
+    << <<0>> || X = true, is_true(X) >>.
+


### PR DESCRIPTION
This is valid (albeit unusual) code:
```erlang
case X = bla() of _ -> foo() end,
X
```