### PR TITLE
Guard support

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3441,33 +3441,28 @@ no_guards({clause, _, _, Guards, _}) ->
     Guards == [].
 
 
--spec check_guard_bif(erlang:anno(), atom(), list()) -> map().
-check_guard_bif(P, is_atom, [{var, _, Var}]) -> #{Var => {type, P, atom, []}};
-check_guard_bif(P, is_binary, [{var, _, Var}]) -> #{Var => {type, P, binary, []}};
-check_guard_bif(P, is_bitstring, [{var, _, Var}]) -> #{Var => {type, P, bitstring, []}};
-check_guard_bif(P, is_boolean, [{var, _, Var}]) -> #{Var => {type, P, boolean, []}};
-check_guard_bif(P, is_float, [{var, _, Var}]) -> #{Var => {type, P, float, []}};
-check_guard_bif(P, is_integer, [{var, _, Var}]) -> #{Var => {type, P, integer, []}};
-check_guard_bif(P, is_number, [{var, _, Var}]) -> #{Var => {type, P, number, []}};
-check_guard_bif(P, is_list, [{var, _, Var}]) -> #{Var => {type, P, list, []}};
-check_guard_bif(P, is_map, [{var, _, Var}]) -> #{Var => {type, P, map, []}};
-check_guard_bif(P, is_pid, [{var, _, Var}]) -> #{Var => {type, P, pid, []}};
-check_guard_bif(P, is_port, [{var, _, Var}]) -> #{Var => {type, P, port, []}};
-check_guard_bif(P, is_reference, [{var, _, Var}]) -> #{Var => {type, P, reference, []}};
-check_guard_bif(P, is_tuple, [{var, _, Var}]) -> #{Var => {type, P, tuple, []}};
-check_guard_bif(P, is_function, [{var, _, Var}]) -> #{Var => {type, P, 'fun', []}};
-check_guard_bif(P, is_record, [{var, _, Var}, {atom, _, Record}]) ->
-    #{Var => {type, P, record, [{atom, P, Record}]}};
-check_guard_bif(_P, _Fun, _Vars) ->
-    #{}.
-
 -spec check_guard_call(erlang:anno(), atom(), list()) -> map().
-check_guard_call(P, Name, Args) ->
-    Arity = length(Args),
-    case erl_internal:bif(Name, Arity) of
-        true -> check_guard_bif(P, Name, Args);
-        false -> #{}
-    end.
+check_guard_call(P, is_atom, [{var, _, Var}]) -> #{Var => {type, P, atom, []}};
+check_guard_call(P, is_binary, [{var, _, Var}]) -> #{Var => {type, P, binary, []}};
+check_guard_call(P, is_bitstring, [{var, _, Var}]) -> #{Var => {type, P, bitstring, []}};
+check_guard_call(P, is_boolean, [{var, _, Var}]) -> #{Var => {type, P, boolean, []}};
+check_guard_call(P, is_float, [{var, _, Var}]) -> #{Var => {type, P, float, []}};
+check_guard_call(P, is_function, [{var, _, Var}]) -> #{Var => {type, P, 'fun', []}};
+check_guard_call(P, is_function, [{var, _, Var}, _]) -> #{Var => {type, P, 'fun', []}};
+check_guard_call(P, is_integer, [{var, _, Var}]) -> #{Var => {type, P, integer, []}};
+check_guard_call(P, is_list, [{var, _, Var}]) -> #{Var => {type, P, list, []}};
+check_guard_call(P, is_map, [{var, _, Var}]) -> #{Var => {type, P, map, []}};
+check_guard_call(P, is_number, [{var, _, Var}]) -> #{Var => {type, P, number, []}};
+check_guard_call(P, is_pid, [{var, _, Var}]) -> #{Var => {type, P, pid, []}};
+check_guard_call(P, is_port, [{var, _, Var}]) -> #{Var => {type, P, port, []}};
+check_guard_call(P, is_record, [{var, _, Var}, {atom, _, Record}]) ->
+    #{Var => {type, P, record, [{atom, P, Record}]}};
+check_guard_call(P, is_record, [{var, _, Var}, {atom, _, Record}, _]) ->
+    #{Var => {type, P, record, [{atom, P, Record}]}};
+check_guard_call(P, is_reference, [{var, _, Var}]) -> #{Var => {type, P, reference, []}};
+check_guard_call(P, is_tuple, [{var, _, Var}]) -> #{Var => {type, P, tuple, []}};
+check_guard_call(_P, _Fun, _Vars) ->
+    #{}.
 
 -spec check_guard(#env{}, term()) -> map().
 check_guard(_Env, {call, P, {atom, _, Fun}, Vars}) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3442,27 +3442,24 @@ no_guards({clause, _, _, Guards, _}) ->
 
 
 -spec check_guard_call(atom(), list()) -> map().
-check_guard_call(is_atom, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), atom, []}};
-check_guard_call(is_binary, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), binary, []}};
-check_guard_call(is_bitstring, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), bitstring, []}};
-check_guard_call(is_boolean, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), boolean, []}};
-check_guard_call(is_float, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), float, []}};
-check_guard_call(is_function, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), 'fun', []}};
-check_guard_call(is_function, [{var, _, Var}, _]) -> #{Var => {type, erl_anno:new(0), 'fun', []}};
-check_guard_call(is_integer, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), integer, []}};
-check_guard_call(is_list, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), list, []}};
-check_guard_call(is_map, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), map, []}};
-check_guard_call(is_number, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), number, []}};
-check_guard_call(is_pid, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), pid, []}};
-check_guard_call(is_port, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), port, []}};
-check_guard_call(is_record, [{var, _, Var}, {atom, _, Record}]) ->
-    #{Var => {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Record}]}};
-check_guard_call(is_record, [{var, _, Var}, {atom, _, Record}, _]) ->
-    #{Var => {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Record}]}};
-check_guard_call(is_reference, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), reference, []}};
-check_guard_call(is_tuple, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), tuple, []}};
-check_guard_call(_Fun, _Vars) ->
-    #{}.
+check_guard_call(is_atom, [{var, _, Var}]) -> #{Var => type(atom)};
+check_guard_call(is_binary, [{var, _, Var}]) -> #{Var => type(binary)};
+check_guard_call(is_bitstring, [{var, _, Var}]) -> #{Var => type(bitstring)};
+check_guard_call(is_boolean, [{var, _, Var}]) -> #{Var => type(boolean)};
+check_guard_call(is_float, [{var, _, Var}]) -> #{Var => type(float)};
+check_guard_call(is_function, [{var, _, Var}]) -> #{Var => type('fun')};
+check_guard_call(is_function, [{var, _, Var}, _]) -> #{Var => type('fun')};
+check_guard_call(is_integer, [{var, _, Var}]) -> #{Var => type(integer)};
+check_guard_call(is_list, [{var, _, Var}]) -> #{Var => type(list)};
+check_guard_call(is_map, [{var, _, Var}]) -> #{Var => type(map)};
+check_guard_call(is_number, [{var, _, Var}]) -> #{Var => type(number)};
+check_guard_call(is_pid, [{var, _, Var}]) -> #{Var => type(pid)};
+check_guard_call(is_port, [{var, _, Var}]) -> #{Var => type(port)};
+check_guard_call(is_record, [{var, _, Var}, {atom, _, Record}]) -> #{Var => type_record(Record)};
+check_guard_call(is_record, [{var, _, Var}, {atom, _, Record}, _]) -> #{Var => type_record(Record)};
+check_guard_call(is_reference, [{var, _, Var}]) -> #{Var => type(reference)};
+check_guard_call(is_tuple, [{var, _, Var}]) -> #{Var => type(tuple)};
+check_guard_call(_Fun, _Vars) -> #{}.
 
 -spec check_guard(#env{}, term()) -> map().
 check_guard(_Env, {call, _, {atom, _, Fun}, Vars}) ->
@@ -3988,6 +3985,9 @@ top() ->
 
 type_var(Name) ->
     {var, erl_anno:new(0), Name}.
+
+type_record(Name) ->
+    {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Name}]}.
 
 return(X) ->
     { X, #{}, constraints:empty() }.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3448,7 +3448,7 @@ check_guard_call(is_bitstring, [{var, _, Var}]) -> #{Var => type(bitstring)};
 check_guard_call(is_boolean, [{var, _, Var}]) -> #{Var => type(boolean)};
 check_guard_call(is_float, [{var, _, Var}]) -> #{Var => type(float)};
 check_guard_call(is_function, [{var, _, Var}]) -> #{Var => type('fun')};
-check_guard_call(is_function, [{var, _, Var}, _]) -> #{Var => type('fun')};
+check_guard_call(is_function, [{var, _, Var}, {integer, _, Arity}]) -> #{Var => type_fun(Arity)};
 check_guard_call(is_integer, [{var, _, Var}]) -> #{Var => type(integer)};
 check_guard_call(is_list, [{var, _, Var}]) -> #{Var => type(list)};
 check_guard_call(is_map, [{var, _, Var}]) -> #{Var => type(map)};
@@ -3986,6 +3986,12 @@ type_var(Name) ->
 
 type_record(Name) ->
     {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Name}]}.
