### PR TITLE
Add failing map_update_with_record_field test which should pass

### DIFF
--- a/test/known_problems/should_pass/map_update_with_record_field.erl
+++ b/test/known_problems/should_pass/map_update_with_record_field.erl
@@ -1,0 +1,16 @@
+-module(map_update_with_record_field).
+
+-export([mapup3/2]).
+
+%% When record `r' is defined or included and used directly in the map type definition,
+%% then `mapup3' passes typechecking.
+%-record(r, {}).
+%-type m() :: #{rec := #r{}}.
+
+%% However, when the actual remote type and corresponding remote record is used,
+%% then `mapup3' fails to typecheck, although it still should.
+-type m() :: #{rec := user_types:my_empty_record()}.
+
+-spec mapup3(m(), user_types:my_empty_record()) -> m().
+mapup3(TypedMap, R) ->
+    TypedMap#{rec => R}.

--- a/test/should_pass/user_types.erl
+++ b/test/should_pass/user_types.erl
@@ -3,8 +3,10 @@
 -export([f/1]).
 
 %% these exported types are used in remote_types module
--export_type([my_tuple/0, my_list/0, my_union/0, my_opaque/0]).
+-export_type([my_tuple/0, my_list/0, my_union/0, my_opaque/0, my_empty_record/0]).
 
+-record(r, {}).
+-type my_empty_record() :: #r{}.
 -type my_atom() :: atom().
 -type my_tuple() :: {my_atom(), integer()}.
 -type my_list() :: list(my_atom()).


### PR DESCRIPTION
I've found this when working on real prod code. A map update using a remote type defined as a record fails unless we use the actual record in the map type field definition.
It seems to me the definitions are equivalent, so the test should pass.