### PR TITLE
make cover doesn't ignore covertools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ gradualizer.d
 cover/
 eunit.coverdata
 test/ct.cover.spec
+test/covertool.erl
+test/covertool.hrl
 /gradualizer
 /_build
+/bin/


### PR DESCRIPTION
~Doing `make cover` now simply crashes with~

```
{"init terminating in do_boot",{{badmatch,{error,{1,erl_parse,["syntax error before: ","'.'"]}}},[{init,start_it,1,[]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
```
~Removing the comments allows it to parse and execute.~

Ok, turns out that after a `git clean -fdx` the command works locally for me. No idea why and I don't think it matters much anyway, so at least I want to submit the ignores.