### PR TITLE
WIP: Improve type checking records

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1127,7 +1127,7 @@ expect_fun_type_union(Env, [Ty|Tys]) ->
             [TyOut | expect_fun_type_union(Env, Tys)]
     end.
 
-expect_record_type(Record, {type, _, record, [{atom, _, Name}]}, _TEnv) ->
+expect_record_type(Record, {type, _, record, [{atom, _, Name}|_]}, _TEnv) ->
     if Record == Name ->
          {ok, constraints:empty()};
        true ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -2085,7 +2085,7 @@ do_type_check_expr_in(Env, ResTy, {record, _, Exp, Name, Fields} = Record) ->
 do_type_check_expr_in(Env, ResTy, {record_field, _, Expr, Name, {atom, _, Field}} = RecordField) ->
     Rec = maps:get(Name, Env#env.tenv#tenv.records),
     FieldTy = get_rec_field_type(Field, Rec),
-    case subtype(ResTy, FieldTy, Env#env.tenv) of
+    case subtype(FieldTy, ResTy, Env#env.tenv) of
         {true, Cs1} ->
             RecTy = {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Name}]},
             {VarBinds, Cs2} = type_check_expr_in(Env, RecTy, Expr),
@@ -2094,7 +2094,7 @@ do_type_check_expr_in(Env, ResTy, {record_field, _, Expr, Name, {atom, _, Field}
             throw({type_error, RecordField, FieldTy, ResTy})
     end;
 do_type_check_expr_in(Env, ResTy, {record_index, _, _, _} = Index) ->
-    case subtype(ResTy, type(integer), Env#env.tenv) of
+    case subtype(type(integer), ResTy, Env#env.tenv) of
         {true, Cs} ->
             {#{}, Cs};
         false ->

--- a/test/should_fail/record.erl
+++ b/test/should_fail/record.erl
@@ -1,9 +1,27 @@
 -module(record).
 
--export([g/0]).
+-export([g/0,
+         undefined_record/0,
+         undefined_record_infer/0,
+         undefined_field/0,
+         undefined_field_infer/0]).
 
 -record(rec, { apa :: integer()}).
 
 -spec g() -> integer().
 g() ->
     #rec{apa = 1}.
+
+-spec undefined_record() -> term().
+undefined_record() ->
+    #undef{apa = 1}.
+
+undefined_record_infer() ->
+    #undef{apa = 1}.
+
+-spec undefined_field() -> term().
+undefined_field() ->
+    #rec{undef = 1}.
+
+undefined_field_infer() ->
+    #rec{undef = 1}.

--- a/test/should_fail/record_field.erl
+++ b/test/should_fail/record_field.erl
@@ -1,6 +1,10 @@
 -module(record_field).
 
--export([f/1, g/1]).
+-export([f/1, g/1,
+         undefined_record/1,
+         undefined_record_infer/1,
+         undefined_field/1,
+         undefined_field_infer/1]).
 
 -record(rec, { apa :: integer()}).
 
@@ -11,3 +15,17 @@ f(A) ->
 -spec g(#rec{}) -> pos_integer().
 g(A) ->
     A#rec.apa.
+
+-spec undefined_record(any()) -> integer().
+undefined_record(A) ->
+    A#undef.apa.
+
+undefined_record_infer(A) ->
+    A#undef.apa.
+
+-spec undefined_field(#{rec}) -> any().
+undefined_field(A) ->
+    A#rec.undef.
+
+undefined_field_infer(A) ->
+    A#rec.undef.

--- a/test/should_fail/record_field.erl
+++ b/test/should_fail/record_field.erl
@@ -1,9 +1,13 @@
 -module(record_field).
 
--export([f/1]).
+-export([f/1, g/1]).
 
 -record(rec, { apa :: integer()}).
 
 -spec f(#rec{}) -> boolean().
 f(A) ->
+    A#rec.apa.
+
+-spec g(#rec{}) -> pos_integer().
+g(A) ->
     A#rec.apa.

--- a/test/should_fail/record_index.erl
+++ b/test/should_fail/record_index.erl
@@ -1,9 +1,13 @@
 -module(record_index).
 
--export([f/0]).
+-export([f/0, g/0]).
 
 -record(rec, { apa :: integer()}).
 
 -spec f() -> boolean().
 f() ->
+    #rec.apa.
+
+-spec g() -> 2.
+g() ->
     #rec.apa.

--- a/test/should_fail/record_index.erl
+++ b/test/should_fail/record_index.erl
@@ -1,6 +1,10 @@
 -module(record_index).
 
--export([f/0, g/0]).
+-export([f/0, g/0,
+         undefined_record/0,
+         undefined_record_infer/0,
+         undefined_field/0,
+         undefined_field_infer/0]).
 
 -record(rec, { apa :: integer()}).
 
@@ -11,3 +15,17 @@ f() ->
 -spec g() -> 2.
 g() ->
     #rec.apa.
+
+-spec undefined_record() -> integer().
+undefined_record() ->
+    #undef.apa.
+
+undefined_record_infer() ->
+    #undef.apa.
+
+-spec undefined_field() -> integer().
+undefined_field() ->
+    #rec.undef.
+
+undefined_field_infer() ->
+    #rec.undef.

--- a/test/should_pass/records.erl
+++ b/test/should_pass/records.erl
@@ -34,3 +34,11 @@ rec_field_subtype(R) ->
 -spec rec_index_subtype() -> number().
 rec_index_subtype() ->
     #r.f2.
+
+-spec rec_refinement() -> #r{f1 :: boolean()}.
+rec_refinement() ->
+    #r{f1 = get_bool()}.
+
+-spec get_bool() -> boolean().
+get_bool() ->
+    true.

--- a/test/should_pass/records.erl
+++ b/test/should_pass/records.erl
@@ -26,3 +26,11 @@ i() ->
 -spec j() -> integer().
 j() ->
     #r.f2.
+
+-spec rec_field_subtype(#r{}) -> number().
+rec_field_subtype(R) ->
+    R#r.f2.
+
+-spec rec_index_subtype() -> number().
+rec_index_subtype() ->
+    #r.f2.


### PR DESCRIPTION
This is a work in progress. I have two questions:

I started to improve handling undefined records and record fields. But then I started to think how Gradualizer is used. In case it will be used as a parse transform (that takes place after pre-processing but before any other compiler steps) then sure these errors can happen. However if Gradualizer is used as other steps like xref, eunit, dialyzer, they are run after successful compilation. If Gradualizer works from a beam file this is surely that case. So why duplicate checks that the compiler already does. Maybe Gradualizer could just run the erlang linter (after epp) in case it works from a source file and the rest of the code can assume there are no linting errors in the AST. What do you think? (There are eg unexported functions in the should_pass examples which result in compiler warnings but Gradualizer happily checks them. I introduced undefined records but compilation fails, that's how I started to think about this)

It is possible to override/refine the types provided in the record definitions in types. eg:
```
-record(rec, {f1 :: atom()}).
-spec f(#rec{f1 :: foo}, term()) -> #rec{f1 :: boolean()}.
f(R, T) ->
  R#rec{f1 = is_integer(T)}.
```
In this case we could make use somehow of the `boolean()` type. Either type-check `is_integer/1` both against `atom()` (from the record definition) and against `boolean()` (from the expected type) ie the intersection of `atom()` and `boolean()`. Or infer the type of the whole record update and check that against the whole `ResTy`.
So in general I think there are multiple flows how to verify the extra info in type-inference and type-checking flows.
Also I'm not sure if this syntax is a pure override or field type (in the above case `boolean()`) must strictly be a subtype of the type from the rec def (ie `atom()`) and whether this also needs to be checked?