### PR TITLE
 Option to specify include path for checking erl files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ escript:
 
 .PHONY: gradualize
 gradualize: escript
-	./gradualizer -pa src/ src/*.erl
+	./gradualizer -pa src/ -I include src/*.erl
 
 .PHONY: nocrashongradualize
 nocrashongradualize: escript

--- a/include/gradualizer.hrl
+++ b/include/gradualizer.hrl
@@ -26,6 +26,7 @@
 %% convenience.
 %%
 -compile({inline, ['::'/2, ':::'/2]}).
+-compile({nowarn_unused_function, ['::'/2, ':::'/2]}).
 
 '::'(Expr, _Type) -> Expr.
 ':::'(Expr, _Type) -> Expr.

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -1,13 +1,15 @@
 %%% @doc Main external API of the Gradualizer
 %%%
 %%% The functions `type_check(file|module|dir)' accept the following options:
+%%% - `{i, Dir}': Include path for `-include' and `-include_lib' when checking
+%%%   Erlang source files. Specify multiple times for multiple include paths.
 %%% - `stop_on_first_error': if `true' stop type checking at the first error,
 %%%   if `false' continue checking all functions in the given file and all files
 %%%   in the given directory.
 %%% - `print_file': if `true' prefix error printouts with the file name the
 %%%   error is from.
-%%% - `crash_on_error': if `true` crash on the first produced error
-%%% - `return_errors': if `true`, turns off error printing and errors
+%%% - `crash_on_error': if `true' crash on the first produced error
+%%% - `return_errors': if `true', turns off error printing and errors
 %%%   (in their internal format) are returned in a list instead of being
 %%%   condensed into a single ok | nok.
 %%% - `fmt_location': how to format location when pretty printing errors
@@ -49,7 +51,8 @@ type_check_file(File, Opts) ->
     ParsedFile =
         case filename:extension(File) of
             ".erl" ->
-                gradualizer_file_utils:get_forms_from_erl(File);
+                Includes = proplists:get_all_values(i, Opts),
+                gradualizer_file_utils:get_forms_from_erl(File, Includes);
             ".beam" ->
                 gradualizer_file_utils:get_forms_from_beam(File);
             Ext ->

--- a/src/gradualizer_bin.erl
+++ b/src/gradualizer_bin.erl
@@ -3,6 +3,8 @@
 
 -export([compute_type/1]).
 
+-include("gradualizer.hrl").
+
 %% Computes the type of a bitstring expression or pattern based on the sizes
 %% of the elements. The returned type is a normalized bitstring type.
 -spec compute_type(ExprOrPat) -> gradualizer_type:abstract_type()
@@ -39,7 +41,7 @@ bin_element_view({bin_element, Anno, {Lit, _, _}, default, _Spec} = BinElem)
     %% Size is not allowed for utf8/utf16/utf32.
     Bin = {bin, Anno, [BinElem]},
     {value, Value, []} = erl_eval:expr(Bin, []),
-    {bit_size(Value), 0};
+    {bit_size(?assert_type(Value, bitstring())), 0};
 bin_element_view({bin_element, Anno, {string, _, Chars}, Size, Spec}) ->
     %% Expand <<"ab":32/float>> to <<$a:32/float, $b:32/float>>
     %% FIXME: Not true for float, integer
@@ -88,7 +90,7 @@ get_type_specifier(Specifiers) when is_list(Specifiers) ->
                  S == bitstring orelse S == bits orelse
                  S == utf8 orelse S == utf16 orelse
                  S == utf32] of
-        [S|_] -> S;
+        [S|_] -> ?assert_type(S, atom());
         []    -> integer   %% default
     end;
 get_type_specifier(default) -> integer.

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -42,6 +42,8 @@ print_usage() ->
     io:format("       --verbose                 Show what Gradualizer is doing~n"),
     io:format("  -pa, --path-add                Add the specified directory to the beginning of~n"),
     io:format("                                 the code path; see erl -pa             [string]~n"),
+    io:format("  -I                             Include path for Erlang source files; see -I in~n"),
+    io:format("                                 the manual page erlc(1)~n"),
     io:format("       --print-file              prefix error printouts with the file name the~n"),
     io:format("                                 error is from~n"),
     io:format("       --no-print-file           inverse of --print-file~n"),
@@ -70,6 +72,7 @@ parse_opts([A | Args], Opts) ->
         "--verbose"                -> parse_opts(Args, [verbose | Opts]);
         "-pa"                      -> handle_path_add(A, Args, Opts);
         "--path-add"               -> handle_path_add(A, Args, Opts);
+        "-I"                       -> handle_include_path(Args, Opts);
         "--print-file"             -> parse_opts(Args, [print_file | Opts]);
         "--no-print-file"          -> parse_opts(Args, [{print_file, false} | Opts]);
         "--stop-on-first-error"    -> parse_opts(Args, [stop_on_first_error | Opts]);
@@ -77,7 +80,7 @@ parse_opts([A | Args], Opts) ->
         "--crash-on-error"         -> parse_opts(Args, [crash_on_error | Opts]);
         "--no-crash-on-error"      -> parse_opts(Args, [{no_crash_on_error, false} | Opts]);
         "--version"                -> {[], [version]};
-	"--fmt-location"           -> handle_fmt_location(Args, Opts);
+        "--fmt-location"           -> handle_fmt_location(Args, Opts);
         "--"                       -> {Args, Opts};
         "-" ++ _                   -> erlang:error(string:join(["Unknown parameter:", A], " "));
         _                          -> {[A | Args], Opts}
@@ -91,6 +94,12 @@ handle_path_add(A, [Path | Args], Opts) ->
         true       -> parse_opts(Args, Opts);
         {error, _} -> erlang:error(string:join(["Bad directory for ", A, ": ", Path], ""))
     end.
+
+-spec handle_include_path([string()], gradualizer:options()) -> {[string()], gradualizer:options()}.
+handle_include_path([Dir | Args], Opts) ->
+    parse_opts(Args, [{i, Dir} | Opts]);
+handle_include_path([], _Opts) ->
+    error("Missing argument for -I").
 
 handle_fmt_location([FmtTypeStr | Args], Opts) ->
     try list_to_existing_atom(FmtTypeStr) of

--- a/src/gradualizer_file_utils.erl
+++ b/src/gradualizer_file_utils.erl
@@ -3,7 +3,7 @@
 -module(gradualizer_file_utils).
 
 -export([
-            get_forms_from_erl/1,
+            get_forms_from_erl/2,
             get_forms_from_beam/1
         ]).
 
@@ -19,9 +19,10 @@
 
 -export_type([parsed_file_error/0, abstract_forms/0]).
 
--spec get_forms_from_erl(file:filename()) -> parsed_file() | parsed_file_error().
-get_forms_from_erl(File) ->
-    case epp_parse_file(File) of
+-spec get_forms_from_erl(file:filename(), IncludePaths :: [file:name()]) ->
+    parsed_file() | parsed_file_error().
+get_forms_from_erl(File, Includes) ->
+    case epp_parse_file(File, Includes) of
         {ok, Forms} ->
             {ok, Forms};
         {error, enoent} ->
@@ -31,12 +32,12 @@ get_forms_from_erl(File) ->
     end.
 
 %% @doc Preprocess and parse a file including column numbers in the result
-epp_parse_file(File) ->
+epp_parse_file(File, Includes) ->
     case file:open(File, [read]) of
         {ok, Fd} ->
             try
                 StartLocation = {1, 1},
-                case epp:open(File, Fd, StartLocation, [], []) of
+                case epp:open(File, Fd, StartLocation, Includes, []) of
                     {ok, Epp} ->
                         %% The undocumented `epp:parse_file/1' just
                         %% takes an internal state, and calls the

--- a/test/test.erl
+++ b/test/test.erl
@@ -36,7 +36,7 @@ gen_should_fail() ->
                       Opts = [{fmt_location, brief},
                               {fmt_expr_fun, fun erl_prettypr:format/1}],
                       lists:foreach(fun({_, Error}) -> typechecker:handle_type_error(Error, Opts) end, Errors),
-                      {ok, Forms} = gradualizer_file_utils:get_forms_from_erl(File),
+                      {ok, Forms} = gradualizer_file_utils:get_forms_from_erl(File, []),
                       ExpectedErrors = typechecker:number_of_exported_functions(Forms),
                       ?assertEqual(ExpectedErrors, length(Errors))
               end


### PR DESCRIPTION
I tried adding `-include("gradualizer.hrl")` to some gradualizer module to be able to use the type assertion macros, but when typechecking source code, `epp` doesn't find the include path. Therefore, I'm adding `-I` to the CLI (same as for `erlc`) and `{i, Dir}` (same as for `compile`) to be able to specify include paths. Now `make gradualize` can call gradualizer with `-I include`.

In the second commit, some false positives reported as type errors are hidden using `?assert_type/2`.