### PR TITLE
Make spec overrides configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,12 @@ cli-tests: bin/gradualizer
 	# 8. No location, no filename
 	bin/gradualizer --fmt-location none --no-print-file test/dir/test_in_dir.erl \
 	|perl -ne '/^The variable N is expected/ or die "CLI 8 ($$_)"'
+	# 9. Possible to exclude prelude (-0777 from https://stackoverflow.com/a/30594643/497116)
+	bin/gradualizer --no-prelude test/should_pass/cyclic_otp_specs.erl \
+	|perl -0777 -ne '/^The type spec/g or die "CLI 9 ($$_)"'
+	# 10. Excluding prelude and then including it is a no-op
+	bin/gradualizer --no-prelude --specs-override-dir priv/prelude \
+	  test/should_pass/cyclic_otp_specs.erl || (echo "CLI 10"; exit 1)
 
 .PHONY: cover
 cover: EUNIT_OPTS =

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3946,6 +3946,8 @@ type_check_forms(Forms, Opts) ->
     CrashOnError = proplists:get_bool(crash_on_error, Opts),
 
     {ok, _} = application:ensure_all_started(gradualizer),
+    proplists:get_bool(no_prelude, Opts) orelse gradualizer_db:import_prelude(),
+    gradualizer_db:import_extra_specs(proplists:get_all_values(specs_override, Opts)),
 
     ParseData =
         collect_specs_types_opaques_and_functions(Forms),


### PR DESCRIPTION
Let's users use their own "preludes" without recompiling Gradualizer.
Could be improved to not re-import the preludes if multiple files are checked, but perhaps that can wait for another PR?