### PR TITLE
Change cli options to use underscores to match the erlang api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,31 +141,31 @@ cli-tests: bin/gradualizer
 	bin/gradualizer test/dir \
 	|perl -ne 'm%^test/dir/test_in_dir.erl:% or die "CLI 1 ($$_)"'
 	# 2. --no-print-file with directory
-	bin/gradualizer --no-print-file test/dir \
+	bin/gradualizer --no_print_file test/dir \
 	|perl -ne '/^The/ or die "CLI 2 ($$_)"'
 	# 3. --print-module with directory
-	bin/gradualizer --print-module test/dir \
+	bin/gradualizer --print_module test/dir \
 	|perl -ne '/^test_in_dir:/ or die "CLI 3 ($$_)"'
 	# 4. --print-basename with directory
-	bin/gradualizer --print-basename test/dir \
+	bin/gradualizer --print_basename test/dir \
 	|perl -ne '/^test_in_dir.erl:/ or die "CLI 4 ($$_)"'
 	# 5. Checking a single file; not printing filename is the default
 	bin/gradualizer test/dir/test_in_dir.erl \
 	|perl -ne '/^The/ or die "CLI 5 ($$_)"'
 	# 6. Brief formatting
-	bin/gradualizer --fmt-location brief --print-basename test/dir \
+	bin/gradualizer --fmt_location brief --print-basename test/dir \
 	|perl -ne '/^test_in_dir.erl:6:12: The variable N is ex/ or die "CLI 6 ($$_)"'
 	# 7. Verbose formatting, without filename
-	bin/gradualizer --fmt-location verbose --no-print-file test/dir \
+	bin/gradualizer --fmt_location verbose --no-print-file test/dir \
 	|perl -ne '/^The variable N on line 6 at column 12/ or die "CLI 7 ($$_)"'
 	# 8. No location, no filename
-	bin/gradualizer --fmt-location none --no-print-file test/dir/test_in_dir.erl \
+	bin/gradualizer --fmt_location none --no-print-file test/dir/test_in_dir.erl \
 	|perl -ne '/^The variable N is expected/ or die "CLI 8 ($$_)"'
 	# 9. Possible to exclude prelude (-0777 from https://stackoverflow.com/a/30594643/497116)
-	bin/gradualizer --no-prelude test/should_pass/cyclic_otp_specs.erl \
+	bin/gradualizer --no_prelude test/should_pass/cyclic_otp_specs.erl \
 	|perl -0777 -ne '/^The type spec/g or die "CLI 9 ($$_)"'
 	# 10. Excluding prelude and then including it is a no-op
-	bin/gradualizer --no-prelude --specs-override-dir priv/prelude \
+	bin/gradualizer --no_prelude --specs_override_dir priv/prelude \
 	  test/should_pass/cyclic_otp_specs.erl || (echo "CLI 10"; exit 1)
 
 .PHONY: cover

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -65,27 +65,27 @@ print_usage() ->
     io:format("  -h,  --help                    display this help and exit~n"),
     io:format("       --infer                   Infer type information from literals and other~n"),
     io:format("                                 language constructs~n"),
-    io:format("       --no-infer                Only use type information from function specs~n"),
+    io:format("       --no_infer                Only use type information from function specs~n"),
     io:format("                                  - the default behaviour~n"),
     io:format("       --verbose                 Show what Gradualizer is doing~n"),
-    io:format("  -pa, --path-add                Add the specified directory to the beginning of~n"),
+    io:format("  -pa, --path_add                Add the specified directory to the beginning of~n"),
     io:format("                                 the code path; see erl -pa             [string]~n"),
     io:format("  -I                             Include path for Erlang source files; see -I in~n"),
     io:format("                                 the manual page erlc(1)~n"),
-    io:format("       --print-file              prefix error printouts with the file name~n"),
+    io:format("       --print_file              prefix error printouts with the file name~n"),
     io:format("                                  - the default when checking a directory or more~n"),
     io:format("                                    than one file~n"),
-    io:format("       --print-basename          prefix error printouts with the file basename~n"),
-    io:format("       --print-module            prefix error printouts with the module~n"),
-    io:format("       --no-print-file           inverse of --print-file~n"),
+    io:format("       --print_basename          prefix error printouts with the file basename~n"),
+    io:format("       --print_module            prefix error printouts with the module~n"),
+    io:format("       --no_print_file           inverse of --print-file~n"),
     io:format("                                  - the default when checking a single file~n"),
-    io:format("       --stop-on-first-error     stop type checking at the first error~n"),
-    io:format("       --no-stop-on-first-error  inverse of --stop-on-first-error~n"),
+    io:format("       --stop_on_first_error     stop type checking at the first error~n"),
+    io:format("       --no_stop_on_first_error  inverse of --stop-on-first-error~n"),
     io:format("                                  - the default behaviour~n"),