+
+type_fun(0) ->
+    {type, erl_anno:new(0), 'fun', [{type, erl_anno:new(0), product, []}, {type, erl_anno:new(0), any, []}]};
+type_fun(Arity) ->
+    Args = [{type, erl_anno:new(0), any, []} || _ <- lists:seq(1, Arity)],
+    {type, erl_anno:new(0), 'fun', [{type, erl_anno:new(0), product, Args}, {type, erl_anno:new(0), any, []}]}.
 
 return(X) ->
     { X, #{}, constraints:empty() }.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3483,6 +3483,10 @@ check_guard(Env, {op, _OrElseAnno, 'orelse', Call1, Call2}) ->
         NTy
     end,
     union_var_binds_help([G1, G2], Lub);
+check_guard(Env, {op, _AndAlsoAnno, 'andalso', Call1, Call2}) ->
+    G1 = check_guard(Env, Call1),
+    G2 = check_guard(Env, Call2),
+    union_var_binds([G1, G2], Env#env.tenv);
 check_guard(Env, Guard) ->
     {_Ty, VB, _Cs} = type_check_expr(Env, Guard), % Do we need to thread the Env?
     VB.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3464,21 +3464,13 @@ check_guard_call(_Fun, _Vars) -> #{}.
 -spec check_guard(#env{}, term()) -> map().
 check_guard(_Env, {call, _, {atom, _, Fun}, Vars}) ->
     check_guard_call(Fun, Vars);
-check_guard(_Env, {call, _, {remote,_,_,{atom, _, Fun}}, Vars}) ->
+check_guard(_Env, {call, _, {remote,_, {atom, _, erlang},{atom, _, Fun}}, Vars}) ->
     check_guard_call(Fun, Vars);
-check_guard(Env, {op, _OrElseAnno, 'orelse', Call1, Call2}) ->
+check_guard(Env, {op, _OrElseAnno, Op, Call1, Call2}) when Op == 'orelse'; Op == 'or' ->
     G1 = check_guard(Env, Call1),
     G2 = check_guard(Env, Call2),
     union_var_binds_symmetrical([G1, G2], Env#env.tenv);
-check_guard(Env, {op, _OrAnno, 'or', Call1, Call2}) ->
-    G1 = check_guard(Env, Call1),
-    G2 = check_guard(Env, Call2),
-    union_var_binds_symmetrical([G1, G2], Env#env.tenv);
-check_guard(Env, {op, _AndAlsoAnno, 'andalso', Call1, Call2}) ->
-    G1 = check_guard(Env, Call1),
-    G2 = check_guard(Env, Call2),
-    union_var_binds([G1, G2], Env#env.tenv);
-check_guard(Env, {op, _AndAnno, 'and', Call1, Call2}) ->
+check_guard(Env, {op, _AndAlsoAnno, Op, Call1, Call2}) when Op == 'andalso'; Op == 'and' ->
     G1 = check_guard(Env, Call1),
     G2 = check_guard(Env, Call2),
     union_var_binds([G1, G2], Env#env.tenv);

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3486,7 +3486,7 @@ check_guard(Env, Guard) ->
     {_Ty, VB, _Cs} = type_check_expr(Env, Guard), % Do we need to thread the Env?
     VB.
 
-%% The difference guards use glb
+%% The different guards use glb
 -spec check_guards_sequence(#env{}, list()) -> map().
 check_guards_sequence(Env, GuardSeq) ->
     RefTys = union_var_binds(

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3492,11 +3492,11 @@ check_guards_sequence(Env, GuardSeq) ->
 -spec check_guards(#env{}, list()) -> map().
 check_guards(Env, []) -> #{};
 check_guards(Env, Guards) ->
-    Tys = lists:map(fun (GuardSeq) ->
+    VarBinds = lists:map(fun (GuardSeq) ->
         check_guards_sequence(Env, GuardSeq)
     end, Guards),
-    Ty = union_var_binds_lub(Tys, Env#env.tenv),
-    Ty.
+    VB = union_var_binds_lub(VarBinds, Env#env.tenv),
+    VB.
 
 type_check_function(Env, {function,_, Name, NArgs, Clauses}) ->
     ?verbose(Env, "Checking function ~p/~p~n", [Name, NArgs]),

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3474,6 +3474,8 @@ check_guard(_Env, {call, P, {atom, _, Fun}, Vars}) ->
     check_guard_call(P, Fun, Vars);
 check_guard(_Env, {call, P, {remote,_,_,{atom, _, Fun}}, Vars}) ->
     check_guard_call(P, Fun, Vars);
+check_guard(Env, {op, _OrElseAnno, 'orelse', Call1, Call2}) ->
+    union_var_binds([check_guard(Env, Call1), check_guard(Env, Call2)], Env#env.tenv);
 check_guard(Env, Guard) ->
     {_Ty, VB, _Cs} = type_check_expr(Env, Guard), % Do we need to thread the Env?
     VB.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3979,8 +3979,6 @@ type_var(Name) ->
 type_record(Name) ->
     {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Name}]}.
 
-type_fun(0) ->
-    {type, erl_anno:new(0), 'fun', [{type, erl_anno:new(0), product, []}, {type, erl_anno:new(0), any, []}]};
 type_fun(Arity) ->
     Args = [{type, erl_anno:new(0), any, []} || _ <- lists:seq(1, Arity)],
     {type, erl_anno:new(0), 'fun', [{type, erl_anno:new(0), product, Args}, {type, erl_anno:new(0), any, []}]}.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3470,7 +3470,15 @@ check_guard(Env, {op, _OrElseAnno, 'orelse', Call1, Call2}) ->
     G1 = check_guard(Env, Call1),
     G2 = check_guard(Env, Call2),
     union_var_binds_symmetrical([G1, G2], Env#env.tenv);
+check_guard(Env, {op, _OrAnno, 'or', Call1, Call2}) ->
+    G1 = check_guard(Env, Call1),
+    G2 = check_guard(Env, Call2),
+    union_var_binds_symmetrical([G1, G2], Env#env.tenv);
 check_guard(Env, {op, _AndAlsoAnno, 'andalso', Call1, Call2}) ->
+    G1 = check_guard(Env, Call1),
+    G2 = check_guard(Env, Call2),
+    union_var_binds([G1, G2], Env#env.tenv);
+check_guard(Env, {op, _AndAnno, 'and', Call1, Call2}) ->
     G1 = check_guard(Env, Call1),
     G2 = check_guard(Env, Call2),
     union_var_binds([G1, G2], Env#env.tenv);

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3441,34 +3441,34 @@ no_guards({clause, _, _, Guards, _}) ->
     Guards == [].
 
 
--spec check_guard_call(erlang:anno(), atom(), list()) -> map().
-check_guard_call(P, is_atom, [{var, _, Var}]) -> #{Var => {type, P, atom, []}};
-check_guard_call(P, is_binary, [{var, _, Var}]) -> #{Var => {type, P, binary, []}};
-check_guard_call(P, is_bitstring, [{var, _, Var}]) -> #{Var => {type, P, bitstring, []}};
-check_guard_call(P, is_boolean, [{var, _, Var}]) -> #{Var => {type, P, boolean, []}};
-check_guard_call(P, is_float, [{var, _, Var}]) -> #{Var => {type, P, float, []}};
-check_guard_call(P, is_function, [{var, _, Var}]) -> #{Var => {type, P, 'fun', []}};
-check_guard_call(P, is_function, [{var, _, Var}, _]) -> #{Var => {type, P, 'fun', []}};
-check_guard_call(P, is_integer, [{var, _, Var}]) -> #{Var => {type, P, integer, []}};
-check_guard_call(P, is_list, [{var, _, Var}]) -> #{Var => {type, P, list, []}};
-check_guard_call(P, is_map, [{var, _, Var}]) -> #{Var => {type, P, map, []}};
-check_guard_call(P, is_number, [{var, _, Var}]) -> #{Var => {type, P, number, []}};
-check_guard_call(P, is_pid, [{var, _, Var}]) -> #{Var => {type, P, pid, []}};
-check_guard_call(P, is_port, [{var, _, Var}]) -> #{Var => {type, P, port, []}};
-check_guard_call(P, is_record, [{var, _, Var}, {atom, _, Record}]) ->
-    #{Var => {type, P, record, [{atom, P, Record}]}};
-check_guard_call(P, is_record, [{var, _, Var}, {atom, _, Record}, _]) ->
-    #{Var => {type, P, record, [{atom, P, Record}]}};
-check_guard_call(P, is_reference, [{var, _, Var}]) -> #{Var => {type, P, reference, []}};
-check_guard_call(P, is_tuple, [{var, _, Var}]) -> #{Var => {type, P, tuple, []}};
-check_guard_call(_P, _Fun, _Vars) ->
+-spec check_guard_call(atom(), list()) -> map().
+check_guard_call(is_atom, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), atom, []}};
+check_guard_call(is_binary, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), binary, []}};
+check_guard_call(is_bitstring, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), bitstring, []}};
+check_guard_call(is_boolean, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), boolean, []}};
+check_guard_call(is_float, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), float, []}};
+check_guard_call(is_function, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), 'fun', []}};
+check_guard_call(is_function, [{var, _, Var}, _]) -> #{Var => {type, erl_anno:new(0), 'fun', []}};
+check_guard_call(is_integer, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), integer, []}};
+check_guard_call(is_list, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), list, []}};
+check_guard_call(is_map, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), map, []}};
+check_guard_call(is_number, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), number, []}};
+check_guard_call(is_pid, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), pid, []}};
+check_guard_call(is_port, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), port, []}};
+check_guard_call(is_record, [{var, _, Var}, {atom, _, Record}]) ->
+    #{Var => {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Record}]}};
+check_guard_call(is_record, [{var, _, Var}, {atom, _, Record}, _]) ->
+    #{Var => {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Record}]}};
+check_guard_call(is_reference, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), reference, []}};
+check_guard_call(is_tuple, [{var, _, Var}]) -> #{Var => {type, erl_anno:new(0), tuple, []}};
+check_guard_call(_Fun, _Vars) ->
     #{}.
 
 -spec check_guard(#env{}, term()) -> map().
-check_guard(_Env, {call, P, {atom, _, Fun}, Vars}) ->
-    check_guard_call(P, Fun, Vars);
-check_guard(_Env, {call, P, {remote,_,_,{atom, _, Fun}}, Vars}) ->
-    check_guard_call(P, Fun, Vars);
+check_guard(_Env, {call, _, {atom, _, Fun}, Vars}) ->
+    check_guard_call(Fun, Vars);
+check_guard(_Env, {call, _, {remote,_,_,{atom, _, Fun}}, Vars}) ->
+    check_guard_call(Fun, Vars);
 check_guard(Env, {op, _OrElseAnno, 'orelse', Call1, Call2}) ->
     G1 = check_guard(Env, Call1),
     G2 = check_guard(Env, Call2),

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -104,10 +104,6 @@ remove_pos({type, _, 'fun', [{type, _, any}, RetTy]}) ->
     %% the only place where `{type, _, any}` can occure
     {type, erl_anno:new(0), 'fun', [{type, erl_anno:new(0), any}
                                    ,remove_pos(RetTy)]};
-remove_pos({type, _, 'fun', [{type, _, product, Args}, RetTy]}) ->
-    {type, erl_anno:new(0), 'fun', [
-        {type, erl_anno:new(0), product, [remove_pos(Arg) || Arg <- Args]}
-        , remove_pos(RetTy)]};
 remove_pos({type, _, Type, Params}) when is_list(Params) ->
     {type, erl_anno:new(0), Type, lists:map(fun remove_pos/1, Params)};
 remove_pos({type, _, Type, any}) when Type == tuple; Type == map ->

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -104,6 +104,10 @@ remove_pos({type, _, 'fun', [{type, _, any}, RetTy]}) ->
     %% the only place where `{type, _, any}` can occure
     {type, erl_anno:new(0), 'fun', [{type, erl_anno:new(0), any}
                                    ,remove_pos(RetTy)]};
+remove_pos({type, _, 'fun', [{type, _, product, Args}, RetTy]}) ->
+    {type, erl_anno:new(0), 'fun', [
+        {type, erl_anno:new(0), product, [remove_pos(Arg) || Arg <- Args]}
+        , remove_pos(RetTy)]};
 remove_pos({type, _, Type, Params}) when is_list(Params) ->
     {type, erl_anno:new(0), Type, lists:map(fun remove_pos/1, Params)};
 remove_pos({type, _, Type, any}) when Type == tuple; Type == map ->

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -91,8 +91,8 @@ remove_pos({Type, _, Value})
 remove_pos({user_type, Anno, Name, Params}) when is_list(Params) ->
     {user_type, anno_keep_only_filename(Anno), Name,
      lists:map(fun remove_pos/1, Params)};
-remove_pos({type, Anno, record, Params = [_Name]}) ->
-    {type, anno_keep_only_filename(Anno), record, Params};
+remove_pos({type, Anno, record, Params = [{atom, AtomAnno, Name}]}) ->
+    {type, anno_keep_only_filename(Anno), record, [{atom, anno_keep_only_filename(AtomAnno), Name}]};
 remove_pos({type, _, bounded_fun, [FT, Cs]}) ->
     {type, erl_anno:new(0), bounded_fun, [remove_pos(FT)
                                          ,lists:map(fun remove_pos/1, Cs)]};

--- a/test/known_problems/should_fail/guard_fail.erl
+++ b/test/known_problems/should_fail/guard_fail.erl
@@ -1,0 +1,7 @@
+-module(guard_fail).
+
+-compile(export_all).
+
+-spec wrong_arity(fun((any()) -> any()) | other) -> fun((any()) -> any()) | not_function.
+wrong_arity(F) when is_function(F, 2) -> F;
+wrong_arity(_) -> not_function.

--- a/test/should_fail/guard_fail.erl
+++ b/test/should_fail/guard_fail.erl
@@ -1,0 +1,30 @@
+-module(guard_fail).
+
+-compile(export_all).
+
+-spec wrong_guard(term()) -> atom() | not_atom.
+wrong_guard(A) when is_integer(A) -> A;
+wrong_guard(_) -> not_atom.
+
+-record(r1, {
+    f
+}).
+
+-record(r2, {
+    f
+}).
+
+-spec wrong_record(term()) -> #r2{} | not_r.
+wrong_record(R) when is_record(R, r1) -> R;
+wrong_record(_) -> not_r.
+
+-spec wrong_union(term()) -> integer() | float() | not_number.
+wrong_union(I) when is_integer(I) -> I;
+wrong_union(F) when is_atom(F) -> F;
+wrong_union(_) -> not_number.
+
+-spec wrong_union2(term()) -> integer() | float() | not_number.
+wrong_union2(N) when is_integer(N) orelse is_atom(N) -> N;
+wrong_union2(_) -> not_number.
+
+

--- a/test/should_fail/guard_fail.erl
+++ b/test/should_fail/guard_fail.erl
@@ -26,3 +26,8 @@ wrong_union(_) -> not_number.
 -spec wrong_union2(integer() | float() | atom()) -> integer() | float() | not_number.
 wrong_union2(N) when is_integer(N) orelse is_atom(N) -> N;
 wrong_union2(_) -> not_number.
+
+-spec wrong_orelse(integer() | atom(), integer() | atom()) -> integer().
+wrong_orelse(X, Y) when is_integer(X) orelse is_integer(Y) -> X + Y;
+wrong_orelse(_, _) -> 42.
+

--- a/test/should_fail/guard_fail.erl
+++ b/test/should_fail/guard_fail.erl
@@ -27,4 +27,6 @@ wrong_union(_) -> not_number.
 wrong_union2(N) when is_integer(N) orelse is_atom(N) -> N;
 wrong_union2(_) -> not_number.
 
-
+-spec wrong_andalso(term()) -> number() | not_integer.
+wrong_andalso(N) when is_integer(N) andalso is_number(N) -> N;
+wrong_andalso(_) -> not_integer.

--- a/test/should_fail/guard_fail.erl
+++ b/test/should_fail/guard_fail.erl
@@ -2,7 +2,7 @@
 
 -compile(export_all).
 
--spec wrong_guard(gradualizer:top()) -> atom() | not_atom.
+-spec wrong_guard(integer() | atom()) -> atom() | not_atom.
 wrong_guard(A) when is_integer(A) -> A;
 wrong_guard(_) -> not_atom.
 
@@ -14,19 +14,19 @@ wrong_guard(_) -> not_atom.
     f
 }).
 
