### PR TITLE
Normalize away annotated types

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -627,6 +627,8 @@ normalize({op, _, _, _Arg1, _Arg2} = Op, _TEnv) ->
     erl_eval:partial_eval(Op);
 normalize({type, Ann, range, [T1, T2]}, TEnv) ->
     {type, Ann, range, [normalize(T1, TEnv), normalize(T2, TEnv)]};
+normalize({ann_type, _, [_Name, T]}, TEnv) ->
+    normalize(T, TEnv);
 normalize(Type, _TEnv) ->
     expand_builtin_aliases(Type).
 

--- a/test/should_pass/glb_ann_types.erl
+++ b/test/should_pass/glb_ann_types.erl
@@ -1,0 +1,20 @@
+-module(glb_ann_types).
+
+-compile(export_all).
+
+-type type() :: erl_parse:abstract_type().
+
+-define(TYPE_MOD, erl_parse).
+%%-define(TYPE_MOD, gradualizer_type).
+
+-spec type_check_comprehension_in(
+        Expr       :: erl_parse:abstract_expr(),
+        Qualifiers :: [ListGen |Filter|BinGen]) ->
+     {map(), constraints:constraints()}
+       when
+        ListGen :: {generate, erl_anno:anno(), ?TYPE_MOD:abstract_expr(), ?TYPE_MOD:abstract_expr()},
+        BinGen  :: {b_generate, erl_anno:anno(), ?TYPE_MOD:abstract_expr(), ?TYPE_MOD:abstract_expr()},
+        Filter  :: ?TYPE_MOD:abstract_expr().
+type_check_comprehension_in(Expr, [{generate, P_Gen, Pat, Gen} | Quals]) ->
+    {#{}, constraints:empty()}.
+


### PR DESCRIPTION
This small change triggers a new "infinite loop" while self-gradualizing
possibly again in GLB. A somewhat minimal extract of
`typechecker:type_check_comprehension_on` which triggers the behaviour
is put into `should_pass/glb_ann_types.erl`.

Should not be merged! Needs to be investigated.