### PR TITLE
Evade the erlc compile bug

### DIFF
--- a/test/known_problems/should_pass/annotated_types_problems.erl
+++ b/test/known_problems/should_pass/annotated_types_problems.erl
@@ -5,5 +5,5 @@
 -record(r, {}).
 -type r() :: #r{}.
 
--spec named_record_arg(R :: r()) -> {ok, R}.
-named_record_arg(#r{} = R) -> {ok, R}.
+-spec named_record_arg(R :: r()) -> ok.
+named_record_arg(#r{} = R) -> ok.


### PR DESCRIPTION
It turns out the previous PR for #224 triggered an `erlc` bug. This one fixes the test to sidestep that. Interesting that [the `erlc` issue is at least 3 years old](http://erlang.org/pipermail/erlang-questions/2016-October/090668.html).

@NelsonVides, thanks for catching that!

`erlc` can't compile the spec:

    -spec named_record_arg(R :: r()) -> {ok, R}.

and reports the following error:

    annotated_types_problems.erl:8: type variable 'R' is only used once (is unbound)

Let's sidestep this issue for this gradualizer test.