### PR TITLE
Print column numbers in errors if available

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3991,11 +3991,12 @@ describe_expr(_)                          -> "expression".
                        typelib:extended_type(),
                        typelib:extended_type()) -> ok.
 print_type_error(Expression, ActualType, ExpectedType) ->
-    io:format("The ~s ~s on line ~p is expected "
+    io:format("The ~s ~s on line ~p~s is expected "
               "to have type ~s but it has type ~s~n",
               [describe_expr(Expression),
                erl_pp:expr(Expression),
                line_no(Expression),
+               maybe_format_column(Expression),
                typelib:pp_type(ExpectedType),
                typelib:pp_type(ActualType)]).
 
@@ -4010,8 +4011,16 @@ pp_intersection_type([Ty|Tys]) ->
 
 
 
-line_no(Ty) ->
-    erl_anno:line(element(2,Ty)).
+line_no(Expr) ->
+    erl_anno:line(element(2, Expr)).
+
+maybe_format_column(Expr) ->
+    case erl_anno:column(element(2, Expr)) of
+        undefined ->
+            "";
+        Column ->
+            " at column " ++ integer_to_list(Column)
+    end.
 
 -spec gen_partition(integer(), list(tuple()), fun((tuple()) -> {integer(), term()} | false)) ->
                            tuple().


### PR DESCRIPTION
This will only work if the abstract forms are aquired from an erlang
source file. Debug info from a beam file won't contain column numbers.

Many places in `handle_type_error` assume the annotation is a single
integer representing the line number, whereas it can be a location
two-tuple now. But the printouts will be fixed gradually as we unify
errors.

(Inspired by Pierre's comment https://github.com/josefs/Gradualizer/pull/152#issue-245932385)