--spec wrong_record(gradualizer:top()) -> #r2{} | not_r.
+-spec wrong_record(#r1{} | #r2{}) -> #r2{} | not_r2.
 wrong_record(R) when is_record(R, r1) -> R;
-wrong_record(_) -> not_r.
+wrong_record(_) -> not_r2.
 
--spec wrong_union(gradualizer:top()) -> integer() | float() | not_number.
+-spec wrong_union(integer() | float() | atom()) -> integer() | float() | not_number.
 wrong_union(I) when is_integer(I) -> I;
 wrong_union(F) when is_atom(F) -> F;
 wrong_union(_) -> not_number.
 
--spec wrong_union2(gradualizer:top()) -> integer() | float() | not_number.
+-spec wrong_union2(integer() | float() | atom()) -> integer() | float() | not_number.
 wrong_union2(N) when is_integer(N) orelse is_atom(N) -> N;
 wrong_union2(_) -> not_number.
 
--spec wrong_andalso(gradualizer:top()) -> atom() | not_integer.
+-spec wrong_andalso(integer() | atom()) -> atom() | not_integer.
 wrong_andalso(N) when is_integer(N) andalso is_atom(N) -> N;
 wrong_andalso(_) -> not_integer.

--- a/test/should_fail/guard_fail.erl
+++ b/test/should_fail/guard_fail.erl
@@ -26,7 +26,3 @@ wrong_union(_) -> not_number.
 -spec wrong_union2(integer() | float() | atom()) -> integer() | float() | not_number.
 wrong_union2(N) when is_integer(N) orelse is_atom(N) -> N;
 wrong_union2(_) -> not_number.
-
--spec wrong_andalso(integer() | atom()) -> atom() | not_integer.
-wrong_andalso(N) when is_integer(N) andalso is_atom(N) -> N;
-wrong_andalso(_) -> not_integer.

--- a/test/should_fail/guard_fail.erl
+++ b/test/should_fail/guard_fail.erl
@@ -2,7 +2,7 @@
 
 -compile(export_all).
 
--spec wrong_guard(term()) -> atom() | not_atom.
+-spec wrong_guard(gradualizer:top()) -> atom() | not_atom.
 wrong_guard(A) when is_integer(A) -> A;
 wrong_guard(_) -> not_atom.
 
@@ -14,19 +14,19 @@ wrong_guard(_) -> not_atom.
     f
 }).
 
