### PR TITLE
Unify errors for char nil, string, bin, tuple, and map

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1964,12 +1964,12 @@ do_type_check_expr_in(Env, Ty, Cons = {cons, _, H, T}) ->
         {type_error, _} ->
             throw({type_error, Cons, type(nonempty_list), Ty})
     end;
-do_type_check_expr_in(Env, Ty, {nil, LINE}) ->
-    case subtype({type, LINE, nil, []}, Ty, Env#env.tenv) of
+do_type_check_expr_in(Env, Ty, {nil, _} = Nil) ->
+    case subtype(type(nil), Ty, Env#env.tenv) of
         {true, Cs} ->
             {#{}, Cs};
         false ->
-            throw({type_error, nil, LINE, Ty})
+            throw({type_error, Nil, type(nil), Ty})
     end;
 do_type_check_expr_in(Env, Ty, {string, LINE, String}) ->
     case subtype({type, LINE, string, []}, Ty, Env#env.tenv) of
@@ -3761,9 +3761,13 @@ handle_type_error({type_error, {cons, Anno, _, _} = Cons, ActualTy, ExpectedTy})
                erl_anno:line(Anno),
                typelib:pp_type(ExpectedTy),
                typelib:pp_type(ActualTy)]);
-handle_type_error({type_error, nil, LINE, Ty}) ->
-    io:format("The empty list on line ~p does not have type ~s~n",
-              [LINE, typelib:pp_type(Ty)]);
+handle_type_error({type_error, {nil, Anno} = Nil, ActualTy, ExpectedTy}) ->
+    io:format("The empty list ~s on line ~p is expected "
+              "to have type ~s but it has type ~s~n",
+              [erl_pp:expr(Nil),
+               erl_anno:line(Anno),
+               typelib:pp_type(ExpectedTy),
+               typelib:pp_type(ActualTy)]);
 handle_type_error({argument_length_mismatch, P, LenTy, LenArgs}) ->
     io:format("The clause on line ~p is expected to have ~p argument(s) "
               "but it has ~p~n ",

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1984,7 +1984,7 @@ do_type_check_expr_in(Env, Ty, {bin, LINE, _BinElements} = Bin) ->
               {true, Cs0} ->
                   Cs0;
               false ->
-                  throw({type_error, bin, LINE, BinTy, Ty})
+                  throw({type_error, Bin, BinTy, Ty})
           end,
     {_Ty, VarBinds, Cs2} = type_check_expr(Env, Bin),
     {VarBinds, constraints:combine(Cs1, Cs2)};
@@ -3895,11 +3895,13 @@ handle_type_error({type_error, tuple, LINE, Ty}) ->
               [LINE, typelib:pp_type(Ty)]);
 handle_type_error({unknown_variable, P, Var}) ->
     io:format("Unknown variable ~p on line ~p.~n", [Var, P]);
-handle_type_error({type_error, bin, P, ActualTy, ExpectTy}) ->
-    io:format("The bit expression on line ~p is expected "
+handle_type_error({type_error, {bin, Anno, _} = Bin, ActualTy, ExpectTy}) ->
+    io:format("The bit expression ~s on line ~p is expected "
               "to have type ~s but it has type ~s~n",
-              [erl_anno:line(P),
-               typelib:pp_type(ExpectTy), typelib:pp_type(ActualTy)]);
+              [erl_pp:expr(Bin),
+               erl_anno:line(Anno),
+               typelib:pp_type(ExpectTy),
+               typelib:pp_type(ActualTy)]);
 handle_type_error({type_error, bit_type, Expr, P, Ty1, Ty2}) ->
     io:format("The expression ~s inside the bit expression on line ~p has type ~s "
               "but the type specifier indicates ~s~n",

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1971,12 +1971,12 @@ do_type_check_expr_in(Env, Ty, {nil, _} = Nil) ->
         false ->
             throw({type_error, Nil, type(nil), Ty})
     end;
-do_type_check_expr_in(Env, Ty, {string, LINE, String}) ->
-    case subtype({type, LINE, string, []}, Ty, Env#env.tenv) of
+do_type_check_expr_in(Env, Ty, {string, _, _} = String) ->
+    case subtype(type(string), Ty, Env#env.tenv) of
       {true, Cs} ->
         {#{}, Cs};
       false ->
-        throw({type_error, string, LINE, String, Ty})
+        throw({type_error, String, type(string), Ty})
     end;
 do_type_check_expr_in(Env, Ty, {bin, LINE, _BinElements} = Bin) ->
     BinTy = gradualizer_bin:compute_type(Bin),
@@ -3733,9 +3733,13 @@ handle_type_error({type_error, {char, Anno, _} = Char, ActualTy, ExpectedTy}) ->
 handle_type_error({type_error, {atom, _, A}, LINE, Ty}) ->
     io:format("The atom ~p on line ~p does not have type ~s~n",
               [A, LINE, typelib:pp_type(Ty)]);
-handle_type_error({type_error, string, LINE, String, Ty}) ->
-    io:format("The string ~p on line ~p does not have type ~s~n",
-              [String, LINE, typelib:pp_type(Ty)]);
+handle_type_error({type_error, {string, Anno, _} = String, ActualTy, ExpectedTy}) ->
+    io:format("The string ~s on line ~p is expected "
+              "to have type ~s but it has type ~s~n",
+              [erl_pp:expr(String),
+               erl_anno:line(Anno),
+               typelib:pp_type(ExpectedTy),
+               typelib:pp_type(ActualTy)]);
 handle_type_error({type_error, int, I, LINE, Ty}) ->
     io:format("The integer ~p on line ~p does not have type ~s~n",
               [I, LINE, typelib:pp_type(Ty)]);

--- a/test/known_problems/should_fail/map_entry.erl
+++ b/test/known_problems/should_fail/map_entry.erl
@@ -1,0 +1,5 @@
+-module(map_entry).
+-export([f/0]).
+
+-spec f() -> #{bepa := apa}.
+f() -> #{apa => bepa}.

--- a/test/should_fail/map_literal.erl
+++ b/test/should_fail/map_literal.erl
@@ -1,0 +1,5 @@
+-module(map_literal).
+-export([f/0]).
+
+-spec f() -> ok.
+f() -> #{apa => bepa}.

--- a/test/should_fail/nil.erl
+++ b/test/should_fail/nil.erl
@@ -1,0 +1,5 @@
+-module(nil).
+-export([f/0]).
+
+-spec f() -> nonempty_list().
+f() -> [].

--- a/test/should_fail/string.erl
+++ b/test/should_fail/string.erl
@@ -1,0 +1,6 @@
+-module(string).
+
+-export([f/0]).
+
+-spec f() -> ok.
+f() -> "".

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -481,13 +481,6 @@ add_type_pat_test_() ->
                                  "f(#r{f = F}) -> F."]))}
     ].
 
-handle_type_error_test_() ->
-    [
-     %% {type_error, nil, Line, Ty}
-     ?_assertNot(type_check_forms(["-spec f() -> atom().",
-                                   "f() -> []."]))
-    ].
-
 subtype(T1, T2) ->
     case typechecker:subtype(T1, T2, {tenv, #{}, #{}}) of
         {true, _} ->


### PR DESCRIPTION
Part of the series of PR's replacing #59, see #49.