### PR TITLE
Fix record compatibility check

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -289,7 +289,7 @@ compat_record_fields([], [], A, _TEnv) ->
 compat_record_fields([{typed_record_field, _NameAndDefaultValue1, T1} | Fs1],
                      [{typed_record_field, _NameAndDefaultValue2, T2} | Fs2],
                      A, TEnv) ->
-    {A1, Cs1} = compat_ty(T1, T2, A, TEnv),
+    {A1, Cs1} = compat(T1, T2, A, TEnv),
     {A2, Cs2} = compat_record_fields(Fs1, Fs2, A1, TEnv),
     {A2, constraints:combine(Cs1, Cs2)};
 compat_record_fields(_, _, _, _) ->

--- a/test/should_pass/record_var.erl
+++ b/test/should_pass/record_var.erl
@@ -1,6 +1,19 @@
 -module(record_var).
 
+-export([f/1, g/0]).
+
 -record(rec, {apa}).
 
 -spec f(A) -> A when A :: #rec{}.
 f(#rec{}) -> #rec{}.
+
+%% also defined in records.erl - with different line numbers
+-record(r, {f1     :: atom(),
+            f2 = 1 :: integer()}).
+
+%% The type of R is #r{} from the records module. As the record
+%% definition and types are the same in the two modules the records
+%% must be compatible.
+g() ->
+    R = records:h(),
+    R#r.f1.

--- a/test/should_pass/records.erl
+++ b/test/should_pass/records.erl
@@ -1,5 +1,9 @@
 -module(records).
 
+-export([f/0, g/1, h/0, i/0, j/0,
+         rec_field_subtype/1,
+         rec_index_subtype/0]).
+
 -record(r, {f1     :: atom(),
             f2 = 1 :: integer()}).
 


### PR DESCRIPTION
Have to remove position before comparing types of two record fields.
It can easily happen that two modules include the same headerfile, but
with different line numbers.

Even so when self-gradualizing in typechecker there was a fully
qualified self-call (?MODULE:fn) so the spec was looked up by
gradualizer_db which fetched it probably from the beam file while the
analysis was run on source. This resulted in different positions even for
the same module as the AST from source has line numbers but the AST from
debug_info doesn't.

This fixes:
src/typechecker.erl: The variable ParseData is expected to have type #parsedata{} but it has type #parsedata{}