### PR TITLE
Fix handling undefined records and record fields

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3417,6 +3417,13 @@ add_type_pat_fields([{record_field, Anno, {atom, _, _} = FieldWithAnno, Pat}|Fie
     FieldTy = get_rec_field_type(FieldWithAnno, Rec),
     {_TyPat, _UBound, VEnv2, Cs1} = add_type_pat(Pat, FieldTy, TEnv, VEnv),
     {VEnv3, Cs2} = add_type_pat_fields(Fields, Record, TEnv, VEnv2),
+    {VEnv3, constraints:combine(Cs1, Cs2)};
+add_type_pat_fields([{record_field, _, {var, _, '_'}, _Pat}|Fields],
+                    Record, TEnv, VEnv) ->
+    %% TODO check Pat against type of unassigned fields
+    {VEnv2, Cs1} = {VEnv, constraints:empty()},
+
+    {VEnv3, Cs2} = add_type_pat_fields(Fields, Record, TEnv, VEnv2),
     {VEnv3, constraints:combine(Cs1, Cs2)}.
 
 %% Given a pattern for a key, finds the matching association in the map type and

--- a/test/should_pass/record_wildcard.erl
+++ b/test/should_pass/record_wildcard.erl
@@ -1,6 +1,6 @@
 -module(record_wildcard).
 
--export([f/0, g/0]).
+-export([f/0, g/0, h/1]).
 
 -record(rec, {apa  = 1         :: integer()
              ,bepa = false     :: boolean()
@@ -15,3 +15,10 @@ f() ->
 g() ->
     #rec{ apa = 1
         , _   = true }.
+
+%% wildcard in pattern matching
+-spec h(#rec{}) -> boolean().
+h(#rec{apa = 1, _ = true}) ->
+    true;
+h(_) ->
+    false.

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -484,12 +484,24 @@ type_check_clause_test_() ->
                                    "h() ->",
                                    "    fun() -> ok end."]))
     ].
+
 add_type_pat_test_() ->
     [{"Pattern matching list against any()",
       ?_assert(type_check_forms(["f([E|_]) -> E."]))},
      {"Pattern matching record against any()",
       ?_assert(type_check_forms(["-record(f, {r}).",
                                  "f(#r{f = F}) -> F."]))}
+    ].
+
+%% it is the responsibility of the compiler to catch undefined records
+%% but to improve code coverage we test them quickly.
+%% Gradualizer should not crash but return error nicely
+undefined_records_test_() ->
+    [?_assertNot(type_check_forms(["-spec f() -> term().",
+                                   "f() -> #r{f = 1}."])),
+     ?_assertNot(type_check_forms(["-record(r, {f1}).",
+                                   "-spec f() -> term().",
+                                   "f() -> #r{f2 = 1}."]))
     ].
 
 subtype(T1, T2) ->


### PR DESCRIPTION
In general Gradualizer should be run on code that compiles without
errors. (i.e. there should be no undefined records or record fields)
However if such a case is encounter crash with an error tuple (that is a
bit nicer than `badkey`, and much nicer than
`function_clause, handle_type_error({error, {record_field_not_found, ...`)

I kept one exception: undefined remote records (and fixed the error
formatting). This is a bit different as it is fetched from
`gradluaizer_db`. The compiler does not check entities in remote modules
(except behaviours), but it will catch this anyway when the remote
module itself is compiled. Maybe this should be an error as well.