### PR TITLE
Refining types on fun guards

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3425,10 +3425,10 @@ check_guards(Env, Guards, P) ->
     X = lists:map(fun(GuardSeq) ->
                           check_guards_sequence(Env, GuardSeq)
                   end, Guards),
-    Glb = fun(_K, Ty1, Ty2) ->
+    Lub = fun(_K, Ty1, Ty2) ->
                   normalize({type, erl_anno:new(0), union, [Ty1, Ty2]}, Env#env.tenv)
           end,
-    VarBinds = union_var_binds_help(X, Glb),
+    VarBinds = union_var_binds_help(X, Lub),
     fail_if_unreachable_clause(VarBinds, P).
 
 %% Here, all Guards must be true, hence we calculate the greatest lower bound

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3446,10 +3446,10 @@ when_guard_test(_Env, {atom, _, _}) -> #{};
 % If Gt is a function call A_m:A(Gt_1, ..., Gt_k),
 %       where A_m is the atom erlang and A is an atom or an operator,
 %       then Rep(Gt) = {call,LINE,{remote,LINE,Rep(A_m),Rep(A)},[Rep(Gt_1), ..., Rep(Gt_k)]}.
-when_guard_test(Env, {call, _, {atom, _, Fun}, Vars}) ->
-    check_guard_call(Env, Fun, Vars);
-when_guard_test(Env, {call, _, {remote,_,_,{atom, _, Fun}}, Vars}) ->
-    check_guard_call(Env, Fun, Vars);
+when_guard_test(Env, {call, P, {atom, _, Fun}, Vars}) ->
+    check_guard_call(Env, P, Fun, Vars);
+when_guard_test(Env, {call, P, {remote,_,_,{atom, _, Fun}}, Vars}) ->
+    check_guard_call(Env, P, Fun, Vars);
 when_guard_test(Env, Guard) ->
     {_Ty, VB, _Cs} = type_check_expr(Env, Guard), % Do we need to thread the Env?
     VB.
@@ -3475,18 +3475,18 @@ when_guard_test(Env, Guard) ->
 
 % {function,LINE,Name,Arity,[Rep(Fc_1), ...,Rep(Fc_k)]}.
 % If Ft is a function type (T_1, ..., T_n) -> T_0, where each T_i is a type, then Rep(Ft) =
-check_guard_call(_Env, TypeBIF, Vars = [{var, _, Var}|_]) ->
+check_guard_call(_Env, P, TypeBIF, Vars = [{var, _, Var}|_]) ->
     case proplists:get_value(TypeBIF, test_bifs()) of
         undefined -> #{};
-        'fun' -> is_function_fun_type(Var, Vars);
-        Val -> #{Var => {type, erl_anno:new(0), Val, []}}
+        'fun' -> is_function_fun_type(P, Var, Vars);
+        Val -> #{Var => {type, P, Val, []}}
     end.
 
-is_function_fun_type(Fun, Vars) ->
+is_function_fun_type(P, Fun, Vars) ->
     case lists:keyfind(integer, 1, Vars) of
         {integer, _ , N} ->
-            #{Fun => {type, erl_anno:new(0), 'fun',
-                      [{type, erl_anno:new(0), product, [type(any) || _<-lists:seq(1,N)]},
+            #{Fun => {type, P, 'fun',
+                      [{type, P, product, [type(any) || _<-lists:seq(1,N)]},
                        type(any)]}};
         false ->
             %% TODO: make a fun type without args and arity — is it possible?

--- a/test/should_fail/fun_guard_info.erl
+++ b/test/should_fail/fun_guard_info.erl
@@ -1,8 +1,17 @@
 -module(fun_guard_info).
--compile([export_all]).
+-export([
+         fun_wrong_arity/1,
+         guard_unreachable_branch/1
+        ]).
 
 -spec fun_wrong_arity(any()) -> boolean().
 fun_wrong_arity(Fun) when is_function(Fun, 2) ->
     Fun(0);
 fun_wrong_arity(_Fun) -> true.
 
+-spec guard_unreachable_branch(atom() | list()) -> list().
+guard_unreachable_branch(Name)
+  when is_atom(Name), is_list(Name) ->
+    erlang:atom_to_list(Name);
+guard_unreachable_branch(_Name) ->
+    [].

--- a/test/should_fail/fun_guard_info.erl
+++ b/test/should_fail/fun_guard_info.erl
@@ -1,0 +1,8 @@
+-module(fun_guard_info).
+-compile([export_all]).
+
+-spec fun_wrong_arity(any()) -> boolean().
+fun_wrong_arity(Fun) when is_function(Fun, 2) ->
+    Fun(0);
+fun_wrong_arity(_Fun) -> true.
+

