### PR TITLE
Unify errors for fun, named_fun, and var

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3740,23 +3740,13 @@ handle_type_error({type_error, tyVar, LINE, Var, VarTy, Ty}) ->
     io:format("The variable ~p on line ~p has type ~s "
               "but is expected to have type ~s~n",
               [Var, LINE, typelib:pp_type(VarTy), typelib:pp_type(Ty)]);
-handle_type_error({type_error, {char, Anno, _} = Char, ActualTy, ExpectedTy}) ->
-    io:format("The character ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(Char),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectedTy),
-               typelib:pp_type(ActualTy)]);
+handle_type_error({type_error, {char, _, _} = Char, ActualType, ExpectedType}) ->
+    print_type_error("character", Char, ActualType, ExpectedType);
 handle_type_error({type_error, {atom, _, A}, LINE, Ty}) ->
     io:format("The atom ~p on line ~p does not have type ~s~n",
               [A, LINE, typelib:pp_type(Ty)]);
-handle_type_error({type_error, {string, Anno, _} = String, ActualTy, ExpectedTy}) ->
-    io:format("The string ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(String),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectedTy),
-               typelib:pp_type(ActualTy)]);
+handle_type_error({type_error, {string, _, _} = String, ActualType, ExpectedType}) ->
+    print_type_error("string", String, ActualType, ExpectedType);
 handle_type_error({type_error, int, I, LINE, Ty}) ->
     io:format("The integer ~p on line ~p does not have type ~s~n",
               [I, LINE, typelib:pp_type(Ty)]);
@@ -3775,20 +3765,10 @@ handle_type_error({type_error, list, LINE, Ty}) ->
 handle_type_error({type_error, cons_pat, P, Cons, Ty}) ->
     io:format("The pattern ~s on line ~p does not have type:~n~s~n"
              ,[erl_pp:expr(Cons),P, typelib:pp_type(Ty)]);
-handle_type_error({type_error, {cons, Anno, _, _} = Cons, ActualTy, ExpectedTy}) ->
-    io:format("The list ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(Cons),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectedTy),
-               typelib:pp_type(ActualTy)]);
-handle_type_error({type_error, {nil, Anno} = Nil, ActualTy, ExpectedTy}) ->
-    io:format("The empty list ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(Nil),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectedTy),
-               typelib:pp_type(ActualTy)]);
+handle_type_error({type_error, {cons, _, _, _} = Cons, ActualType, ExpectedType}) ->
+    print_type_error("list", Cons, ActualType, ExpectedType);
+handle_type_error({type_error, {nil, _} = Nil, ActualType, ExpectedType}) ->
+    print_type_error("empty list", Nil, ActualType, ExpectedType);
 handle_type_error({argument_length_mismatch, P, LenTy, LenArgs}) ->
     io:format("The clause on line ~p is expected to have ~p argument(s) "
               "but it has ~p~n ",
@@ -3897,13 +3877,8 @@ handle_type_error({type_error, list_op_error, ListOp, P, Ty, _}) ->
     io:format("The operator ~p on line ~p is given an argument "
               "with a non-list type ~s~n",
               [ListOp, P, typelib:pp_type(Ty)]);
-handle_type_error({type_error, {map, Anno, _} = Map, ActualTy, ExpectTy}) ->
-    io:format("The map ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(Map),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectTy),
-               typelib:pp_type(ActualTy)]);
+handle_type_error({type_error, {map, _, _} = Map, ActualType, ExpectedType}) ->
+    print_type_error("map", Map, ActualType, ExpectedType);
 handle_type_error({type_error, operator_pattern, P, Expr, Ty}) ->
     io:format("The operator pattern ~s on line ~p is expected to have type "
               "~s~n"
@@ -3919,13 +3894,8 @@ handle_type_error({type_error, tuple, LINE, Ty}) ->
               [LINE, typelib:pp_type(Ty)]);
 handle_type_error({unknown_variable, P, Var}) ->
     io:format("Unknown variable ~p on line ~p.~n", [Var, P]);
