### PR TITLE
Enable overriding cli options with attributes

### DIFF
--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -176,7 +176,7 @@ type_check_forms(Forms, Opts) ->
                             ok | nok | [{file:filename(), any()}].
 type_check_forms(File, Forms, Opts) ->
     ReturnErrors = proplists:get_bool(return_errors, Opts),
-    OptsForModule = Opts ++ options_from_forms(Forms),
+    OptsForModule = normalize_options(options_from_forms(Forms), Opts),
     Errors = typechecker:type_check_forms(Forms, OptsForModule),
     case {ReturnErrors, Errors} of
         {true, _ } ->
@@ -196,3 +196,13 @@ options_from_forms([{attribute, _L, gradualizer, Opt} | Fs]) ->
     [Opt | options_from_forms(Fs)];
 options_from_forms([_F | Fs]) -> options_from_forms(Fs);
 options_from_forms([]) -> [].
+
+%% Normalize options so that module local options override options
+%% from the top level
+normalize_options(ModOpts, Opts) ->
+    proplists:normalize(ModOpts ++ Opts ++ [prelude] % using prelude is the default
+		       ,[{negations, [{no_infer, infer}
+				     ,{no_prelude, prelude}
+				     ]
+			 }]
+		       ).

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -176,7 +176,10 @@ type_check_forms(Forms, Opts) ->
                             ok | nok | [{file:filename(), any()}].
 type_check_forms(File, Forms, Opts) ->
     ReturnErrors = proplists:get_bool(return_errors, Opts),
-    OptsForModule = normalize_options(options_from_forms(Forms), Opts),
+    OptsForModule =
+	options_from_forms(Forms) ++
+	Opts ++
+	[prelude], % using prelude is the default if nothing else is specified
     Errors = typechecker:type_check_forms(Forms, OptsForModule),
     case {ReturnErrors, Errors} of
         {true, _ } ->
@@ -196,13 +199,3 @@ options_from_forms([{attribute, _L, gradualizer, Opt} | Fs]) ->
     [Opt | options_from_forms(Fs)];
 options_from_forms([_F | Fs]) -> options_from_forms(Fs);
 options_from_forms([]) -> [].
-
-%% Normalize options so that module local options override options
-%% from the top level
-normalize_options(ModOpts, Opts) ->
-    proplists:normalize(ModOpts ++ Opts ++ [prelude] % using prelude is the default
-		       ,[{negations, [{no_infer, infer}
-				     ,{no_prelude, prelude}
-				     ]
-			 }]
-		       ).

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -116,7 +116,7 @@ parse_opts([A | Args], Opts) ->
         "--crash-on-error"         -> parse_opts(Args, [crash_on_error | Opts]);
         "--no-crash-on-error"      -> parse_opts(Args, [{crash_on_error, false} | Opts]);
         "--version"                -> {[], [version]};
-        "--no-prelude"             -> parse_opts(Args, [no_prelude | Opts]);
+        "--no-prelude"             -> parse_opts(Args, [{prelude, false}| Opts]);
         "--specs-override-dir"     -> handle_specs_override(A, Args, Opts);
         "--fmt-location"           -> handle_fmt_location(Args, Opts);
         "--"                       -> {Args, Opts};

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3950,7 +3950,7 @@ type_check_forms(Forms, Opts) ->
     CrashOnError = proplists:get_bool(crash_on_error, Opts),
 
     {ok, _} = application:ensure_all_started(gradualizer),
-    proplists:get_bool(no_prelude, Opts) orelse gradualizer_db:import_prelude(),
+    proplists:get_bool(prelude, Opts) andalso gradualizer_db:import_prelude(),
     gradualizer_db:import_extra_specs(proplists:get_all_values(specs_override, Opts)),
 
     ParseData =

--- a/test/gradualizer_cli_tests.erl
+++ b/test/gradualizer_cli_tests.erl
@@ -105,7 +105,7 @@ fmt_location_invalid2_test() ->
 
 prelude_test() ->
     {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no-prelude", "file.erl"]),
-    ?assertEqual(true, proplists:get_value(no_prelude, Opts)).
+    ?assertEqual(false, proplists:get_value(prelude, Opts)).
 
 specs_override_dir_test() ->
     {ok, _Files, Opts} = gradualizer_cli:handle_args(["--specs-override-dir", "dir", "file.erl"]),


### PR DESCRIPTION
The PR #212 introduced the `-gradualizer()` attribute, which allows
setting options for gradualizer in a module. I would have expected
these directives to override options on the command line, which is the
behaviour in other compilers and in dialyzer. This patch makes sure
that the attributes override cli options properly.

This patch also changes slightly how some options are treated internally.