-    io:format("       --no-prelude              Do not override OTP specs.~n"),
-    io:format("       --specs-override-dir      Add specs overrides from the *.specs.erl files in~n"),
+    io:format("       --no_prelude              Do not override OTP specs.~n"),
+    io:format("       --specs_override_dir      Add specs overrides from the *.specs.erl files in~n"),
     io:format("                                 this directory.~n"),
-    io:format("       --fmt-location            How to format location when pretty printing errors~n"),
+    io:format("       --fmt_location            How to format location when pretty printing errors~n"),
     io:format("                                 (Column is only available if analyzing from source)~n"),
     io:format("                                 - 'none': no location for easier comparison~n"),
     io:format("                                 - 'brief': for machine processing~n"),
@@ -102,23 +102,23 @@ parse_opts([A | Args], Opts) ->
         "-h"                       -> {[], [help]};
         "--help"                   -> {[], [help]};
         "--infer"                  -> parse_opts(Args, [infer | Opts]);
-        "--no-infer"               -> parse_opts(Args, [{infer, false} | Opts]);
+        "--no_infer"               -> parse_opts(Args, [{infer, false} | Opts]);
         "--verbose"                -> parse_opts(Args, [verbose | Opts]);
         "-pa"                      -> handle_path_add(A, Args, Opts);
-        "--path-add"               -> handle_path_add(A, Args, Opts);
+        "--path_add"               -> handle_path_add(A, Args, Opts);
         "-I"                       -> handle_include_path(A, Args, Opts);
-        "--print-file"             -> parse_opts(Args, [print_file | Opts]);
-        "--print-module"           -> parse_opts(Args, [{print_file, module} | Opts]);
-        "--print-basename"         -> parse_opts(Args, [{print_file, basename} | Opts]);
-        "--no-print-file"          -> parse_opts(Args, [{print_file, false} | Opts]);
-        "--stop-on-first-error"    -> parse_opts(Args, [stop_on_first_error | Opts]);
-        "--no-stop-on-first-error" -> parse_opts(Args, [{stop_on_first_error, false} | Opts]);
-        "--crash-on-error"         -> parse_opts(Args, [crash_on_error | Opts]);
-        "--no-crash-on-error"      -> parse_opts(Args, [{crash_on_error, false} | Opts]);
+        "--print_file"             -> parse_opts(Args, [print_file | Opts]);
+        "--print_module"           -> parse_opts(Args, [{print_file, module} | Opts]);
+        "--print_basename"         -> parse_opts(Args, [{print_file, basename} | Opts]);
+        "--no_print_file"          -> parse_opts(Args, [{print_file, false} | Opts]);
+        "--stop_on_first_error"    -> parse_opts(Args, [stop_on_first_error | Opts]);
+        "--no_stop_on_first_error" -> parse_opts(Args, [{stop_on_first_error, false} | Opts]);
+        "--crash_on_error"         -> parse_opts(Args, [crash_on_error | Opts]);
+        "--no_crash_on_error"      -> parse_opts(Args, [{crash_on_error, false} | Opts]);
         "--version"                -> {[], [version]};
-        "--no-prelude"             -> parse_opts(Args, [{prelude, false}| Opts]);
-        "--specs-override-dir"     -> handle_specs_override(A, Args, Opts);
-        "--fmt-location"           -> handle_fmt_location(Args, Opts);
+        "--no_prelude"             -> parse_opts(Args, [{prelude, false}| Opts]);
+        "--specs_override_dir"     -> handle_specs_override(A, Args, Opts);
+        "--fmt_location"           -> handle_fmt_location(Args, Opts);
         "--"                       -> {Args, Opts};
         "-" ++ _                   -> erlang:error(string:join(["Unknown parameter:", A], " "));
         _                          -> {[A | Args], Opts}

--- a/test/gradualizer_cli_tests.erl
+++ b/test/gradualizer_cli_tests.erl
@@ -34,7 +34,7 @@ infer_test() ->
     {ok, _Files, Opts} = gradualizer_cli:handle_args(["--infer", "--", "file.erl"]),
     ?assert(proplists:get_bool(infer, Opts)).
 no_infer_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no-infer", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no_infer", "file.erl"]),
     ?assertNot(proplists:get_bool(infer, Opts)).
 
 verbose_test() ->