--spec wrong_record(term()) -> #r2{} | not_r.
+-spec wrong_record(gradualizer:top()) -> #r2{} | not_r.
 wrong_record(R) when is_record(R, r1) -> R;
 wrong_record(_) -> not_r.
 
--spec wrong_union(term()) -> integer() | float() | not_number.
+-spec wrong_union(gradualizer:top()) -> integer() | float() | not_number.
 wrong_union(I) when is_integer(I) -> I;
 wrong_union(F) when is_atom(F) -> F;
 wrong_union(_) -> not_number.
 
--spec wrong_union2(term()) -> integer() | float() | not_number.
+-spec wrong_union2(gradualizer:top()) -> integer() | float() | not_number.
 wrong_union2(N) when is_integer(N) orelse is_atom(N) -> N;
 wrong_union2(_) -> not_number.
 
--spec wrong_andalso(term()) -> number() | not_integer.
-wrong_andalso(N) when is_integer(N) andalso is_number(N) -> N;
+-spec wrong_andalso(gradualizer:top()) -> atom() | not_integer.
+wrong_andalso(N) when is_integer(N) andalso is_atom(N) -> N;
 wrong_andalso(_) -> not_integer.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -64,3 +64,8 @@ function(_) -> not_function.
 -spec record(term()) -> #r{} | not_r.
 record(R) when is_record(R, r) -> R;
 record(_) -> not_r.