-handle_type_error({type_error, {bin, Anno, _} = Bin, ActualTy, ExpectTy}) ->
-    io:format("The bit expression ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(Bin),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectTy),
-               typelib:pp_type(ActualTy)]);
+handle_type_error({type_error, {bin, _, _} = Bin, ActualType, ExpectedType}) ->
+    print_type_error("bit expression", Bin, ActualType, ExpectedType);
 handle_type_error({type_error, bit_type, Expr, P, Ty1, Ty2}) ->
     io:format("The expression ~s inside the bit expression on line ~p has type ~s "
               "but the type specifier indicates ~s~n",
@@ -3946,34 +3916,14 @@ handle_type_error({type_error, bc, P, Expr, Ty}) ->
 handle_type_error({type_error, check_clauses}) ->
     %%% TODO: Improve quality of type error
     io:format("Type error in clauses");
-handle_type_error({type_error, {record, Anno, _, _} = Rec, ActualTy, ExpectTy}) ->
-    io:format("The record ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(Rec),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectTy),
-               typelib:pp_type(ActualTy)]);
-handle_type_error({type_error, {record, Anno, _, _, _} = Rec, ActualTy, ExpectTy}) ->
-    io:format("The record update ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(Rec),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectTy),
-               typelib:pp_type(ActualTy)]);
-handle_type_error({type_error, {record_field, Anno, _, _, _} = Field, ActualTy, ExpectTy}) ->
-    io:format("The record field ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(Field),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectTy),
-               typelib:pp_type(ActualTy)]);
-handle_type_error({type_error, {record_index, Anno, _, _} = Index, ActualTy, ExpectTy}) ->
-    io:format("The record index ~s on line ~p is expected "
-              "to have type ~s but it has type ~s~n",
-              [erl_pp:expr(Index),
-               erl_anno:line(Anno),
-               typelib:pp_type(ExpectTy),
-               typelib:pp_type(ActualTy)]);
+handle_type_error({type_error, {record, _, _, _} = Rec, ActualType, ExpectedType}) ->
+    print_type_error("record", Rec, ActualType, ExpectedType);
+handle_type_error({type_error, {record, _, _, _, _} = Rec, ActualType, ExpectedType}) ->
+    print_type_error("record update", Rec, ActualType, ExpectedType);
+handle_type_error({type_error, {record_field, _, _, _, _} = Field, ActualType, ExpectedType}) ->
+    print_type_error("record field", Field, ActualType, ExpectedType);
+handle_type_error({type_error, {record_index, _, _, _} = Index, ActualType, ExpectedType}) ->
+    print_type_error("record index", Index, ActualType, ExpectedType);
 handle_type_error({type_error, record_pattern, P, Record, Ty}) ->
     io:format("The record patterns for record #~p on line ~p is expected to have"
               " type ~s.~n"
@@ -4011,6 +3961,19 @@ handle_type_error({type_error, mismatch, Ty, Expr}) ->
               [erl_pp:expr(Expr), erl_anno:line(element(2, Expr)), typelib:pp_type(Ty)]);
 handle_type_error(type_error) ->
     io:format("TYPE ERROR~n").
