### PR TITLE
Fix badmatch in union var binds

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3646,7 +3646,7 @@ union_var_binds([], _) ->
     #{};
 union_var_binds(VarBindsList, TEnv) ->
     % TODO: Don't drop the constraints
-    Glb = fun(_K, S, T) -> {T, _Cs} = glb(S, T, TEnv), T end,
+    Glb = fun(_K, Ty1, Ty2) -> {Ty, _Cs} = glb(Ty1, Ty2, TEnv), Ty end,
     union_var_binds_help(VarBindsList, Glb).
 
 %% Tail recursive helper.

--- a/test/should_pass/varbind_in_case.erl
+++ b/test/should_pass/varbind_in_case.erl
@@ -20,3 +20,11 @@ ok(ok) -> ok.
 bar() ->
     ok(case Ok = ok of ok -> ok end),
     Ok.
+
+-spec merge_vars(boolean(), 1..2, 2..3) -> 1..3.
+merge_vars(A, B, C) ->
+    case A of
+        true ->  V = B;
+        false -> V = C
+    end,
+    V.


### PR DESCRIPTION
The resulting type of glb is not necessarily the same as the second type.