### PR TITLE
Type annotations using '::'/2

### DIFF
--- a/include/gradualizer.hrl
+++ b/include/gradualizer.hrl
@@ -1,0 +1,35 @@
+%% Syntax elements for type annotations
+%%
+%% The macro ?annotate_type/2 can be used to annotate an expression with a
+%% type.  This is useful to add type annotation after fetching a value from an
+%% ets table, received a message on a known form or read from a dict, proplist,
+%% process dictionary, etc.
+%%
+%% The specified type must be compatible with the type detected by Gradualizer.
+%% Otherwise a type error is reported.
+%%
+%%     N = ?annotate_type( Message, non_neg_integer() )
+%%
+%% The macro ?assert_type/2 can be used to override any type detected by
+%% Gradualizer.  For example, the programmer may know that the length of
+%% a list is within a certain range, rather than any non_neg_integer():
+%%
+%%     Arity = ?assert_type( length(Args), arity() )
+%%
+%% The function '::' can also be used directly if the type is quoted:
+%%
+%%     N = '::'(Message, "non_neg_integer()")
+%%
+%% Gradualizer occurences of the '::'/2 function and adjusts type checking
+%% accordingly.  The macros are supplied only for convenience.
+
+-compile({inline, ['::'/2]}).
+
+'::'(Expr, _Type) -> Expr.
+
+%% Type annotation
+-define(annotate_type(Expr, Type), '::'(Expr, ??Type)).
+
+%% Forced type cast, via any()
+-define(assert_type(Expr, Type), '::'('::'(Expr, "any()"), ??Type)).
+

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1418,6 +1418,15 @@ do_type_check_expr(Env, {bin, _, BinElements} = BinExpr) ->
     {RetTy,
      union_var_binds(VarBinds, Env#env.tenv),
      constraints:combine(Css)};
+do_type_check_expr(Env, {call, P, {atom, _, '::'}, [Expr, {string, _, TypeStr}]}) ->
+    %% Magic function used as type annotation.
+    try typelib:parse_type(TypeStr) of
+        Type ->
+            {VarBinds, Cs} = type_check_expr_in(Env, Type, Expr),
+            {Type, VarBinds, Cs}
+    catch error:_ ->
+        throw({bad_type_annotation, P, TypeStr})
+    end;
 do_type_check_expr(Env, {call, P, Name, Args}) ->
     {FunTy, VarBinds1, Cs1} = type_check_fun(Env, Name, length(Args)),
     {ResTy, VarBinds2, Cs2} = type_check_call_ty(Env, expect_fun_type(Env, FunTy), Args
@@ -2193,6 +2202,19 @@ do_type_check_expr_in(Env, ResTy, {'case', _, Expr, Clauses}) ->
     {union_var_binds(VarBinds, VB, Env#env.tenv), constraints:combine(Cs1,Cs2)};
 do_type_check_expr_in(Env, ResTy, {'if', _, Clauses}) ->
     check_clauses(Env, [], ResTy, Clauses);
+do_type_check_expr_in(Env, ResTy, {call, P, {atom, _, '::'}, [Expr, {string, _, TypeStr}]} = TyAnno) ->
+    try typelib:parse_type(TypeStr) of
+        Type ->
+            case subtype(Type, ResTy, Env#env.tenv) of
+                {true, Cs1} ->
+                    {VarBinds, Cs2} = type_check_expr_in(Env, Type, Expr),
+                    {VarBinds, constraints:combine(Cs1, Cs2)};
+                false ->
+                    throw({type_error, TyAnno, ResTy, Type})
+            end
+    catch error:_ ->
+        throw({bad_type_annotation, P, TypeStr})
+    end;
 do_type_check_expr_in(Env, ResTy, {call, P, Name, Args}) ->
     {FunTy, VarBinds, Cs} = type_check_fun(Env, Name, length(Args)),
     {VarBinds2, Cs2} = type_check_call(Env, ResTy, expect_fun_type(Env, FunTy), Args,
@@ -4122,6 +4144,9 @@ handle_type_error({type_error, map, P, ResTy, MapTy}) ->
 handle_type_error({type_error, mismatch, Ty, Expr}) ->
     io:format("The expression ~s at line ~p does not have type ~s~n",
               [erl_pp:expr(Expr), erl_anno:line(element(2, Expr)), typelib:pp_type(Ty)]);
+handle_type_error({bad_type_annotation, P, TypeStr}) ->
+    io:format("The type annotation ~p on line ~p is not a valid type~n",
+              [TypeStr, erl_anno:line(P)]);
 handle_type_error(type_error) ->
     io:format("TYPE ERROR~n").
 

--- a/test/should_fail/annotated_types_fail.erl
+++ b/test/should_fail/annotated_types_fail.erl
@@ -1,0 +1,23 @@
+-module(annotated_types_fail).
+
+-export([f/1, g/0, g/1, syntax/0]).
+
+-include_lib("gradualizer/include/gradualizer.hrl").
+
+-spec f(integer()) -> any().
+f(N) ->
+    ?annotate_type(N, pos_integer()).
+
+-spec g() -> non_neg_integer().
+g() ->
+    receive {int, N} -> ?annotate_type(N, integer()) end.
+
+g(X) ->
+    N = ?annotate_type(X, integer()),
+    atom_or_die(N).
+
+syntax() ->
+    '::'(banana, "not a type").
+
+-spec atom_or_die(atom()) -> ok.
+atom_or_die(A) when is_atom(A) -> ok.

--- a/test/should_pass/annotated_types.erl
+++ b/test/should_pass/annotated_types.erl
@@ -1,0 +1,18 @@
+-module(annotated_types).
+
+-export([f/1]).
+
+-include_lib("gradualizer/include/gradualizer.hrl").
+
+f(Expr) ->
+    {call, _, _Name, Args} = Expr,
+    Arity = ?assert_type(length(Args), arity()),
+    do_stuff_with_arity(Arity).
+
+-spec g() -> non_neg_integer().
+g() ->
+    receive {age, Age} -> ?annotate_type(Age, non_neg_integer()) end.
+
+
+-spec do_stuff_with_arity(arity()) -> ok.
+do_stuff_with_arity(_Arity) -> ok.


### PR DESCRIPTION
Calling `'::'(Expr, "integer()")` has the same effect as calling a typed function such as

```Erlang
-spec int_id(integer()) -> integer().
int_id(N) -> N.
```