### PR TITLE
Unify errors

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4492,6 +4492,8 @@ describe_expr({record_field, _, _, _, _}) -> "record field";
 describe_expr({record_index, _, _, _})    -> "record index";
 describe_expr({string, _, _})             -> "string";
 describe_expr({var, _, _})                -> "variable";
+describe_expr({lc, _, _, _})              -> "list comprehension";
+describe_expr({bc, _, _, _})              -> "binary comprehension";
 describe_expr(_)                          -> "expression".
 
 -spec print_type_error(gradualizer_type:abstract_expr(),

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4405,13 +4405,6 @@ handle_type_error({unknown_variable, Anno, Var}, Opts) ->
               [format_location(Anno, brief, Opts),
                Var,
                format_location(Anno, verbose, Opts)]);
-handle_type_error({type_error, bit_type, Expr, Anno, Ty1, Ty2}, Opts) ->
-    io:format("~sThe expression ~s inside the bit expression~s has type ~s "
-              "but the type specifier indicates ~s~n",
-              [format_location(Anno, brief, Opts),
-               pp_expr(Expr, Opts),
-               format_location(Anno, verbose, Opts),
-               pp_type(Ty1, Opts), pp_type(Ty2, Opts)]);
 handle_type_error({type_error, check_clauses}, _Opts) ->
     %%% TODO: Improve quality of type error
     io:format("Type error in clauses");

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4435,11 +4435,6 @@ handle_type_error({type_error, record_pattern, Anno, Record, Ty}, Opts) ->
                Record,
                format_location(Anno, verbose, Opts),
                pp_type(Ty, Opts)]);
-handle_type_error({type_error, map, Anno, ExpectedTy}, Opts) ->
-    io:format("~sThe map~s does not have type ~s~n",
-              [format_location(Anno, brief, Opts),
-               format_location(Anno, verbose, Opts),
-               pp_type(ExpectedTy, Opts)]);
 handle_type_error({type_error, badkey, KeyExpr, MapType}, Opts) ->
     %% Compare to the runtime error raised by maps:get(Key, Map) error:{badkey, Key}.
     io:format("~sThe expression ~s~s is not a valid key in the map type ~s~n",
@@ -4473,12 +4468,6 @@ handle_type_error({type_error, cyclic_type_vars, _Anno, Ty, Xs}, Opts) ->
                pp_type(Ty, Opts),
                [ "s" || length(Xs) > 1 ],
                string:join(lists:map(fun atom_to_list/1, lists:sort(Xs)), ", ")]);