+
+-spec multiple(term()) -> integer() | float() | not_number.
+multiple(I) when is_integer(I) -> I;
+multiple(F) when is_float(F) -> F;
+multiple(_) -> not_number.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -69,3 +69,7 @@ record(_) -> not_r.
 multiple(I) when is_integer(I) -> I;
 multiple(F) when is_float(F) -> F;
 multiple(_) -> not_number.
+
+-spec multiple2(term()) -> integer() | float() | not_number.
+multiple2(N) when is_integer(N) orelse is_float(N) -> N;
+multiple2(_) -> not_number.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -64,7 +64,3 @@ function(_) -> not_function.
 -spec record(term()) -> #r{} | not_r.
 record(R) when is_record(R, r) -> R;
 record(_) -> not_r.
-
--spec complex(term()) -> binary() | integer() | not_binary_or_integer.
-complex(X) when is_binary(X) orelse is_integer(X) -> X;
-complex(_) -> not_binary_or_integer.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -1,0 +1,70 @@
+-module(guard).
+
+
+-spec atom(term()) -> atom() | not_atom.
+atom(A) when is_atom(A) -> A;
+atom(_) -> not_atom.
+
+-spec binary(term()) -> binary() | not_binary.
+binary(B) when is_binary(B) -> B;
+binary(_) -> not_binary.
+
+-spec bitstring(term()) -> bitstring() | not_bitstring.
+bitstring(B) when is_bitstring(B) -> B;
+bitstring(_) -> not_bitstring.
+
+-spec boolean(term()) -> boolean() | not_boolean.
+boolean(B) when is_boolean(B) -> B;
+boolean(_) -> not_boolean.
+
+-spec float(term()) -> float() | not_float.
+float(F) when is_float(F) -> F;
+float(_) -> not_float.
+
+-spec integer(term()) -> integer() | not_integer.
+integer(I) when is_integer(I) -> I;
+integer(_) -> not_integer.
+
+-spec number(term()) -> number() | not_number.
+number(N) when is_number(N) -> N;
+number(_) -> not_number.
+
+-spec list(term()) -> list() | not_list.
+list(L) when is_list(L) -> L;
+list(_) -> not_list.
+
+-spec map(term()) -> map() | not_map.
+map(M) when is_map(M) -> M;
+map(_) -> not_map.
+
+-spec pid(term()) -> pid() | not_pid.
+pid(P) when is_pid(P) -> P;
+pid(_) -> not_pid.
+
+-spec port(term()) -> port() | not_port.
+port(P) when is_port(P) -> P;
+port(_) -> not_port.
+
+-spec reference(term()) -> reference() | not_reference.
+reference(R) when is_reference(R) -> R;
+reference(_) -> not_reference.
+
+-spec tuple(term()) -> tuple() | not_tuple.
+tuple(T) when is_tuple(T) -> T;
+tuple(_) -> not_tuple.
+
+-spec function(term()) -> function() | not_function.
+function(F) when is_function(F) -> F;
+function(_) -> not_function.
+
+-record(r, {
+    f
+}).
+
+-spec record(term()) -> #r{} | not_r.
+record(R) when is_record(R, r) -> R;
+record(_) -> not_r.
+
+-spec complex(term()) -> binary() | integer() | not_binary_or_integer.
+complex(X) when is_binary(X) orelse is_integer(X) -> X;
+complex(_) -> not_binary_or_integer.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -79,6 +79,10 @@ multiple(I) when is_integer(I) -> I;
 multiple(F) when is_float(F) -> F;
 multiple(_) -> not_number.
 
