### PR TITLE
Handle term() when expecting tuple, list or record

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -966,6 +966,8 @@ expect_tuple_type({type, _, tuple, any}, _N) ->
     any;
 expect_tuple_type({type, _, tuple, Tys}, N) when length(Tys) == N ->
     {elem_ty, Tys, constraints:empty()};
+expect_tuple_type(?type(term) = TermTy, N) ->
+    {elem_ty, lists:duplicate(N, TermTy), constraints:empty()};
 expect_tuple_type({ann_type, _, [_, Ty]}, N) ->
     expect_tuple_type(Ty, N);
 expect_tuple_type(Union = {type, _, union, UnionTys}, N) ->

--- a/test/should_pass/stuff_as_term.erl
+++ b/test/should_pass/stuff_as_term.erl
@@ -1,0 +1,11 @@
+-module(stuff_as_term).
+
+-compile([export_all, nowarn_export_all]).
+
+-spec tuple_as_term() -> term().
+tuple_as_term() ->
+    {x, y, z}.
+
+-spec tuple_pat_as_term(term()) -> any().
+tuple_pat_as_term({X, Y}) ->
+    {Y, X}.

--- a/test/should_pass/stuff_as_term.erl
+++ b/test/should_pass/stuff_as_term.erl
@@ -2,6 +2,8 @@
 
 -compile([export_all, nowarn_export_all]).
 
+-record(rec, {field :: term()}).
+
 -spec tuple_as_term() -> term().
 tuple_as_term() ->
     {x, y, z}.
@@ -9,3 +11,18 @@ tuple_as_term() ->
 -spec tuple_pat_as_term(term()) -> any().
 tuple_pat_as_term({X, Y}) ->
     {Y, X}.
+
+-spec cons_as_term() -> term().
+cons_as_term() -> [x, y].
+
+-spec cons_pat_as_term(term()) -> any().
+cons_pat_as_term([X|Xs]) -> X.
+
+-spec fun_as_term() -> term().
+fun_as_term() -> fun (X) -> X + 1 end.
+
+-spec record_as_term() -> term().
+record_as_term() -> #rec{}.
+
+-spec record_pat_as_term(term()) -> any().
+record_pat_as_term(#rec{}) -> ok.


### PR DESCRIPTION
These cases were not handle. Thus, we had errors saying that a tuple/cons/record doesn't have type term().