### PR TITLE
Fix function_clause on improper type_error thrown from add_type_pat/4

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3246,14 +3246,14 @@ add_type_pat(String = {string, P, _}, Ty, _TEnv, VEnv) ->
         false ->
             throw({type_error, pattern, P, String, Ty})
     end;
-add_type_pat({bin, P, BinElements} = Bin, Ty, TEnv, VEnv) ->
+add_type_pat({bin, _P, BinElements} = Bin, Ty, TEnv, VEnv) ->
     %% Check the size parameters of the bit pattern
     BinTy = gradualizer_bin:compute_type(Bin),
     Cs1 = case subtype(BinTy, Ty, TEnv) of
               {true, Cs0} ->
                   Cs0;
               false ->
-                  throw({type_error, bin, P, BinTy, Ty})
+                  throw({type_error, Bin, BinTy, Ty})
           end,
     %% Check the elements
     {NewVEnv, Cs} =

--- a/test/should_fail/bin_type_error.erl
+++ b/test/should_fail/bin_type_error.erl
@@ -1,0 +1,6 @@
+-module(bin_type_error).
+
+-export([throws_bin_type_error/1]).
+
+-spec throws_bin_type_error(integer()) -> any().
+throws_bin_type_error(<<>>) -> ok.


### PR DESCRIPTION
Fix errors of the following type:

```erlang
$ gradualizer src/mam/mod_mam_utils.erl
src/mam/mod_mam_utils.erl: escript: exception error: no function clause matching
                 typechecker:handle_type_error({type_error,bin,154,
                                                {type,0,binary,
                                                 [{integer,0,0},
                                                  {integer,0,0}]},
                                                {user_type,152,
                                                 iso8601_datetime_binary,[]}}) (/Users/erszcz/work/josefs/gradualizer/_build/default/lib/gradualizer/src/typechecker.erl, line 3711)
  in function  typechecker:'-type_check_forms/2-fun-0-'/7 (/Users/erszcz/work/josefs/gradualizer/_build/default/lib/gradualizer/src/typechecker.erl, line 3598)
  in call from lists:foldr/3 (lists.erl, line 1276)
  in call from gradualizer:type_check_forms/3 (/Users/erszcz/work/josefs/gradualizer/_build/default/lib/gradualizer/src/gradualizer.erl, line 147)
  in call from gradualizer:'-type_check_files/2-fun-1-'/4 (/Users/erszcz/work/josefs/gradualizer/_build/default/lib/gradualizer/src/gradualizer.erl, line 118)
  in call from lists:foldl/3 (lists.erl, line 1263)
  in call from gradualizer_cli:handle_args/1 (/Users/erszcz/work/josefs/gradualizer/_build/default/lib/gradualizer/src/gradualizer_cli.erl, line 17)
```