+-spec or_test(integer() | float() | atom()) -> integer() | float() | not_number.
+or_test(N) when is_integer(N) or is_float(N) -> N;
+or_test(_) -> not_number.
+
 -spec orelse1(integer() | float() | atom()) -> integer() | float() | not_number.
 orelse1(N) when is_integer(N) orelse is_float(N) -> N;
 orelse1(_) -> not_number.
@@ -86,6 +90,10 @@ orelse1(_) -> not_number.
 -spec orelse2(integer() | float() | atom()) -> integer() | float() | not_number.
 orelse2(N) when is_integer(N); is_float(N) -> N;
 orelse2(_) -> not_number.
+
+-spec and_test(integer() | atom()) -> integer() | not_integer.
+and_test(N) when is_integer(N) and is_number(N) -> N;
+and_test(_) -> not_integer.
 
 -spec andalso1(integer() | atom()) -> integer() | not_integer.
 andalso1(N) when is_integer(N) andalso is_number(N) -> N;

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -71,10 +71,18 @@ multiple(I) when is_integer(I) -> I;
 multiple(F) when is_float(F) -> F;
 multiple(_) -> not_number.
 
--spec multiple2(term()) -> integer() | float() | not_number.
-multiple2(N) when is_integer(N) orelse is_float(N) -> N;
-multiple2(_) -> not_number.
+-spec orelse1(term()) -> integer() | float() | not_number.
+orelse1(N) when is_integer(N) orelse is_float(N) -> N;
+orelse1(_) -> not_number.
 
--spec multiple3(term()) -> integer() | float() | not_number.
-multiple3(N) when is_integer(N); is_float(N) -> N;
-multiple3(_) -> not_number.
+-spec orelse2(term()) -> integer() | float() | not_number.
+orelse2(N) when is_integer(N); is_float(N) -> N;
+orelse2(_) -> not_number.
+
+-spec andalso1(term()) -> integer() | not_integer.
+andalso1(N) when is_integer(N) andalso is_number(N) -> N;
+andalso1(_) -> not_integer.
+
+-spec andalso2(term()) -> integer() | not_integer.
+andalso2(N) when is_integer(N), is_number(N) -> N;
+andalso2(_) -> not_integer.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -1,5 +1,6 @@
 -module(guard).
 
+-compile(export_all).
 
 -spec atom(term()) -> atom() | not_atom.
 atom(A) when is_atom(A) -> A;

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -74,3 +74,7 @@ multiple(_) -> not_number.
 -spec multiple2(term()) -> integer() | float() | not_number.
 multiple2(N) when is_integer(N) orelse is_float(N) -> N;
 multiple2(_) -> not_number.
+
+-spec multiple3(term()) -> integer() | float() | not_number.
+multiple3(N) when is_integer(N); is_float(N) -> N;
+multiple3(_) -> not_number.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -95,7 +95,40 @@ andalso1(_) -> not_integer.
 andalso2(N) when is_integer(N), is_number(N) -> N;
 andalso2(_) -> not_integer.
 
--spec good_orelse(integer() | atom(), integer() | atom()) -> integer().
-good_orelse(X, Y) when is_integer(X) andalso is_integer(Y) -> X + Y;
-good_orelse(_, _) -> 42.
+-spec good_andalso(integer() | atom(), integer() | atom()) -> integer().
+good_andalso(X, Y) when is_integer(X) andalso is_integer(Y) -> X + Y;
+good_andalso(_, _) -> 42.
 
