### PR TITLE
File consult prelude

### DIFF
--- a/priv/prelude/file.specs.erl
+++ b/priv/prelude/file.specs.erl
@@ -1,0 +1,31 @@
+-module(file).
+
+%% This module contains specs to replace incorrect or inexact specs in OTP.
+
+-type deep_list() :: [char() | atom() | deep_list()].
+-type name_all()  :: string() | atom() | deep_list() | (RawFilename :: binary()).
+-type posix() ::
+        'eacces' | 'eagain' |
+        'ebadf' | 'ebadmsg' | 'ebusy' |
+        'edeadlk' | 'edeadlock' | 'edquot' |
+        'eexist' |
+        'efault' | 'efbig' | 'eftype' |
+        'eintr' | 'einval' | 'eio' | 'eisdir' |
+        'eloop' |
+        'emfile' | 'emlink' | 'emultihop' |
+        'enametoolong' | 'enfile' |
+        'enobufs' | 'enodev' | 'enolck' | 'enolink' | 'enoent' |
+        'enomem' | 'enospc' | 'enosr' | 'enostr' | 'enosys' |
+        'enotblk' | 'enotdir' | 'enotsup' | 'enxio' |
+        'eopnotsupp' | 'eoverflow' |
+        'eperm' | 'epipe' |
+        'erange' | 'erofs' |
+        'espipe'  | 'esrch'  | 'estale' |
+        'etxtbsy' |
+        'exdev'.
+
+-spec consult(Filename) -> {ok, Terms} | {error, Reason} when
+      Filename :: name_all(),
+      Terms :: [any()],
+      Reason :: posix() | badarg | terminated | system_limit
+              | {Line :: integer(), Mod :: module(), Term :: term()}.

--- a/test/should_pass/file_consult.erl
+++ b/test/should_pass/file_consult.erl
@@ -1,0 +1,8 @@
+-module(file_consult).
+
+-export([f/0]).
+
+-spec f() -> [integer()].
+f() ->
+    {ok, Terms} = file:consult("primes.txt"),
+    Terms.


### PR DESCRIPTION
I'm not sure if this prelude change is the right thing. I think that most times when a user calls `file:consult/1`, they know what type the result will have. However, the file *could* contain something else, so perhaps `term()` is actually correct. Forcing the user to type out their expectations could be beneficial as well. Is `file:consult/1` actually one of the few functions where it's right that they return `term()`? 
