### PR TITLE
Add known problems for function intersections

### DIFF
--- a/test/known_problems/should_fail/intersection.erl
+++ b/test/known_problems/should_fail/intersection.erl
@@ -1,0 +1,9 @@
+-module(intersection).
+-export([j/1]).
+
+-spec i(a, b) -> {a, b};
+       (d, e) -> {d, e}.
+i(V, U) -> {V, U}.
+
+-spec j({d, b} | {a, e}) -> {a, b} | {d, e}.
+j({V, U}) -> i(V, U).

--- a/test/known_problems/should_pass/intersection.erl
+++ b/test/known_problems/should_pass/intersection.erl
@@ -1,0 +1,21 @@
+-module(intersection).
+-export([f/1, g/1, j/1]).
+
+-spec f(a|b) -> a|b.
+f(V) -> h(V).
+
+-spec g(a|b) -> a|b.
+g(V) ->
+    A = h(V),
+    A.
+
+-spec h(a) -> a;
+       (b) -> b.
+h(V) -> V.
+
+-spec i(a, b) -> {a, b};
+       (d, e) -> {d, e}.
+i(V, U) -> {V, U}.
+
+-spec j({a, b} | {d, e}) -> {a, b} | {d, e}.
+j({V, U}) -> i(V, U).


### PR DESCRIPTION
In order to fix this I believe we need to extend the constraint language. [Flow](https://arxiv.org/pdf/1708.08021.pdf) has both disjunction and conjunction. This is crucial in order to not get false positives such as the one in `test/known_problems/should_fail/intersection.erl`.

Also see #130.