### PR TITLE
Add a test for a known crash on map update

### DIFF
--- a/test/known_problems/should_pass/update_map_type_error.erl
+++ b/test/known_problems/should_pass/update_map_type_error.erl
@@ -1,0 +1,15 @@
+-module(update_map_type_error).
+
+-compile(export_all).
+
+-spec t(list()) -> map().
+t(Rows) ->
+    lists:foldl(fun({Id, Name, Member}, #{members := []} = List) ->
+                        List#{id := Id,
+                              name := Name,
+                              members := [binary_to_list(Member)]};
+                   ({_, _, Member}, #{members := Members} = List) ->
+                        List#{members := [binary_to_list(Member) | Members]}
+                end, #{id => undefined,
+                       name => undefined,
+                       members => []}, Rows).


### PR DESCRIPTION
We've just found a bug:

```
$ gradualizer update_map_type_error.erl
escript: exception error: no function clause matching
                 typechecker:update_map_type({var,25,'Acc'},
                                             [{type,
                                               {8,31},
                                               map_field_exact,
                                               [{atom,{8,31},id},
                                                {var,0,
                                                 "_TyVar-576460752303423485"}]},
                                              {type,
                                               {9,31},
                                               map_field_exact,
                                               [{atom,{9,31},name},
                                                {var,0,
                                                 "_TyVar-576460752303423453"}]},
                                              {type,
                                               {10,31},
                                               map_field_exact,
                                               [{atom,{10,31},members},
                                                {type,0,nonempty_list,
                                                 [{type,406,list,
                                                   [{type,406,byte,[]}]}]}]}]) (src/typechecker.erl, line 2866)
  in function  typechecker:do_type_check_expr_in/3 (src/typechecker.erl, line 2202)
  in call from typechecker:type_check_expr_in/3 (src/typechecker.erl, line 2076)
  in call from typechecker:check_clause/4 (src/typechecker.erl, line 3242)
  in call from typechecker:'-check_clauses/4-fun-0-'/4 (src/typechecker.erl, line 3204)
  in call from lists:foldl/3 (lists.erl, line 1263)
  in call from typechecker:check_clauses/4 (src/typechecker.erl, line 3202)
  in call from typechecker:do_type_check_expr_in/3 (src/typechecker.erl, line 2326)
```