### PR TITLE
Override specs for proplists

### DIFF
--- a/src/gradualizer_prelude.erl
+++ b/src/gradualizer_prelude.erl
@@ -99,3 +99,14 @@
 -spec lists:zipwith (fun((X, Y)    -> T), [X], [Y])      -> [T].
 -spec lists:zipwith3(fun((X, Y, Z) -> T), [X], [Y], [Z]) -> [T].
 
+%% Proplists: Changing term() to any() in the most frequently used functions.
+-spec proplists:delete(any(), list()) -> list().
+-spec proplists:get_all_values(any(), list()) -> list().
+-spec proplists:get_value(any(), list()) -> any().
+-spec proplists:get_value(any(), list(), any()) -> any().
+-spec proplists:get_bool(any(), list()) -> boolean().
+-spec proplists:get_keys(list()) -> list().
+-spec proplists:lookup(any(), list()) -> none | tuple().
+-spec proplists:lookup_all(any(), list()) -> [tuple()].
+-spec proplists:append_values(any(), list()) -> list().
+-spec proplists:substitute_aliases([{any(), any()}], list()) -> list().


### PR DESCRIPTION
Another step in #39.

This silences some errors especially often reported for `proplists:get_value/2,3` returning `term()` rather than `any()`.

For reference:

* https://github.com/erlang/otp/blob/master/lib/stdlib/src/proplists.erl
* http://erlang.org/doc/man/proplists.html
