### PR TITLE
Fix glb for funs with any arity

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -528,6 +528,17 @@ glb_ty({type, _, 'fun', [{type, _, product, Args1}, Res1]},
                 false -> {type(none), Cs}
             end
     end;
+glb_ty({type, _, 'fun', [{type, _, any} = Any, Res1]},
+       {type, _, 'fun', [{type, _, any}, Res2]}, A, TEnv) ->
+    {Res, Cs} = glb(Res1, Res2, A, TEnv),
+    {type('fun', [Any, Res]), Cs};
+
+glb_ty({type, _, 'fun', [{type, _, any}, Res1]},
+       {type, _, 'fun', [{type, _, product, _} = TArgs2, _]} = T2, A, TEnv) ->
+    glb_ty(type('fun', [TArgs2, Res1]), T2, A, TEnv);
+glb_ty({type, _, 'fun', [{type, _, product, _} = TArgs1, _]} = T1,
+       {type, _, 'fun', [{type, _, any}, Res2]}, A, TEnv) ->
+    glb_ty(T1, type('fun', [TArgs1, Res2]), A, TEnv);
 
 %% normalize and remove_pos only does the top layer
 glb_ty({type, _, Name, Args1}, {type, _, Name, Args2}, A, TEnv)

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -201,12 +201,20 @@ glb_test_() ->
 
      %% Functions
      ?glb( t("fun((integer(), number()) -> a | b)"),
-           t("fun((number(),  number())  -> b | c)"),
+           t("fun((number(),  number()) -> b | c)"),
            t("fun((number(),  number()) -> b)")),
 
      ?glb( t("fun((integer(), number()) -> a | b)"),
            t("fun((number(),  float())  -> b | c)"),
            ?t(none()) ), %% Should be same as previous
+
+     ?glb( t("fun((...) -> a | b)"),
+           t("fun((...) -> b | c)"),
+           t("fun((...) -> b)")),
+
+     ?glb( t("fun((...)                -> a | b)"),
+           t("fun((number(), number()) -> b | c)"),
+           t("fun((number(), number()) -> b)")),
 
      %% Annotated types
      ?glb( ?t(X :: integer()), ?t(number()), ?t(integer()) ),


### PR DESCRIPTION
Without the extra clauses in `glb_ty` a fun with any arity would be
handled by the next clause which calls `remove_pos` for each "arg" and
which crashes on the special `{type, Anno, any}` tuple that is not
really a type.