### PR TITLE
Unify and test first part of arith_op and int_op

### DIFF
--- a/test/known_problems/should_fail/int_op.erl
+++ b/test/known_problems/should_fail/int_op.erl
@@ -1,0 +1,11 @@
+-module(int_op).
+-export([plusfloatany/2, divfloatany/2]).
+
+-spec plusfloatany(float(), any()) -> integer().
+plusfloatany(X, Y) ->
+    A = X + Y,
+    A.
+
+-spec divfloatany(float(), any()) -> integer() | any().
+divfloatany(X, Y) -> X div Y.
+

--- a/test/known_problems/should_pass/arith_op.erl
+++ b/test/known_problems/should_pass/arith_op.erl
@@ -1,0 +1,8 @@
+-module(arith_op).
+-export([plusintfloat/2, plusfloatint/2]).
+
+-spec plusintfloat(integer(), float()) -> float().
+plusintfloat(X, Y) -> X + Y.
+
+-spec plusfloatint(float(), integer()) -> float().
+plusfloatint(X, Y) -> X + Y.

--- a/test/should_fail/arith_op.erl
+++ b/test/should_fail/arith_op.erl
@@ -1,7 +1,8 @@
 -module(arith_op).
 -export([failplus/1, faildivvar/1, faildivlit/1, failpositivedivision/1,
          faildivprecise/1, failplusprecise/2, failminusprecisepos/2,
-         failminusnonneg/2, failminuspreciseneg/2]).
+         failminusnonneg/2, failminuspreciseneg/2, failplusarg/2,
+         faildivarg/2, failplusarg2/2, faildivarg2/2]).
 
 -spec failplus(_) -> tuple().
 failplus(X) -> X + X.
@@ -29,3 +30,19 @@ failminusnonneg(X, Y) -> X - Y.
 
 -spec failminuspreciseneg(neg_integer(), non_neg_integer()) -> neg_integer().
 failminuspreciseneg(X, Y) -> X - Y.
+
+-spec failplusarg(one, integer()) -> integer().
+failplusarg(X, Y) -> X + Y.
+
+-spec faildivarg(integer(), zero) -> integer().
+faildivarg(X, Y) -> X div Y.
+
+-spec failplusarg2(one, integer()) -> integer().
+failplusarg2(X, Y) ->
+    A = X + Y,
+    A.
+
+-spec faildivarg2(integer(), zero) -> integer().
+faildivarg2(X, Y) ->
+    A = X div Y,
+    A.

--- a/test/should_pass/arith_op.erl
+++ b/test/should_pass/arith_op.erl
@@ -1,0 +1,36 @@
+-module(arith_op).
+-export([plusintint/2, plusfloatfloat/2,
+         plusintfloat/2, plusfloatint/2,
+         plusany/2, plusany2/2, plusany3/2, plusany4/2]).
+
+-spec plusintint(integer(), integer()) -> integer().
+plusintint(X, Y) -> X + Y.
+
+-spec plusfloatfloat(float(), float()) -> float().
+plusfloatfloat(X, Y) -> X + Y.
+
+-spec plusintfloat(integer(), float()) -> float().
+plusintfloat(X, Y) ->
+    A = X + Y,
+    A.
+
+-spec plusfloatint(float(), integer()) -> float().
+plusfloatint(X, Y) ->
+    A = X + Y,
+    A.
+
+-spec plusany(integer(), any()) -> number().
+plusany(X, Y) -> X + Y.
+
+-spec plusany2(integer(), any()) -> integer().
+plusany2(X, Y) -> Y + X.
+
+-spec plusany3(integer(), any()) -> integer().
+plusany3(X, Y) ->
+    A = Y + X,
+    A.
+
+-spec plusany4(integer(), any()) -> integer().
+plusany4(X, Y) ->
+    A = X + Y,
+    A.

--- a/test/should_pass/int_op.erl
+++ b/test/should_pass/int_op.erl
@@ -1,0 +1,30 @@
+-module(int_op).
+-export([plusany/2, plusany2/2, plusany3/2,
+         divany/2, divany2/2, divany3/2, divany4/2]).
+
+-spec plusany(integer(), any()) -> number().
+plusany(X, Y) -> X + Y.
+
+-spec plusany2(integer(), any()) -> integer().
+plusany2(X, Y) -> Y + X.
+
+-spec plusany3(integer(), any()) -> integer().
+plusany3(X, Y) ->
+    A = Y + X,
+    A.
+
+-spec divany(integer(), any()) -> integer().
+divany(X, Y) -> X div Y.
+
+-spec divany2(integer(), any()) -> integer().
+divany2(X, Y) -> Y div X.
+
+-spec divany3(integer(), any()) -> integer().
+divany3(X, Y) ->
+    A = X div Y,
+    A.
+
+-spec divany4(integer(), any()) -> integer().
+divany4(X, Y) ->
+    A = Y div X,
+    A.


### PR DESCRIPTION
I'm leaving `type_check_arith_op_in` as is for now since this PR is big enough already.
I'd love if the [Wiki entry on bidirectional-type-checking](https://github.com/josefs/Gradualizer/wiki/Bidirectional-type-checking) was improved - I can get by, but it's a bit difficult since there are few comments in the codebase.

I've added some known problems that I think we ought to catch. We are currently quite inconsistent, e.g. changing the functions in `known_problems/should_pass/int_op.erl` to below makes them both fail.
 ```Erlang
-spec plusfloatany(float(), any()) -> integer().
plusfloatany(X, Y) ->
    X + Y.

-spec divfloatany(float(), any()) -> integer().
divfloatany(X, Y) -> X div Y.
```