--- a/test/should_fail/fun_guard_info.erl
+++ b/test/should_fail/fun_guard_info.erl
@@ -1,7 +1,9 @@
 -module(fun_guard_info).
 -export([
          fun_wrong_arity/1,
-         guard_unreachable_branch/1
+         guard_unreachable_branch/1,
+         at_least_one_of_them_is_an_atom/2,
+         refined_types_makes_it_fail/2
         ]).
 
 -spec fun_wrong_arity(any()) -> boolean().
@@ -15,3 +17,20 @@ guard_unreachable_branch(Name)
     erlang:atom_to_list(Name);
 guard_unreachable_branch(_Name) ->
     [].
+
+% We know here that for sure at least one of them is an atom,
+% so this operation has no chance to pass.
+-spec at_least_one_of_them_is_an_atom(any(), any()) -> any().
+at_least_one_of_them_is_an_atom(A,B)
+  when is_atom(A), is_integer(B);
+       is_integer(A), is_atom(B) ->
+    A + B.
+
+% Here we know that one is an atom and the other is an integer,
+% or similarly, that A can be either an atom or an integer.
+% Hence the operation `atom_to_list` is not ensured safe.
+-spec refined_types_makes_it_fail(any(), any()) -> any().
+refined_types_makes_it_fail(A,B)
+  when is_atom(A), is_integer(B);
+       is_integer(A), is_atom(B) ->
+    erlang:atom_to_list(A).

--- a/test/should_pass/fun_guard_info.erl
+++ b/test/should_pass/fun_guard_info.erl
@@ -1,0 +1,30 @@
+-module(fun_guard_info).
+-export([
+         guard_is_atom/1,
+         remote_guard/1,
+         fun_correct_arity/1,
+         fun_unspecified_arity/1
+        ]).
+
+-spec guard_is_atom(atom() | list()) -> list().
+guard_is_atom(Name) when is_atom(Name) ->
+    erlang:atom_to_list(Name);
+guard_is_atom(_Name) ->
+    [].
+
+-spec remote_guard(atom() | list()) -> list().
+remote_guard(Name) when erlang:is_atom(Name) ->
+    erlang:atom_to_list(Name);
+remote_guard(_Name) ->
+    [].
+
+-spec fun_correct_arity(any()) -> boolean().
+fun_correct_arity(Fun) when is_function(Fun, 2) ->
+    Fun(0, 1);
+fun_correct_arity(_Fun) -> true.
+
+-spec fun_unspecified_arity(any()) -> boolean().
+fun_unspecified_arity(Fun) when is_function(Fun) ->
+    Fun(0,1);
+fun_unspecified_arity(_Fun) -> true.
+

--- a/test/should_pass/fun_guard_info.erl
+++ b/test/should_pass/fun_guard_info.erl
@@ -3,7 +3,8 @@
          guard_is_atom/1,
          remote_guard/1,
          fun_correct_arity/1,
-         fun_unspecified_arity/1
+         fun_unspecified_arity/1,
+         fun_different_variables/2
         ]).
 
 -spec guard_is_atom(atom() | list()) -> list().
@@ -28,3 +29,8 @@ fun_unspecified_arity(Fun) when is_function(Fun) ->
     Fun(0,1);
 fun_unspecified_arity(_Fun) -> true.
 
+-spec fun_different_variables(any(), any()) -> any().
+fun_different_variables(A,B)
+  when is_atom(A), is_integer(B);
+       is_integer(A), is_atom(B) ->
+    ok.


### PR DESCRIPTION
I think that my intentions are better explained in the tests:

Now these are passing:
```erlang
-spec guard_is_atom(atom() | list()) -> list().
guard_is_atom(Name) when is_atom(Name) ->
    erlang:atom_to_list(Name);
guard_is_atom(_Name) ->
    [].

-spec remote_guard(atom() | list()) -> list().
remote_guard(Name) when erlang:is_atom(Name) ->
    erlang:atom_to_list(Name);
remote_guard(_Name) ->
    [].

-spec fun_correct_arity(any()) -> boolean().
fun_correct_arity(Fun) when is_function(Fun, 2) ->
    Fun(0, 1);
fun_correct_arity(_Fun) -> true.

-spec fun_unspecified_arity(any()) -> boolean().
fun_unspecified_arity(Fun) when is_function(Fun) ->
    Fun(0,1);
fun_unspecified_arity(_Fun) -> true.
```

And these are not:
```erlang
-spec fun_wrong_arity(any()) -> boolean().
fun_wrong_arity(Fun) when is_function(Fun, 2) ->
    Fun(0);
fun_wrong_arity(_Fun) -> true.

-spec guard_unreachable_branch(atom() | list()) -> list().
guard_unreachable_branch(Name)
  when is_atom(Name), is_list(Name) ->
    erlang:atom_to_list(Name);
guard_unreachable_branch(_Name) ->
    [].
```