-handle_type_error({type_error, map, Anno, ResTy, MapTy}, Opts) ->
-    io:format("~sThe map~s is expected to have type:~n~s~n"
-	      "but has the type:~n~s~n",
-	      [format_location(Anno, brief, Opts),
-               format_location(Anno, verbose, Opts),
-               pp_type(ResTy, Opts), pp_type(MapTy, Opts)]);
 handle_type_error({type_error, mismatch, Ty, Expr}, Opts) ->
     io:format("~sThe expression ~s~s does not have type ~s~n",
               [format_location(Expr, brief, Opts),

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4494,6 +4494,7 @@ describe_expr({string, _, _})             -> "string";
 describe_expr({var, _, _})                -> "variable";
 describe_expr({lc, _, _, _})              -> "list comprehension";
 describe_expr({bc, _, _, _})              -> "binary comprehension";
+describe_expr({tuple, _, _})              -> "tuple";
 describe_expr(_)                          -> "expression".
 
 -spec print_type_error(gradualizer_type:abstract_expr(),

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4439,25 +4439,33 @@ handle_type_error(type_error, _) ->
 
 -spec describe_expr(gradualizer_type:abstract_expr()) -> string().
 describe_expr({atom, _, _})               -> "atom";
+describe_expr({bc, _, _, _})              -> "binary comprehension";
 describe_expr({bin, _, _})                -> "bit expression";
+describe_expr({block,_,_})                -> "block";
 describe_expr({char, _, _})               -> "character";
+describe_expr({call, _, _})               -> "function call";
+describe_expr({'catch', _, _})            -> "catch expression";
+describe_expr({'case', _, _, _})          -> "case expression";
 describe_expr({cons, _, _, _})            -> "list";
 describe_expr({float, _, _})              -> "float";
-describe_expr({'fun', _, _})              -> "fun";
+describe_expr({'fun', _, _})              -> "fun expression";
 describe_expr({integer, _, _})            -> "integer";
+describe_expr({'if', _, _})               -> "if expression";
+describe_expr({lc, _, _, _})              -> "list comprehension";
 describe_expr({map, _, _})                -> "map";
-describe_expr({map, _, _, _} )            -> "map update";
-describe_expr({named_fun, _, _, _})       -> "named fun";
+describe_expr({map, _, _, _})             -> "map update";
+describe_expr({match, _, _, _})           -> "match";
+describe_expr({named_fun, _, _, _})       -> "named fun expression";
 describe_expr({nil, _})                   -> "empty list";
 describe_expr({record, _, _, _})          -> "record";
+describe_expr({'receive', _, _, _, _})    -> "receive expression";
 describe_expr({record, _, _, _, _})       -> "record update";
 describe_expr({record_field, _, _, _, _}) -> "record field";
 describe_expr({record_index, _, _, _})    -> "record index";
 describe_expr({string, _, _})             -> "string";
-describe_expr({var, _, _})                -> "variable";
-describe_expr({lc, _, _, _})              -> "list comprehension";
-describe_expr({bc, _, _, _})              -> "binary comprehension";
 describe_expr({tuple, _, _})              -> "tuple";
+describe_expr({'try', _, _, _, _, _})     -> "try expression";
+describe_expr({var, _, _})                -> "variable";
 describe_expr(_)                          -> "expression".
 
 -spec print_type_error(gradualizer_type:abstract_expr(),

--- a/test/should_fail/generator.erl
+++ b/test/should_fail/generator.erl
@@ -1,0 +1,12 @@
+-module(generator).
+
+-export([f/1, g/1]).
+
+-spec f(integer()) -> list().
+f(N) ->
+    [ X || X <- N].
+
+-spec g(integer()) -> list().
+g(N) ->
+    L = [ X || X <- N],
+    L.

--- a/test/should_fail/list_op.erl
+++ b/test/should_fail/list_op.erl
@@ -1,12 +1,16 @@
 -module(list_op).
--export([append/1,
+-export([append_right_error/1,
+         append_left_error/1,
          append/0,
          subtract/1,
          subtract/2,
          subtract/0]).
 
--spec append(integer()) -> _ | integer().
-append(X) -> [1] ++ X.
+-spec append_right_error(integer()) -> _ | integer().
+append_right_error(X) -> [1] ++ X.
+
+-spec append_left_error(integer()) -> _ | integer().
+append_left_error(X) -> X ++ [1].
 
 %% FIXME checking this function used to crash
 %% now it returns the following error


### PR DESCRIPTION
Old messages when checking `test/should_fail/lc_not_list.erl`:
```
The list comprehension on line 8 at column 14 is expected to have type integer() which has no list subtypes
The binary comprehension on line 9 at column 14 is expected to have type integer() which has no binary subtypes
```
New messages:
```
The expression [ 
 X ||
     X <- [1, 2]
] on line 8 at column 14 is expected to have type integer() but it has type list()
The expression << 
  <<X>> ||
      X <- [1, 2]
>> on line 9 at column 14 is expected to have type integer() but it has type <<_:_*1>>
```

Old messages when checking `test/should_fail/test/should_fail/bc.erl`:
```
The variable X on line 6 at column 8 is expected to have type binary() but it has type integer()
The expression list_to_integer(X) in the bit string comprehension on line 9 has type integer() but a bit type is expected.
```
New messages:
```
The variable X on line 6 at column 8 is expected to have type binary() but it has type integer()
The expression list_to_integer(X) on line 9 at column 9 is expected to have type <<_:_*1>> but it has type integer()
```
Old messages when checking `test/should_fail/generator.erl `:
```
The generator in a list comprehension on line 7 at column 14 is expected to return a list type, but returns integer()
The generator in a list comprehension on line 11 at column 18 is expected to return a list type, but returns integer()
```
New messages:
```
The variable N on line 7 at column 17 is expected to have type list() but it has type integer()
The variable N on line 11 at column 21 is expected to have type list() but it has type integer()
```
Old messages when checking `test/should_fail/list_op.erl`:
```
The operator '++' on line 10 at column 30 is given an argument with a non-list type integer()
The operator '++' on line 13 at column 27 is given an argument with a non-list type integer()
The operator '++' on line 19 at column 32 is expected to have type _TyVar-576460752303423485 which is too precise to be statically checked
The operator '--' on line 22 at column 20 is expected to have type {ok, [a]}, which has no list subtypes
The operator '--' on line 25 at column 24 is expected to have type [a, ...] which is too precise to be statically checked
The operator '--' on line 31 at column 32 is expected to have type _TyVar-576460752303423453 which is too precise to be statically checked
```
New messages:
```
The variable X on line 10 at column 33 is expected to have type list() but it has type integer()
The variable X on line 13 at column 25 is expected to have type list() but it has type integer()
The operator '++' on line 19 at column 32 is expected to have type _TyVar-576460752303423484 which is too precise to be statically checked
The expression Xs -- Xs on line 22 at column 20 is expected to have type {ok, [a]} but it has type list()
The operator '--' on line 25 at column 24 is expected to have type [a, ...] which is too precise to be statically checked
The operator '--' on line 31 at column 32 is expected to have type _TyVar-576460752303423452 which is too precise to be statically checked
```