### PR TITLE
Add beams as Make dependency for shell target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ ebin/gradualizer.app: src/gradualizer.app.src | ebin
 	cp $< $@
 
 .PHONY: shell
-shell:
+shell: app
 	erl -pa ebin
 
 .PHONY: escript


### PR DESCRIPTION
Just makes it so Make recompiles beam files before starting the shell if needed.