### PR TITLE
Allow wildcards in path args for cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,11 @@ escript:
 
 .PHONY: gradualize
 gradualize: escript
-	./gradualizer -pa src/ -I include src/*.erl
+	./gradualizer -pa src/ -I include -- src/*.erl
 
 .PHONY: nocrashongradualize
 nocrashongradualize: escript
-	./gradualizer -pa src/ src/*.erl; \
+	./gradualizer -pa src/ -I include -- src/*.erl; \
     EXIT=$$?; \
     if [ $$EXIT -eq 0 ] || [ $$EXIT -eq 1 ]; then \
         exit 0; \


### PR DESCRIPTION
Note the wildcards mustn't be expanded by the shell because the `-pa` option only takes one argument
```
gradualizer -pa myapp/deps/\*/ebin ...
or
gradualizer -pa 'myapp/deps/*/ebin' ...
```

Should wikdcards be supported by the new `-I` option as well?