### PR TITLE
Handle -gradualizer(Options) in modules

### DIFF
--- a/test/should_fail/infer_enabled.erl
+++ b/test/should_fail/infer_enabled.erl
@@ -1,0 +1,8 @@
+-module(infer_enabled).
+
+-gradualizer(infer).
+-export([f/0]).
+
+f() ->
+    X = 1, Y = banana,
+    X + Y.


### PR DESCRIPTION
This is tested using the infer option in a test module.

The code is inspired by how it's done in `compile` in OTP.