### PR TITLE
Unify errors

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1912,7 +1912,7 @@ type_check_call_ty(Env, {fun_ty_union, Tyss, Cs}, Args, E) ->
     {ResTy, VarBinds, CsI} = type_check_call_ty_union(Env, Tyss, Args, E),
     {ResTy, VarBinds, constraints:combine(Cs, CsI)};
 type_check_call_ty(_Env, {type_error, _}, _Args, {Name, P, FunTy}) ->
-    throw({type_error, call, P, FunTy, Name}).
+    throw({type_error, Name, FunTy, type('fun')}).
 
 type_check_call_ty_intersect(_Env, [], _Args, {Name, P, FunTy}) ->
     throw({type_error, call_intersect, P, FunTy, Name});
@@ -4207,18 +4207,6 @@ handle_type_error({type_error, call_arity, Anno, Fun, TyArity, CallArity}, Opts)
                pp_expr(Fun, Opts),
                format_location(Anno, verbose, Opts),
                TyArity, ["s" || TyArity /= 1], CallArity]);
-handle_type_error({type_error, call, _Anno, Name, TyArgs, ArgTys}, Opts) ->
-    io:format("~sThe function ~p expects arguments of type~n~p~n but is given "
-              "arguments of type~n~p~n",
-              [format_location(_Anno, brief, Opts),
-               Name, TyArgs, ArgTys]);
-handle_type_error({type_error, call, Anno, Ty, Name}, Opts) ->
-    io:format("~sThe function ~s, called~s doesn't have a function type~n"
-             "Rather, it has the following type~n~s~n",
-              [format_location(Anno, brief, Opts),
-               pp_expr(Name, Opts),
-               format_location(Anno, verbose, Opts),
-               pp_type(Ty, Opts)]);
 handle_type_error({type_error, call_intersect, Anno, FunTy, Name}, Opts) ->
     io:format("~sThe type of the function ~s, called~s doesn't match "
               "the surrounding calling context.~n"

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1778,7 +1778,7 @@ type_check_logic_op(Env, Op, P, Arg1, Arg2) ->
     {Ty1, VB1, Cs1} = type_check_expr(Env, Arg1),
     case subtype(Ty1, {type, P, bool, []}, Env#env.tenv) of
         false ->
-            throw({type_error, boolop, Op, P, Ty1});
+            throw({type_error, Arg1, Ty1, type(boolean)});
         {true, Cs2} ->
             {Ty2, VB2, Cs3} = type_check_expr(Env#env{ venv = UnionVarBindsSecondArg(Env#env.venv,VB1 )}, Arg2),
             % Allow any() in second argument for shortcut operators
@@ -1786,7 +1786,7 @@ type_check_logic_op(Env, Op, P, Arg1, Arg2) ->
                           true                            -> type(bool) end,
             case subtype(Ty2, SndArgTy, Env#env.tenv) of
                 false ->
-                    throw({type_error, boolop, Op, P, Ty2});
+                    throw({type_error, Arg2, Ty2, type(boolean)});
                 {true, Cs4} ->
                     Inferred =
                         case Op of
@@ -4247,13 +4247,6 @@ handle_type_error({type_error, no_type_match_intersection, Anno, Func, FunTy}, O
                Name,
                format_location(Anno, verbose, Opts),
                pp_intersection_type(FunTy, Opts)]);
-handle_type_error({type_error, boolop, BoolOp, Anno, Ty}, Opts) ->
-    io:format("~sThe operator ~p~s is given a non-boolean argument "
-              "of type ~s~n",
-              [format_location(Anno, brief, Opts),
-               BoolOp,
-               format_location(Anno, verbose, Opts),
-               pp_type(Ty, Opts)]);
 handle_type_error({type_error, relop, RelOp, Anno, Ty1, Ty2}, Opts) ->
     io:format("~sThe operator ~p~s requires arguments of "
               "compatible types.~nHowever, it has arguments "

--- a/test/should_fail/logic_op.erl
+++ b/test/should_fail/logic_op.erl
@@ -1,8 +1,37 @@
 -module(logic_op).
--export([failand/1, failandalso/1]).
+-export([failand/1, failand2/1,
+         failandleft/2, failandleft2/2,
+         failandright/2, failandright2/2,
+         failandalso/1, failandalso2/1]).
 
 -spec failand(boolean()) -> tuple().
 failand(X) -> X and X.
 
+-spec failand2(boolean()) -> tuple().
+failand2(X) ->
+    O = X and X,
+    O.
+
+-spec failandleft(boolean(), integer()) -> boolean().
+failandleft(B, N) -> N and B.
+
+-spec failandleft2(boolean(), integer()) -> boolean().
+failandleft2(B, N) ->
+    O = N and B,
+    O.
+
+-spec failandright(boolean(), integer()) -> boolean().
+failandright(B, N) -> B and N.
+
+-spec failandright2(boolean(), integer()) -> boolean().
+failandright2(B, N) ->
+    O = B and N,
+    O.
+
 -spec failandalso(boolean()) -> tuple().
 failandalso(X) -> X andalso {}.
+
+-spec failandalso2(boolean()) -> tuple().
+failandalso2(X) ->
+    O = X andalso {},
+    O.

--- a/test/should_fail/named_fun.erl
+++ b/test/should_fail/named_fun.erl
@@ -1,8 +1,13 @@
 -module(named_fun).
 
--export([bar/0]).
+-export([bar/0, baz/1]).
 
 -spec foo(integer()) -> integer().
 foo(N) -> N.
 
 bar() -> foo(fun F(0) -> 0; F(X) -> F(X - 1) end).
+
+-spec baz(integer()) -> boolean().
+baz(I) ->
+    O = I({}),
+    O.


### PR DESCRIPTION
Old messages when checking `test/should_fail/logic_op.erl`
```
The expression X and X on line 8 at column 17 is expected to have type tuple() but it has type boolean()
The variable O on line 13 at column 5 is expected to have type tuple() but it has type false | true
The variable N on line 16 at column 22 is expected to have type boolean() but it has type integer()
The operator 'and' on line 20 at column 11 is given a non-boolean argument of type integer()
The variable N on line 24 at column 29 is expected to have type boolean() but it has type integer()
The operator 'and' on line 28 at column 11 is given a non-boolean argument of type integer()
The expression X
andalso
{} on line 32 at column 21 is expected to have type tuple() but it has type {} | false
The variable O on line 37 at column 5 is expected to have type tuple() but it has type false | false | true
```
New messages:
```
The expression X and X on line 8 at column 17 is expected to have type tuple() but it has type boolean()
The variable O on line 13 at column 5 is expected to have type tuple() but it has type false | true
The variable N on line 16 at column 22 is expected to have type boolean() but it has type integer()
The variable N on line 20 at column 9 is expected to have type boolean() but it has type integer()
The variable N on line 24 at column 29 is expected to have type boolean() but it has type integer()
The variable N on line 28 at column 15 is expected to have type boolean() but it has type integer()
The expression X
andalso
{} on line 32 at column 21 is expected to have type tuple() but it has type {} | false
The variable O on line 37 at column 5 is expected to have type tuple() but it has type false | false | true
```

Old messages when checking `test/should_fail/rel_op.erl`
```
The operator '>' on line 5 at column 14 is expected to have type tuple() which is not a supertype of boolean()
The operator '==' on line 8 at column 17 is given two arguments with non-compatible types:
a | b
b | c
```
New messages:
```
The expression X > X on line 5 at column 14 is expected to have type tuple() but it has type boolean()
The operator '==' on line 8 at column 17 is given two arguments with non-compatible types:
a | b
b | c
```

Old messages when checking `test/should_fail/shortcut_ops.erl`:
```
The operator 'andalso' on line 6 at column 39 is expected to have type number() which does not include 'false'
The variable N on line 9 at column 49 is expected to have type false but it has type integer() | float()
The operator 'orelse' on line 12 at column 40 is expected to have type number() which does not include 'true'
The variable N on line 15 at column 45 is expected to have type true but it has type integer() | float()
```
New messages:
```
The expression True
andalso
N on line 6 at column 39 is expected to have type number() but it has type integer() | float() | false
The variable N on line 9 at column 49 is expected to have type false but it has type integer() | float()
The expression False
orelse
N on line 12 at column 40 is expected to have type number() but it has type integer() | float() | true
The variable N on line 15 at column 45 is expected to have type true but it has type integer() | float()
```
Old messages when checking `test/should_fail/named_fun.erl`:
```
The named fun expression fun F(0) ->
        0;
    F(X) ->
        F(X - 1)
end on line 8 at column 14 is expected to have type integer() but it has type fun()
The function I, called on line 12 at column 9 doesn't have a function type
Rather, it has the following type
integer()
```
New messages:
```
The named fun expression fun F(0) ->
        0;
    F(X) ->
        F(X - 1)
end on line 8 at column 14 is expected to have type integer() but it has type fun()
The variable I on line 12 at column 9 is expected to have type fun() but it has type integer()
```