+-spec all(All) -> All when
+    All :: atom()
+        | binary()
+        | bitstring()
+        | boolean()
+        | float()
+        | function()
+        | integer()
+        | list()
+        | map()
+        | number()
+        | pid()
+        | port()
+        | #r{}
+        | reference()
+        | tuple().
+all(X) when is_atom(X) -> X;
+all(X) when is_binary(X) -> X;
+all(X) when is_bitstring(X) -> X;
+all(X) when is_boolean(X) -> X;
+all(X) when is_float(X) -> X;
+all(X) when is_function(X) -> X;
+all(X) when is_function(X, 1) -> X;
+all(X) when is_integer(X) -> X;
+all(X) when is_list(X) -> X;
+all(X) when is_map(X) -> X;
+all(X) when is_number(X) -> X;
+all(X) when is_pid(X) -> X;
+all(X) when is_port(X) -> X;
+all(X) when is_record(X, r) -> X;
+all(X) when is_record(X, r, 1) -> X;
+all(X) when is_reference(X) -> X;
+all(X) when is_tuple(X) -> X.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -2,87 +2,95 @@
 
 -compile(export_all).
 
--spec atom(gradualizer:top()) -> atom() | not_atom.
+-spec atom(atom() | integer()) -> atom() | not_atom.
 atom(A) when is_atom(A) -> A;
 atom(_) -> not_atom.
 
--spec binary(gradualizer:top()) -> binary() | not_binary.
+-spec binary(binary() | atom()) -> binary() | not_binary.
 binary(B) when is_binary(B) -> B;
 binary(_) -> not_binary.
 
--spec bitstring(gradualizer:top()) -> bitstring() | not_bitstring.
+-spec bitstring(bitstring() | atom()) -> bitstring() | not_bitstring.
 bitstring(B) when is_bitstring(B) -> B;
 bitstring(_) -> not_bitstring.
 
--spec boolean(gradualizer:top()) -> boolean() | not_boolean.
+-spec boolean(boolean() | atom()) -> boolean() | not_boolean.
 boolean(B) when is_boolean(B) -> B;
 boolean(_) -> not_boolean.
 
--spec float(gradualizer:top()) -> float() | not_float.
+-spec float(float() | atom()) -> float() | not_float.
 float(F) when is_float(F) -> F;
 float(_) -> not_float.
 
--spec integer(gradualizer:top()) -> integer() | not_integer.
+-spec integer(integer() | atom()) -> integer() | not_integer.
 integer(I) when is_integer(I) -> I;
 integer(_) -> not_integer.
 
--spec number(gradualizer:top()) -> number() | not_number.
+-spec number(number() | atom()) -> number() | not_number.
 number(N) when is_number(N) -> N;
 number(_) -> not_number.
 
--spec list(gradualizer:top()) -> list() | not_list.
+-spec list(list() | atom()) -> list() | not_list.
 list(L) when is_list(L) -> L;
 list(_) -> not_list.
 
--spec map(gradualizer:top()) -> map() | not_map.
+-spec map(map() | atom()) -> map() | not_map.
 map(M) when is_map(M) -> M;
 map(_) -> not_map.
 
--spec pid(gradualizer:top()) -> pid() | not_pid.
+-spec pid(pid() | atom()) -> pid() | not_pid.
 pid(P) when is_pid(P) -> P;
 pid(_) -> not_pid.
 
--spec port(gradualizer:top()) -> port() | not_port.
+-spec port(port() | atom()) -> port() | not_port.
 port(P) when is_port(P) -> P;
 port(_) -> not_port.
 
--spec reference(gradualizer:top()) -> reference() | not_reference.
+-spec reference(reference() | atom()) -> reference() | not_reference.
 reference(R) when is_reference(R) -> R;
 reference(_) -> not_reference.
 
--spec tuple(gradualizer:top()) -> tuple() | not_tuple.
+-spec tuple(tuple() | atom()) -> tuple() | not_tuple.
 tuple(T) when is_tuple(T) -> T;
 tuple(_) -> not_tuple.
 
--spec function(gradualizer:top()) -> function() | not_function.
+-spec function(function() | atom()) -> function() | not_function.
 function(F) when is_function(F) -> F;
 function(_) -> not_function.
+
+-spec function2(function() | atom()) -> function() | not_function.
+function2(F) when is_function(F, 1) -> F;
+function2(_) -> not_function.
 
 -record(r, {
     f
 }).
 
