### PR TITLE
Rework how overriden otp types are compiled and loaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
   # At that point, update otp_release in the corresponding list below
 
   - env: TEST=".travis/travis_has_latest_otp_version"
-    otp_release: 21.2
+    otp_release: 22.1
 
   # Run make target specialized for the checks we want to make in Travis for
   # the latest OTP release.
@@ -36,9 +36,9 @@ matrix:
 # The latest OTP version is special and therefore explicitly
 # included above instead.
 otp_release:
-
-  - 21.0
+  - 22.0
   # Last minor version of older OTP releases
+  - 21.3
   - 20.3
   - 19.3
 

--- a/src/gradualizer_prelude.erl
+++ b/src/gradualizer_prelude.erl
@@ -1,5 +1,7 @@
 -module(gradualizer_prelude).
 
+-compile({parse_transform, gradualizer_prelude_parse_trans}).
+
 %% This module contains specs to replace incorrect or inexact specs in OTP.
 
 -spec erlang:apply(function(), [any()]) -> any().

--- a/src/gradualizer_prelude_parse_trans.erl
+++ b/src/gradualizer_prelude_parse_trans.erl
@@ -1,0 +1,15 @@
+-module(gradualizer_prelude_parse_trans).
+
+-export([parse_transform/2]).
+
+parse_transform(Forms, _Options) ->
+    [{attribute, _, file, _} = File,
+     {attribute, _, module, _} = Mod
+     |SpecForms] = Forms,
+
+    [File,
+     Mod,
+     {attribute,2,export,[{get_prelude,0}]},
+     {function,3,get_prelude,0,
+      [{clause,3,[],[],
+        [erl_parse:abstract(SpecForms)]}]}].


### PR DESCRIPTION
This is just a bare minimum to allow compilation on OTP 22.