### PR TITLE
Fix broken CLI features and add CLI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
 # The latest OTP version is special and therefore explicitly
 # included above instead.
 otp_release:
-  - 22.0
+
   - 21.0
   # Last minor version of older OTP releases
   - 20.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
 # The latest OTP version is special and therefore explicitly
 # included above instead.
 otp_release:
-
+  - 22.0
   - 21.0
   # Last minor version of older OTP releases
   - 20.3

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4030,7 +4030,7 @@ print_errors(Errors, Opts) ->
     ok.
 
 print_error(Error, Opts) ->
-    File = proplists:get_value(print_file, Opts),
+    File = proplists:get_value(filename, Opts),
     FmtLoc = proplists:get_value(fmt_location, Opts, verbose),
     case File of
         undefined -> ok;

--- a/test/dir/test_in_dir.erl
+++ b/test/dir/test_in_dir.erl
@@ -1,0 +1,6 @@
+-module(test_in_dir).
+
+-export([fail/1]).
+
+-spec fail(integer()) -> atom().
+fail(N) -> N.


### PR DESCRIPTION
E.g. checking a directory and --no-print-file were broken.

Since eunit captures stdout, it's quite hard to test the CLI from
within eunit. Instead, simple CLI tests are added in the Makefile.