### PR TITLE
New specs for functions in the lists module

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {project_plugins, [{covertool, "2.0.0"}]}.
 {cover_export_enabled, true}.
 {covertool, [{coverdata_files, ["eunit.coverdata"]}]}.
+{dialyzer, [{exclude_mods, [gradualizer_prelude]}]}.
 {escript_emu_args, "%%! -escript main gradualizer_cli\n"}.
 {eunit_opts, [verbose]}.
 {minimum_otp_vsn, "19.0"}.

--- a/src/gradualizer_prelude.erl
+++ b/src/gradualizer_prelude.erl
@@ -31,7 +31,7 @@
 
 -spec lists:filter(fun((T) -> boolean() | {true, Value}), [T]) -> [T | Value].
 
--spec lists:flatmap(fun((A) -> B), [A]) -> [B].
+-spec lists:flatmap(fun((A) -> [B]), [A]) -> [B].
 
 -type deep_list(A) :: [A | deep_list(A)].
 

--- a/src/gradualizer_prelude.erl
+++ b/src/gradualizer_prelude.erl
@@ -30,6 +30,8 @@
 -spec lists:duplicate(T, non_neg_integer()) -> [T].
 
 -spec lists:filter(fun((T) -> boolean()), [T]) -> [T].
+-spec lists:filtermap(fun((Elem) -> boolean() | {'true', Value}), [Elem])
+		     -> [Elem | Value].
 
 -spec lists:flatmap(fun((A) -> [B]), [A]) -> [B].
 

--- a/src/gradualizer_prelude.erl
+++ b/src/gradualizer_prelude.erl
@@ -38,7 +38,7 @@
 -spec lists:flatten(deep_list(A))      -> [A].
 -spec lists:flatten(deep_list(A), [A]) -> [A].
 
--spec lists:foldl(fun((T, Acc) -> Acc), [T], Acc) -> Acc.
+-spec lists:foldl(fun((T, Acc) -> Acc), Acc, [T]) -> Acc.
 -spec lists:foldr(fun((T, Acc) -> Acc), [T], Acc) -> Acc.
 -spec lists:join(T, [T]) -> [T].
 

--- a/src/gradualizer_prelude.erl
+++ b/src/gradualizer_prelude.erl
@@ -39,7 +39,7 @@
 -spec lists:flatten(deep_list(A), [A]) -> [A].
 
 -spec lists:foldl(fun((T, Acc) -> Acc), Acc, [T]) -> Acc.
--spec lists:foldr(fun((T, Acc) -> Acc), [T], Acc) -> Acc.
+-spec lists:foldr(fun((T, Acc) -> Acc), Acc, [T]) -> Acc.
 -spec lists:join(T, [T]) -> [T].
 
 -spec lists:foreach(fun((T) -> term()), [T]) -> ok.

--- a/src/gradualizer_prelude.erl
+++ b/src/gradualizer_prelude.erl
@@ -5,6 +5,7 @@
 -spec erlang:hd([A, ...]) -> A.
 -spec erlang:tl([A, ...]) -> [A].
 
+
 %% change return Val to any() from term()
 -spec application:get_env(Par) -> 'undefined' | {'ok', Val} when
       Par :: atom(),
@@ -18,3 +19,81 @@
       Par :: atom(),
       Def :: term(),
       Val :: any().
