### PR TITLE
Improve type inference of cons cells 

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -2831,7 +2831,7 @@ check_clauses_intersect(Env, [Ty|Tys], Clauses) ->
 
 check_clauses_union(_Env, [], _Clauses) ->
     %% TODO: Improve quality of type error
-    throw({typer_error, check_clauses});
+    throw({type_error, check_clauses});
 check_clauses_union(Env, [Ty|Tys], Clauses) ->
     try
         check_clauses_fun(Env, Ty, Clauses)

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3941,7 +3941,7 @@ pp_intersection_type([Ty|Tys]) ->
 
 
 line_no(Ty) ->
-    element(2,Ty).
+    erl_anno:line(element(2,Ty)).
 
 -spec gen_partition(integer(), list(tuple()), fun((tuple()) -> {integer(), term()} | false)) ->
                            tuple().

--- a/test/known_problems/should_pass/list_tail.erl
+++ b/test/known_problems/should_pass/list_tail.erl
@@ -1,0 +1,8 @@
+-module(list_tail).
+
+-compile([export_all]).
+
+%% Improper list in type inference - currently considered a type error
+atom_tail() ->
+    [ 1 | list_to_atom("banana")].
+

--- a/test/should_pass/list.erl
+++ b/test/should_pass/list.erl
@@ -8,3 +8,17 @@ f([]) ->
     0;
 f([A|As]) ->
     A + f(As).
+
+string_tail() ->
+    [ 1 | atom_to_list(foo)].
+
+-spec list_union_tail([atom()] | [integer()]) -> any().
+list_union_tail(L) ->
+    [ 1 | L ].
+
+list_any_tail() ->
+    [ 1 | return_list() ].
+
+-spec return_list() -> nonempty_list().
+return_list() ->
+    [2, 3].


### PR DESCRIPTION
Make use of existing utility function `expect_list_type/2`.
This is to avoid errors like: "The type string() is not a list type".

Improper lists are still not supported.