### PR TITLE
Unify error printing and unify errors for float, int

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1937,12 +1937,13 @@ do_type_check_expr_in(Env, Ty, I = {integer, LINE, Int}) ->
         false ->
             throw({type_error, int, Int, LINE, Ty})
     end;
-do_type_check_expr_in(Env, Ty, {float, LINE, F}) ->
-    case subtype({type, LINE, float, []}, Ty, Env#env.tenv) of
+do_type_check_expr_in(Env, Ty, {float, _, _} = Float) ->
+    ExpectedType = type(float),
+    case subtype(ExpectedType, Ty, Env#env.tenv) of
         {true, Cs} ->
             {#{}, Cs};
         false ->
-            throw({type_error, float, F, LINE, Ty})
+            throw({type_error, Float, ExpectedType, Ty})
     end;
 do_type_check_expr_in(Env, Ty, Atom = {atom, _, _}) ->
     case subtype(Atom, Ty, Env#env.tenv) of
@@ -3759,9 +3760,6 @@ handle_type_error({not_exported, remote_type, {{atom, LINE, _} = Module, Name, A
 handle_type_error({type_error, int, I, LINE, Ty}) ->
     io:format("The integer ~p on line ~p does not have type ~s~n",
               [I, LINE, typelib:pp_type(Ty)]);
-handle_type_error({type_error, float, F, LINE, Ty}) ->
-    io:format("The float ~p on line ~p does not have type ~s~n",
-              [F, LINE, typelib:pp_type(Ty)]);
 handle_type_error({type_error, compat, _LINE, Ty1, Ty2}) ->
     io:format("The type ~s is not compatible with type ~s~n"
              ,[typelib:pp_type(Ty1), typelib:pp_type(Ty2)]);
@@ -3957,6 +3955,7 @@ describe_expr({atom, _, _})               -> "atom";
 describe_expr({bin, _, _})                -> "bit expression";
 describe_expr({char, _, _})               -> "character";
 describe_expr({cons, _, _, _})            -> "list";
+describe_expr({float, _, _})              -> "float";
 describe_expr({'fun', _, _})              -> "function expression";
 describe_expr({map, _, _})                -> "map";
 describe_expr({map, _, _, _} )            -> "map update";

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1930,12 +1930,12 @@ do_type_check_expr_in(Env, Ty, {match, _, Pat, Expr}) ->
     {_PatTy, _UBound, NewVEnv, Cs2} =
         add_type_pat(Pat, Ty, Env#env.tenv, Env#env.venv),
     {union_var_binds(VarBinds, NewVEnv, Env#env.tenv), constraints:combine(Cs, Cs2)};
-do_type_check_expr_in(Env, Ty, I = {integer, LINE, Int}) ->
+do_type_check_expr_in(Env, Ty, I = {integer, _, _}) ->
     case subtype(I, Ty, Env#env.tenv) of
         {true, Cs} ->
             {#{}, Cs};
         false ->
-            throw({type_error, int, Int, LINE, Ty})
+            throw({type_error, I, I, Ty})
     end;
 do_type_check_expr_in(Env, Ty, {float, _, _} = Float) ->
     ExpectedType = type(float),
@@ -3757,9 +3757,6 @@ handle_type_error({undef, user_type, LINE, {Name, Arity}}) ->
 handle_type_error({not_exported, remote_type, {{atom, LINE, _} = Module, Name, Arity}}) ->
     io:format("The type ~s:~s/~p on line ~p is not exported~n",
               [erl_pp:expr(Module), erl_pp:expr(Name), Arity, LINE]);
-handle_type_error({type_error, int, I, LINE, Ty}) ->
-    io:format("The integer ~p on line ~p does not have type ~s~n",
-              [I, LINE, typelib:pp_type(Ty)]);
 handle_type_error({type_error, compat, _LINE, Ty1, Ty2}) ->
     io:format("The type ~s is not compatible with type ~s~n"
              ,[typelib:pp_type(Ty1), typelib:pp_type(Ty2)]);
@@ -3957,6 +3954,7 @@ describe_expr({char, _, _})               -> "character";
 describe_expr({cons, _, _, _})            -> "list";
 describe_expr({float, _, _})              -> "float";
 describe_expr({'fun', _, _})              -> "function expression";
+describe_expr({integer, _, _})       -> "integer";
 describe_expr({map, _, _})                -> "map";
 describe_expr({map, _, _, _} )            -> "map update";
 describe_expr({named_fun, _, _, _})       -> "function expression";


### PR DESCRIPTION
Part of the series of PR's replacing #59, see #49

After discussion with @zuiderkwast we realized that all unified type errors are unique in that they are four-tuples where the second element is_tuple. The goal is to get all expressions that we can to match this format. The place I was worried about is how to replace binary operators, e.g. int_error. Our conclusion is that printing the erroneous expression and its expected type should be enough. The biggest missing feature is info about the column of an expression. I guess it's in the OTP backlog but is there a way we could help speed that process up (contributing or stating its importance).