+
+-spec print_type_error(string(),
+                       erl_parse:abstract_expr(),
+                       typelib:type_et_cetera(),
+                       typelib:type_et_cetera()) -> ok.
+print_type_error(Explanation, Expression, ActualType, ExpectedType) ->
+    io:format("The ~s ~s on line ~p is expected "
+              "to have type ~s but it has type ~s~n",
+              [Explanation,
+               erl_pp:expr(Expression),
+               line_no(Expression),
+               typelib:pp_type(ExpectedType),
+               typelib:pp_type(ActualType)]).
 
 pp_intersection_type([]) ->
     "";

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3963,8 +3963,8 @@ handle_type_error(type_error) ->
 
 -spec print_type_error(string(),
                        erl_parse:abstract_expr(),
-                       typelib:type_et_cetera(),
-                       typelib:type_et_cetera()) -> ok.
+                       typelib:extended_type(),
+                       typelib:extended_type()) -> ok.
 print_type_error(Explanation, Expression, ActualType, ExpectedType) ->
     io:format("The ~s ~s on line ~p is expected "
               "to have type ~s but it has type ~s~n",

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1908,13 +1908,13 @@ type_check_expr_in(Env, ResTy, Expr) ->
 do_type_check_expr_in(Env, {type, _, any, []}, Expr) ->
     {_Ty, VB, Cs} = type_check_expr(Env, Expr),
     {VB, Cs};
-do_type_check_expr_in(Env, Ty, {var, LINE, Var}) ->
-    VarTy = maps:get(Var, Env#env.venv),
+do_type_check_expr_in(Env, Ty, {var, _, Name} = Var) ->
+    VarTy = maps:get(Name, Env#env.venv),
     case subtype(VarTy, Ty, Env#env.tenv) of
         {true, Cs} ->
             {#{}, Cs};
         false ->
-            throw({type_error, tyVar, LINE, Var, VarTy, Ty})
+            throw({type_error, Var, VarTy, Ty})
     end;
 do_type_check_expr_in(Env, Ty, {match, _, Pat, Expr}) ->
     {VarBinds, Cs} = type_check_expr_in(Env, Ty, Expr),
@@ -3135,7 +3135,7 @@ add_types_pats([Pat | Pats], [Ty | Tys], TEnv, VEnv, PatTysAcc, UBoundsAcc, CsAc
            constraints:constraints()}.
 add_type_pat({var, _, '_'}, Ty, _TEnv, VEnv) ->
     {Ty, Ty, VEnv, constraints:empty()};
-add_type_pat({var, P, A}, Ty, TEnv, VEnv) ->
+add_type_pat({var, _, A} = Var, Ty, TEnv, VEnv) ->
     %% TODO: In a fun clause, A is always free, but not in e.g. case clauses
     case VEnv of
         #{A := VarTy} ->
@@ -3143,7 +3143,7 @@ add_type_pat({var, P, A}, Ty, TEnv, VEnv) ->
                 {true, Cs} ->
                     {type(none), VarTy, VEnv, Cs};
                 false ->
-                    throw({type_error, tyVar, P, A, VarTy, Ty})
+                    throw({type_error, Var, VarTy, Ty})
             end;
         _FreeVar ->
             {Ty, Ty, VEnv#{A => Ty}, constraints:empty()}
@@ -3736,10 +3736,8 @@ handle_type_error({undef, user_type, LINE, {Name, Arity}}) ->
 handle_type_error({not_exported, remote_type, {{atom, LINE, _} = Module, Name, Arity}}) ->
     io:format("The type ~s:~s/~p on line ~p is not exported~n",
               [erl_pp:expr(Module), erl_pp:expr(Name), Arity, LINE]);
-handle_type_error({type_error, tyVar, LINE, Var, VarTy, Ty}) ->
-    io:format("The variable ~p on line ~p has type ~s "
-              "but is expected to have type ~s~n",
-              [Var, LINE, typelib:pp_type(VarTy), typelib:pp_type(Ty)]);
+handle_type_error({type_error, {var, _, _} = Var, ActualType, ExpectedType}) ->
+    print_type_error("variable", Var, ActualType, ExpectedType);
 handle_type_error({type_error, {char, _, _} = Char, ActualType, ExpectedType}) ->
     print_type_error("character", Char, ActualType, ExpectedType);
 handle_type_error({type_error, {atom, _, A}, LINE, Ty}) ->

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -4,7 +4,7 @@
 -export([remove_pos/1, annotate_user_types/2, get_module_from_annotation/1,
          substitute_type_vars/2,
          pp_type/1, debug_type/3, parse_type/1]).
--export_type([constraint/0, function_type/0, type_et_cetera/0]).
+-export_type([constraint/0, function_type/0, extended_type/0]).
 
 -type type() :: erl_parse:abstract_type().
 
@@ -20,11 +20,11 @@
                                 'fun',
                                 [{type, erl_anno:anno(), product, [type()]} |
                                  type()]}.
--type type_et_cetera() :: type() |
+-type extended_type() :: type() |
                           {type, erl_anno:anno(), bounded_fun,
                                  [function_type() | [constraint()]]} |
-                          [type_et_cetera()].
--spec pp_type(type_et_cetera()) -> string().
+                          [extended_type()].
+-spec pp_type(extended_type()) -> string().
 pp_type(Types = [_|_]) ->
     %% TODO: This is a workaround for the fact that a list is sometimes used in
     %% place of a type. It typically represents a function type with multiple

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -4,6 +4,7 @@
 -export([remove_pos/1, annotate_user_types/2, get_module_from_annotation/1,
          substitute_type_vars/2,
          pp_type/1, debug_type/3, parse_type/1]).
+-export_type([constraint/0, function_type/0, type_et_cetera/0]).
 
 -type type() :: erl_parse:abstract_type().
 

--- a/test/known_problems/should_pass/generator_var_shadow.erl
+++ b/test/known_problems/should_pass/generator_var_shadow.erl
@@ -1,0 +1,6 @@
+-module(generator_var_shadow).
+-export([f/2]).
+
+-spec f(boolean(), [integer()]) -> [integer()].
+f(X, Xs) ->
+    [X || X <- Xs].

--- a/test/should_fail/case_pattern.erl
+++ b/test/should_fail/case_pattern.erl
@@ -1,0 +1,8 @@
+-module(case_pattern).
+-export([f/2]).
+
+-spec f(integer(), atom()) -> ok.
+f(X, Y) ->
+    case Y of
+        X -> ok
+    end.

--- a/test/should_fail/case_pattern2.erl
+++ b/test/should_fail/case_pattern2.erl
@@ -1,0 +1,8 @@
+-module(case_pattern2).
+-export([f/2]).
+
+-spec f(integer(), atom()) -> ok.
+f(X, Y) ->
+    case {X, Y} of
+        {Z, Z} -> ok
+    end.

--- a/test/should_fail/match.erl
+++ b/test/should_fail/match.erl
@@ -1,0 +1,7 @@
+-module(match).
+-export([fail/0]).
+
+-spec foo() -> integer().
+foo() -> 0.
+
+fail() -> X = [X = foo()].

--- a/test/should_fail/named_fun.erl
+++ b/test/should_fail/named_fun.erl
@@ -1,0 +1,8 @@
+-module(named_fun).
+
+-compile([export_all, nowarn_export_all]).
+
+-spec foo(integer()) -> integer().
+foo(N) -> N.
+
+bar() -> foo(fun F(0) -> 0; F(X) -> F(X - 1) end).


### PR DESCRIPTION
Part of the series of PR's replacing #59, see #49.

Still looking for a test case that covers `add_type_pat({var, _, A} = Var, Ty, TEnv, VEnv)`.
I tried exploring different expressions using `=`, generators, and `case` but I didn't manage to find a case where the check fails (and should fail). Help wanted!