+
+-spec lists:append([[T]])     -> [T].
+-spec lists:append([T], [T])  -> [T].
+-spec lists:delete(T, [T])    -> [T].
+-spec lists:droplast([T, ...]) -> [T].
+
+-spec lists:dropwhile(fun((T) -> boolean()), [T]) -> [T].
+
+-spec lists:duplicate(T, non_neg_integer()) -> [T].
+
+-spec lists:filter(fun((T) -> boolean() | {true, Value}), [T]) -> [T | Value].
+
+-spec lists:flatmap(fun((A) -> B), [A]) -> [B].
+
+-type deep_list(A) :: [A | deep_list(A)].
+
+-spec lists:flatten(deep_list(A))      -> [A].
+-spec lists:flatten(deep_list(A), [A]) -> [A].
+
+-spec lists:foldl(fun((T, Acc) -> Acc), [T], Acc) -> Acc.
+-spec lists:foldr(fun((T, Acc) -> Acc), [T], Acc) -> Acc.
+-spec lists:join(T, [T]) -> [T].
+
+-spec lists:foreach(fun((T) -> term()), [T]) -> ok.
+
+-spec lists:last([T, ...]) -> T.
+
+-spec lists:map(fun((A) -> B), [A]) -> [B].
+-spec lists:mapfoldl(fun((A, Acc) -> {B, Acc}), Acc, [A]) -> {[B], Acc}.
+-spec lists:mapfoldr(fun((A, Acc) -> {B, Acc}), Acc, [A]) -> {[B], Acc}.
+
+-spec lists:max([T, ...]) -> T.
+-spec lists:min([T, ...]) -> T.
+
+-spec lists:merge([[T]]) -> [T].
+-spec lists:merge([X], [Y]) -> [X | Y].
+-spec lists:merge(fun((A, B) -> boolean()), [A], [B]) -> [A | B].
+-spec lists:merge3([X], [Y], [Z]) -> [X | Y | Z].
+
+-spec lists:nth    (pos_integer(), [T, ...]) -> T.
+-spec lists:nthtail(pos_integer(), [T, ...]) -> [T].
+
+-spec lists:partition(fun((T) -> boolean()), [T]) -> {[T], [T]}.
+
+-spec lists:reverse([T]) -> [T].
+
+-spec lists:reverse([T], [T]) -> [T].
+
+-spec lists:sort([T]) -> [T].
+-spec lists:sort(fun((T, T) -> boolean()), [T]) -> [T].
+
+-spec lists:split(integer(), [T]) -> {[T], [T]}.
+
+-spec lists:splitwith(fun((T) -> boolean()), [T]) -> {[T], [T]}.
+
+-spec lists:sublist([T],                non_neg_integer()) -> [T].
+-spec lists:sublist([T], pos_integer(), non_neg_integer()) -> [T].
+
+-spec lists:subtract([T], [T]) -> [T].
+
+-spec lists:takewhile(fun((T) -> boolean()), [T]) -> [T].
+
+-spec lists:umerge([[T]]) -> [T].
+-spec lists:umerge([X], [Y]) -> [X | Y].
+-spec lists:umerge(fun((A, B) -> boolean()), [A], [B]) -> [A | B].
+-spec lists:umerge3([X], [Y], [Z]) -> [X | Y | Z].
+
+-spec lists:unzip ([{A, B}])    -> {[A], [B]}.
+-spec lists:unzip3([{A, B, C}]) -> {[A], [B], [C]}.
+
+-spec lists:usort([T]) -> [T].
+-spec lists:usort(fun((T, T) -> boolean()), [T]) -> [T].
+
+-spec lists:zip ([A], [B])      -> [{A, B}].
+-spec lists:zip3([A], [B], [C]) -> [{A, B, C}].
+-spec lists:zipwith (fun((X, Y)    -> T), [X], [Y])      -> [T].
+-spec lists:zipwith3(fun((X, Y, Z) -> T), [X], [Y], [Z]) -> [T].
+

--- a/src/gradualizer_prelude.erl
+++ b/src/gradualizer_prelude.erl
@@ -29,7 +29,7 @@
 
 -spec lists:duplicate(T, non_neg_integer()) -> [T].
 
--spec lists:filter(fun((T) -> boolean() | {true, Value}), [T]) -> [T | Value].
+-spec lists:filter(fun((T) -> boolean()), [T]) -> [T].
 
 -spec lists:flatmap(fun((A) -> [B]), [A]) -> [B].
 
@@ -70,7 +70,7 @@
 -spec lists:sort([T]) -> [T].
 -spec lists:sort(fun((T, T) -> boolean()), [T]) -> [T].
 
--spec lists:split(integer(), [T]) -> {[T], [T]}.
+-spec lists:split(non_neg_integer(), [T]) -> {[T], [T]}.
 
 -spec lists:splitwith(fun((T) -> boolean()), [T]) -> {[T], [T]}.
 


### PR DESCRIPTION
I've started the work on creating alternative type specs for otp modules which have specs that don't work well with the Gradualizer. This PR handles the lists module.

Most of the changes are just removing `T :: term()` from the constraints. 

I'd appreciate feedback on:

- the type of `reverse/2`. I've given it a slightly more restrictive type than in otp. For reference, the otp type is
    ```
    -spec reverse(List1, Tail) -> List2 when
      List1 :: [T],
      Tail :: term(),
      List2 :: [T],
      T :: term().
    ```
- Naming convention of type variables. I've mostly followed the naming convention from otp, but it mixes `A`, `B`, `C` with `X`, `Y`, `Z` and simply `T`. Should we try to harmonize the names?

- I have added union types to the return type of `merge` and `umerge`. Is that appropriate?

EDIT: No more unions in the type of `filter`