### PR TITLE
Add known problem for varbind in case

### DIFF
--- a/test/known_problems/should_pass/varbind_in_case.erl
+++ b/test/known_problems/should_pass/varbind_in_case.erl
@@ -1,0 +1,13 @@
+-module(varbind_in_case).
+
+-compile([export_all, nowarn_export_all]).
+
+-spec tuple_bind({foo, integer()} | {bar, float()}) -> number().
+tuple_bind(A) ->
+    case A of
+        {foo, N} ->
+            ok;
+        {bar, N} ->
+            ok
+        end,
+    N.


### PR DESCRIPTION
N is supposed to be bound after the case end. Once fixed, the function should be moved to the module with the same name in should_pass.