@@ -59,61 +59,61 @@ pa_test_() ->
     %% Skipping the successful cases which have side-effects of calling
     %% code:add_pathsa/1 directly, e.g. ["-pa", "dir1", "dir2", "--", "file.erl"]
     [?_assertMatch({error, "No files"++_}, gradualizer_cli:handle_args(["-pa", "ebin"])),
-     ?_assertMatch({error, "No files"++_}, gradualizer_cli:handle_args(["--path-add", "ebin", "file.erl"])),
+     ?_assertMatch({error, "No files"++_}, gradualizer_cli:handle_args(["--path_add", "ebin", "file.erl"])),
      ?_assertMatch({error, "No files"++_}, gradualizer_cli:handle_args(["-pa", "ebin", "file.erl"])),
      ?_assertMatch({error, "Missing "++_}, gradualizer_cli:handle_args(["-pa", "--", "file.erl"]))].
 
 print_file_true_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--print-file", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--print_file", "file.erl"]),
     ?assertEqual(true, proplists:get_value(print_file, Opts)).
 print_file_module_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--print-module", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--print_module", "file.erl"]),
     ?assertEqual(module, proplists:get_value(print_file, Opts)).
 print_file_basename_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--print-basename", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--print_basename", "file.erl"]),
     ?assertEqual(basename, proplists:get_value(print_file, Opts)).
 print_file_false_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no-print-file", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no_print_file", "file.erl"]),
     ?assertEqual(false, proplists:get_value(print_file, Opts)).
 
 stop_on_first_error_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--stop-on-first-error", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--stop_on_first_error", "file.erl"]),
     ?assert(proplists:get_bool(stop_on_first_error, Opts)).
 no_stop_on_first_error_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no-stop-on-first-error", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no_stop_on_first_error", "file.erl"]),
     ?assertEqual(false, proplists:get_bool(stop_on_first_error, Opts)).
 crash_on_error_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--crash-on-error", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--crash_on_error", "file.erl"]),
     ?assertEqual(true, proplists:get_value(crash_on_error, Opts)).
 no_crash_on_error_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no-crash-on-error", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no_crash_on_error", "file.erl"]),
     ?assertEqual(false, proplists:get_value(crash_on_error, Opts)).
 
 fmt_location_brief_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--fmt-location", "brief", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--fmt_location", "brief", "file.erl"]),
     ?assertEqual(brief, proplists:get_value(fmt_location, Opts)).
 fmt_location_verbose_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--fmt-location", "verbose", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--fmt_location", "verbose", "file.erl"]),
     ?assertEqual(verbose, proplists:get_value(fmt_location, Opts)).
 fmt_location_none_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--fmt-location", "none", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--fmt_location", "none", "file.erl"]),
     ?assertEqual(none, proplists:get_value(fmt_location, Opts)).
 fmt_location_invalid1_test() ->
-    ?assertMatch({error, _}, gradualizer_cli:handle_args(["--fmt-location", "backwards", "file.erl"])).
+    ?assertMatch({error, _}, gradualizer_cli:handle_args(["--fmt_location", "backwards", "file.erl"])).
 fmt_location_invalid2_test() ->
-    ?assertMatch({error, _}, gradualizer_cli:handle_args(["--fmt-location", "normal", "file.erl"])).
+    ?assertMatch({error, _}, gradualizer_cli:handle_args(["--fmt_location", "normal", "file.erl"])).
 
 prelude_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no-prelude", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no_prelude", "file.erl"]),
     ?assertEqual(false, proplists:get_value(prelude, Opts)).
 
 specs_override_dir_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--specs-override-dir", "dir", "file.erl"]),
+    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--specs_override_dir", "dir", "file.erl"]),
     ?assertEqual("dir", proplists:get_value(specs_override, Opts)).
 specs_override_2_dirs_test() ->
     %% Accepts single arg; inconsistent with -pa and -I:
-    {ok, Files, Opts} = gradualizer_cli:handle_args(["--specs-override-dir", "d1", "d2", "--", "file.erl"]),
+    {ok, Files, Opts} = gradualizer_cli:handle_args(["--specs_override_dir", "d1", "d2", "--", "file.erl"]),
     ?assertEqual(["d1"], proplists:get_all_values(specs_override, Opts)),
     ?assertEqual(["d2", "--", "file.erl"], Files).
 specs_override_fail_test() ->
-    ?assertMatch({error, _}, gradualizer_cli:handle_args(["--specs-override-dir"])).
+    ?assertMatch({error, _}, gradualizer_cli:handle_args(["--specs_override_dir"])).


### PR DESCRIPTION
This patch implements the suggestion in #213 to harmonize the way
options are written. It used to be that we have e.g. `--no-infer` in
the command line but `no_infer` when calling gradualizer from the
api. Now we will use `--no_infer` on the command line.

This spelling of the options matches the convention of dialyzer.