--spec record(gradualizer:top()) -> #r{} | not_r.
+-spec record(#r{} | atom()) -> #r{} | not_r.
 record(R) when is_record(R, r) -> R;
 record(_) -> not_r.
 
--spec multiple(gradualizer:top()) -> integer() | float() | not_number.
+-spec record2(#r{} | atom()) -> #r{} | not_r.
+record2(R) when is_record(R, r, 1) -> R;
+record2(_) -> not_r.
+
+-spec multiple(integer() | float() | atom()) -> integer() | float() | not_number.
 multiple(I) when is_integer(I) -> I;
 multiple(F) when is_float(F) -> F;
 multiple(_) -> not_number.
 
--spec orelse1(gradualizer:top()) -> integer() | float() | not_number.
+-spec orelse1(integer() | float() | atom()) -> integer() | float() | not_number.
 orelse1(N) when is_integer(N) orelse is_float(N) -> N;
 orelse1(_) -> not_number.
 
--spec orelse2(gradualizer:top()) -> integer() | float() | not_number.
+-spec orelse2(integer() | float() | atom()) -> integer() | float() | not_number.
 orelse2(N) when is_integer(N); is_float(N) -> N;
 orelse2(_) -> not_number.
 
--spec andalso1(gradualizer:top()) -> integer() | not_integer.
+-spec andalso1(integer() | atom()) -> integer() | not_integer.
 andalso1(N) when is_integer(N) andalso is_number(N) -> N;
 andalso1(_) -> not_integer.
 
--spec andalso2(gradualizer:top()) -> integer() | not_integer.
+-spec andalso2(integer() | atom()) -> integer() | not_integer.
 andalso2(N) when is_integer(N), is_number(N) -> N;
 andalso2(_) -> not_integer.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -58,7 +58,7 @@ tuple(_) -> not_tuple.
 function(F) when is_function(F) -> F;
 function(_) -> not_function.
 
--spec function2(function() | atom()) -> function() | not_function.
+-spec function2(fun((any()) -> any()) | atom()) -> fun((any()) -> any()) | not_function.
 function2(F) when is_function(F, 1) -> F;
 function2(_) -> not_function.
 

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -6,6 +6,10 @@
 atom(A) when is_atom(A) -> A;
 atom(_) -> not_atom.
 
+-spec atom2(atom() | integer()) -> atom() | not_atom.
+atom(A) when erlang:is_atom(A) -> A;
+atom(_) -> not_atom.
+
 -spec binary(binary() | atom()) -> binary() | not_binary.
 binary(B) when is_binary(B) -> B;
 binary(_) -> not_binary.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -94,3 +94,8 @@ andalso1(_) -> not_integer.
 -spec andalso2(integer() | atom()) -> integer() | not_integer.
 andalso2(N) when is_integer(N), is_number(N) -> N;
 andalso2(_) -> not_integer.
+
+-spec good_orelse(integer() | atom(), integer() | atom()) -> integer().
+good_orelse(X, Y) when is_integer(X) andalso is_integer(Y) -> X + Y;
+good_orelse(_, _) -> 42.
+

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -2,59 +2,59 @@
 
 -compile(export_all).
 
--spec atom(term()) -> atom() | not_atom.
+-spec atom(gradualizer:top()) -> atom() | not_atom.
 atom(A) when is_atom(A) -> A;
 atom(_) -> not_atom.
 
--spec binary(term()) -> binary() | not_binary.
+-spec binary(gradualizer:top()) -> binary() | not_binary.
 binary(B) when is_binary(B) -> B;
 binary(_) -> not_binary.
 
--spec bitstring(term()) -> bitstring() | not_bitstring.
+-spec bitstring(gradualizer:top()) -> bitstring() | not_bitstring.
 bitstring(B) when is_bitstring(B) -> B;
 bitstring(_) -> not_bitstring.
 
--spec boolean(term()) -> boolean() | not_boolean.
+-spec boolean(gradualizer:top()) -> boolean() | not_boolean.
 boolean(B) when is_boolean(B) -> B;
 boolean(_) -> not_boolean.
 
--spec float(term()) -> float() | not_float.
+-spec float(gradualizer:top()) -> float() | not_float.
 float(F) when is_float(F) -> F;
 float(_) -> not_float.
 
--spec integer(term()) -> integer() | not_integer.
+-spec integer(gradualizer:top()) -> integer() | not_integer.
 integer(I) when is_integer(I) -> I;
 integer(_) -> not_integer.
 
--spec number(term()) -> number() | not_number.
+-spec number(gradualizer:top()) -> number() | not_number.
 number(N) when is_number(N) -> N;
 number(_) -> not_number.
 
--spec list(term()) -> list() | not_list.
+-spec list(gradualizer:top()) -> list() | not_list.
 list(L) when is_list(L) -> L;
 list(_) -> not_list.
 
--spec map(term()) -> map() | not_map.
+-spec map(gradualizer:top()) -> map() | not_map.
 map(M) when is_map(M) -> M;
 map(_) -> not_map.
 
--spec pid(term()) -> pid() | not_pid.
+-spec pid(gradualizer:top()) -> pid() | not_pid.
 pid(P) when is_pid(P) -> P;
 pid(_) -> not_pid.
 
--spec port(term()) -> port() | not_port.
+-spec port(gradualizer:top()) -> port() | not_port.
 port(P) when is_port(P) -> P;
 port(_) -> not_port.
 
--spec reference(term()) -> reference() | not_reference.
+-spec reference(gradualizer:top()) -> reference() | not_reference.
 reference(R) when is_reference(R) -> R;
 reference(_) -> not_reference.
 
--spec tuple(term()) -> tuple() | not_tuple.
+-spec tuple(gradualizer:top()) -> tuple() | not_tuple.
 tuple(T) when is_tuple(T) -> T;
 tuple(_) -> not_tuple.
 
--spec function(term()) -> function() | not_function.
+-spec function(gradualizer:top()) -> function() | not_function.
 function(F) when is_function(F) -> F;
 function(_) -> not_function.
 
@@ -62,27 +62,27 @@ function(_) -> not_function.
     f
 }).
 
--spec record(term()) -> #r{} | not_r.
+-spec record(gradualizer:top()) -> #r{} | not_r.
 record(R) when is_record(R, r) -> R;
 record(_) -> not_r.
 
--spec multiple(term()) -> integer() | float() | not_number.
+-spec multiple(gradualizer:top()) -> integer() | float() | not_number.
 multiple(I) when is_integer(I) -> I;
 multiple(F) when is_float(F) -> F;
 multiple(_) -> not_number.
 
--spec orelse1(term()) -> integer() | float() | not_number.
+-spec orelse1(gradualizer:top()) -> integer() | float() | not_number.
 orelse1(N) when is_integer(N) orelse is_float(N) -> N;
 orelse1(_) -> not_number.
 
--spec orelse2(term()) -> integer() | float() | not_number.
+-spec orelse2(gradualizer:top()) -> integer() | float() | not_number.
 orelse2(N) when is_integer(N); is_float(N) -> N;
 orelse2(_) -> not_number.
 
--spec andalso1(term()) -> integer() | not_integer.
+-spec andalso1(gradualizer:top()) -> integer() | not_integer.
 andalso1(N) when is_integer(N) andalso is_number(N) -> N;
 andalso1(_) -> not_integer.
 
--spec andalso2(term()) -> integer() | not_integer.
+-spec andalso2(gradualizer:top()) -> integer() | not_integer.
 andalso2(N) when is_integer(N), is_number(N) -> N;
 andalso2(_) -> not_integer.


### PR DESCRIPTION
Simple support for guard BIFs to allow constraining `term()` to something more specific.