### PR TITLE
Fix handling iolist/iodata

### DIFF
--- a/test/should_fail/iodata_fail.erl
+++ b/test/should_fail/iodata_fail.erl
@@ -1,0 +1,13 @@
+-module(iodata_fail).
+
+-export([utf/0]).
+
+%% an iodata can only contain bytes, no utf characters
+utf() ->
+    %% the last character is hexadecimal 256
+    %% (unicode "Latin Capital Letter a with Macron")
+    expect_iodata("foo\x{100}").
+
+-spec expect_iodata(iodata()) -> any().
+expect_iodata(_IOData) ->
+    ok.

--- a/test/should_fail/iodata_fail.erl
+++ b/test/should_fail/iodata_fail.erl
@@ -2,7 +2,7 @@
 
 -export([utf/0]).
 
-%% an iodata can only contain bytes, no utf characters
+%% an iodata can only contain bytes, no unicode code points above 255
 utf() ->
     %% the last character is hexadecimal 256
     %% (unicode "Latin Capital Letter a with Macron")

--- a/test/should_pass/iodata.erl
+++ b/test/should_pass/iodata.erl
@@ -1,0 +1,17 @@
+-module(iodata).
+
+-export([f/0, g/0]).
+
+-spec f() -> iolist().
+f() ->
+    [$a|list_to_binary("b")].
+
+-spec g() -> term().
+g() ->
+    expect_iodata("foo"),
+    expect_iodata(["foo"]),
+    expect_iodata(<<"foo">>).
+
+-spec expect_iodata(iodata()) -> any().
+expect_iodata(_IOData) ->
+    ok.

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -360,7 +360,7 @@ type_check_in_test_() ->
 
 infer_types_test_() ->
     %% Checking type_check_expr with inference enabled
-    [?_assertEqual("{1, [$e | $h | $l | $o, ...], [], banana, float(), $c}",
+    [?_assertEqual("{1, [101 | 104 | 108 | 111, ...], [], banana, float(), $c}",
                    type_check_expr(_Env = "",
                                    _Expr = "{1, \"hello\", \"\", banana, 3.14, $c}",
                                    [infer])),
@@ -384,6 +384,11 @@ infer_types_test_() ->
      ?_assertMatch("<<_:7, _:_*16>>",
                    type_check_expr(_Env = "f() -> receive X -> X end.",
                                    _Expr = "<<(f())/utf16, 7:7>>",
+                                   [infer])),
+     %% infer exact type of strings
+     ?_assertMatch("[$0..$c, ...]",
+                   type_check_expr(_Env = "",
+                                   _Expr = "\"0123456789abc\"",
                                    [infer])),
      %% infer exact type of record index
      ?_assertMatch("2",

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -71,6 +71,10 @@ subtype_test_() ->
      ?_assert(subtype(?t( nonempty_list()   ), ?t( [a]              ))),
      ?_assert(subtype(?t( nonempty_list()   ), ?t( [a, ...]         ))),
      ?_assert(subtype(?t( [a, ...]          ), ?t( [a]              ))),
+     ?_assert(subtype(?t( []                ), ?t( iolist()         ))),
+     ?_assert(subtype(?t( maybe_improper_list(byte(), binary()) ), ?t( iolist() ))),
+     ?_assert(subtype(?t( nonempty_list()   ), ?t( iodata()         ))),
+     ?_assert(subtype(?t( [byte()]          ), ?t( string()         ))),
 
      %% Tuples
      ?_assert(subtype(?t( {a,b,c}           ), ?t( tuple()          ))),
@@ -356,7 +360,7 @@ type_check_in_test_() ->
 
 infer_types_test_() ->
     %% Checking type_check_expr with inference enabled
-    [?_assertEqual("{1, nonempty_string(), [], banana, float(), $c}",
+    [?_assertEqual("{1, [$e | $h | $l | $o, ...], [], banana, float(), $c}",
                    type_check_expr(_Env = "",
                                    _Expr = "{1, \"hello\", \"\", banana, 3.14, $c}",
                                    [infer])),


### PR DESCRIPTION
There was a typo in the alias of iolist.

Not all strings are iolists but in case of a literal string we are able
to decide, so we can propagate a more precise type.