### PR TITLE
Support record matching at the function clause level

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1401,14 +1401,11 @@ do_type_check_expr(Env, {var, P, Var}) ->
             throw({unknown_variable, P, Var})
     end;
 do_type_check_expr(Env, {match, _, Pat, Expr}) ->
-    io:format(user, "DEBUG: do_type_check_expr, start~n", []),
     {Ty, VarBinds, Cs} = type_check_expr(Env, Expr),
     NormTy = normalize(Ty, Env#env.tenv),
-    io:format(user, "DEBUG: do_type_check_expr, before~n", []),
     {_PatTy, UBoundNorm, Env2, Cs2} =
             ?throw_orig_type(add_type_pat(Pat, NormTy, Env#env.tenv, VarBinds),
                              Ty, NormTy),
-    io:format(user, "DEBUG: do_type_check_expr, UBoundNorm = ~p~n", [UBoundNorm]),
     UBound = case UBoundNorm of NormTy -> Ty;
                                 _Other -> UBoundNorm end,
     {UBound, Env2, constraints:combine(Cs,Cs2)};
@@ -3261,10 +3258,8 @@ check_clause(Env, ArgsTy, ResTy, C = {clause, P, Args, Guards, Block}) ->
     ?verbose(Env, "~sChecking clause :: ~s~n", [gradualizer_fmt:format_location(C, brief), typelib:pp_type(ResTy)]),
     case {length(ArgsTy), length(Args)} of
         {L, L} ->
-            io:format(user, "DEBUG: check_clause, begin~n", []),
             {PatTys, _UBounds, VEnv2, Cs1} =
                 add_types_pats(Args, ArgsTy, Env#env.tenv, Env#env.venv),
-            io:format(user, "DEBUG: check_clause, PatTys = ~p~n", [PatTys]),
             EnvNew      = Env#env{ venv =  VEnv2 },
             VarBinds1   = check_guards(EnvNew, Guards),
             EnvNewest   = EnvNew#env{ venv = add_var_binds(EnvNew#env.venv, VarBinds1, Env#env.tenv) },
@@ -3486,14 +3481,10 @@ add_types_pats([], [], _TEnv, VEnv, PatTysAcc, UBoundsAcc, CsAcc) ->
     {lists:reverse(PatTysAcc), lists:reverse(UBoundsAcc),
      VEnv, constraints:combine(CsAcc)};
 add_types_pats([Pat | Pats], [Ty | Tys], TEnv, VEnv, PatTysAcc, UBoundsAcc, CsAcc) ->
-    io:format(user, "DEBUG: add_type_pats, begin~n", []),
     NormTy = normalize(Ty, TEnv),
-%%    io:format(user, "DEBUG: add_type_pats, NormTy = ~p~n", [NormTy]),
     {PatTyNorm, UBoundNorm, VEnv2, Cs1} =
         ?throw_orig_type(add_type_pat(Pat, NormTy, TEnv, VEnv),
                          Ty, NormTy),
-    io:format(user, "DEBUG: add_type_pats, PatTyNorm = ~p~n", [PatTyNorm]),
-    io:format(user, "DEBUG: add_type_pats, UBoundNorm = ~p~n", [UBoundNorm]),
     %% De-normalize the returned types if they are the type checked against.
     PatTy  = case PatTyNorm  of NormTy -> Ty;
                                 _      -> PatTyNorm end,
@@ -3722,10 +3713,6 @@ add_type_pat(Pat, Ty, _TEnv, _VEnv) ->
     throw({type_error, pattern, element(2, Pat), Pat, Ty}).
 
 add_type_pat_var(Pat, Var, PatVar, Ty, TEnv, VEnv) ->
-    io:format(user, "DEBUG: add_type_pat_var, Pat = ~p~n", [Pat]),
-    io:format(user, "DEBUG: add_type_pat_var, Var = ~p~n", [Var]),
-    io:format(user, "DEBUG: add_type_pat_var, PatVar = ~p~n", [PatVar]),
-    io:format(user, "DEBUG: add_type_pat_var, Ty = ~p~n", [Ty]),
     %% Refine using Pat1 first to be able to bind Pat2 to a refined type.
     {PatTy1, Ty1, VEnv1, Cs2} = add_type_pat(Pat, Ty, TEnv, VEnv),
     {PatTy2, Ty2, VEnv2, Cs1} = add_type_pat(PatVar, Ty1, TEnv, VEnv1),

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3647,7 +3647,7 @@ add_type_pat({record, P, Record, Fields}, Ty, TEnv, VEnv) ->
         type_error -> throw({type_error, record_pattern, P, Record, Ty});
         {ok, Cs1} ->
             {VEnv2, Cs2} = add_type_pat_fields(Fields, Record, TEnv, VEnv),
-            RecTy = {type, P, record, [{atom, P, Record}]},
+            RecTy = {type, erl_anno:new(0), record, [{atom, P, Record}]},
             {type(none), RecTy, VEnv2, constraints:combine(Cs1, Cs2)}
     end;
 add_type_pat({map, _, _} = MapPat, {var, _, Var} = TyVar, _TEnv, VEnv) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3647,7 +3647,7 @@ add_type_pat({record, P, Record, Fields}, Ty, TEnv, VEnv) ->
         type_error -> throw({type_error, record_pattern, P, Record, Ty});
         {ok, Cs1} ->
             {VEnv2, Cs2} = add_type_pat_fields(Fields, Record, TEnv, VEnv),
-            RecTy = {type, erl_anno:new(0), record, [{atom, P, Record}]},
+            RecTy = {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Record}]},
             {type(none), RecTy, VEnv2, constraints:combine(Cs1, Cs2)}
     end;
 add_type_pat({map, _, _} = MapPat, {var, _, Var} = TyVar, _TEnv, VEnv) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1401,11 +1401,14 @@ do_type_check_expr(Env, {var, P, Var}) ->
             throw({unknown_variable, P, Var})
     end;
 do_type_check_expr(Env, {match, _, Pat, Expr}) ->
+    io:format(user, "DEBUG: do_type_check_expr, start~n", []),
     {Ty, VarBinds, Cs} = type_check_expr(Env, Expr),
     NormTy = normalize(Ty, Env#env.tenv),
+    io:format(user, "DEBUG: do_type_check_expr, before~n", []),
     {_PatTy, UBoundNorm, Env2, Cs2} =
             ?throw_orig_type(add_type_pat(Pat, NormTy, Env#env.tenv, VarBinds),
                              Ty, NormTy),
+    io:format(user, "DEBUG: do_type_check_expr, UBoundNorm = ~p~n", [UBoundNorm]),
     UBound = case UBoundNorm of NormTy -> Ty;
                                 _Other -> UBoundNorm end,
     {UBound, Env2, constraints:combine(Cs,Cs2)};
@@ -3258,8 +3261,10 @@ check_clause(Env, ArgsTy, ResTy, C = {clause, P, Args, Guards, Block}) ->
     ?verbose(Env, "~sChecking clause :: ~s~n", [gradualizer_fmt:format_location(C, brief), typelib:pp_type(ResTy)]),
     case {length(ArgsTy), length(Args)} of
         {L, L} ->
+            io:format(user, "DEBUG: check_clause, begin~n", []),
             {PatTys, _UBounds, VEnv2, Cs1} =
                 add_types_pats(Args, ArgsTy, Env#env.tenv, Env#env.venv),
+            io:format(user, "DEBUG: check_clause, PatTys = ~p~n", [PatTys]),
             EnvNew      = Env#env{ venv =  VEnv2 },
             VarBinds1   = check_guards(EnvNew, Guards),
             EnvNewest   = EnvNew#env{ venv = add_var_binds(EnvNew#env.venv, VarBinds1, Env#env.tenv) },
@@ -3481,10 +3486,14 @@ add_types_pats([], [], _TEnv, VEnv, PatTysAcc, UBoundsAcc, CsAcc) ->
     {lists:reverse(PatTysAcc), lists:reverse(UBoundsAcc),
      VEnv, constraints:combine(CsAcc)};
 add_types_pats([Pat | Pats], [Ty | Tys], TEnv, VEnv, PatTysAcc, UBoundsAcc, CsAcc) ->
+    io:format(user, "DEBUG: add_type_pats, begin~n", []),
     NormTy = normalize(Ty, TEnv),
+%%    io:format(user, "DEBUG: add_type_pats, NormTy = ~p~n", [NormTy]),
     {PatTyNorm, UBoundNorm, VEnv2, Cs1} =
         ?throw_orig_type(add_type_pat(Pat, NormTy, TEnv, VEnv),
                          Ty, NormTy),
+    io:format(user, "DEBUG: add_type_pats, PatTyNorm = ~p~n", [PatTyNorm]),
+    io:format(user, "DEBUG: add_type_pats, UBoundNorm = ~p~n", [UBoundNorm]),
     %% De-normalize the returned types if they are the type checked against.
     PatTy  = case PatTyNorm  of NormTy -> Ty;
                                 _      -> PatTyNorm end,
@@ -3713,6 +3722,10 @@ add_type_pat(Pat, Ty, _TEnv, _VEnv) ->
     throw({type_error, pattern, element(2, Pat), Pat, Ty}).
 
 add_type_pat_var(Pat, Var, PatVar, Ty, TEnv, VEnv) ->
+    io:format(user, "DEBUG: add_type_pat_var, Pat = ~p~n", [Pat]),
+    io:format(user, "DEBUG: add_type_pat_var, Var = ~p~n", [Var]),
+    io:format(user, "DEBUG: add_type_pat_var, PatVar = ~p~n", [PatVar]),
+    io:format(user, "DEBUG: add_type_pat_var, Ty = ~p~n", [Ty]),
     %% Refine using Pat1 first to be able to bind Pat2 to a refined type.
     {PatTy1, Ty1, VEnv1, Cs2} = add_type_pat(Pat, Ty, TEnv, VEnv),
     {PatTy2, Ty2, VEnv2, Cs1} = add_type_pat(PatVar, Ty1, TEnv, VEnv1),

--- a/test/known_problems/should_pass/pattern_record.erl
+++ b/test/known_problems/should_pass/pattern_record.erl
@@ -1,0 +1,8 @@
+-module(pattern_record).
+
+-compile(export_all).
+
+-record(test, {n :: integer()}).
+-spec test42(#test{n :: 42} | bananas) -> #test{n :: 42} | not_test.
+test42(#test{} = Test) -> Test;
+test42(_) -> not_test.

--- a/test/should_fail/pattern_record_fail.erl
+++ b/test/should_fail/pattern_record_fail.erl
@@ -1,0 +1,19 @@
+-module(pattern_record_fail).
+
+-compile(export_all).
+
+-record(r1, {
+    f
+}).
+
+-record(r2, {
+    f
+}).
+
+-spec bad_match1(#r1{} | other) -> #r1{} | not_r1.
+bad_match1(R = #r2{}) -> R;
+bad_match1(_) -> not_r1.
+
+-spec bad_match2(#r1{} | #r2{}) -> #r1{} | not_r1.
+bad_match2(R = #r2{}) -> R;
+bad_match2(_) -> not_r1.

--- a/test/should_fail/pattern_record_fail.erl
+++ b/test/should_fail/pattern_record_fail.erl
@@ -17,3 +17,8 @@ bad_match1(_) -> not_r1.
 -spec bad_match2(#r1{} | #r2{}) -> #r1{} | not_r1.
 bad_match2(R = #r2{}) -> R;
 bad_match2(_) -> not_r1.
+
+-spec fail(#r1{} | #r2{}) -> integer().
+fail(R = #r2{f = F}) -> R.f + F;
+fail(_) -> 0.
+

--- a/test/should_fail/pattern_record_fail.erl
+++ b/test/should_fail/pattern_record_fail.erl
@@ -19,6 +19,6 @@ bad_match2(R = #r2{}) -> R;
 bad_match2(_) -> not_r1.
 
 -spec fail(#r1{} | #r2{}) -> integer().
-fail(R = #r2{f = F}) -> R.f + F;
+fail(R = #r2{f = F}) -> R#r1.f + F;
 fail(_) -> 0.
 

--- a/test/should_pass/pattern_record.erl
+++ b/test/should_pass/pattern_record.erl
@@ -1,0 +1,27 @@
+-module(pattern_record).
+
+-record(test, {
+    field :: integer()
+}).
+
+-spec clause_match(term()) -> #test{} | not_test.
+clause_match(#test{} = Test) -> Test;
+clause_match(_) -> not_test.
+
+-spec clause_match2(term()) -> #test{} | not_test.
+clause_match2(Test = #test{}) -> Test;
+clause_match2(_) -> not_test.
+
+-spec pat_match(term()) -> #test{} | not_test.
+pat_match(T) ->
+    case T of
+        #test{} = Test -> Test;
+        _ -> not_test
+    end.
+
+-spec pat_match2(term()) -> #test{} | not_test.
+pat_match2(T) ->
+    case T of
+        Test = #test{} -> Test;
+        _ -> not_test
+    end.

--- a/test/should_pass/pattern_record.erl
+++ b/test/should_pass/pattern_record.erl
@@ -25,3 +25,15 @@ pat_match2(T) ->
         Test = #test{} -> Test;
         _ -> not_test
     end.
+
+-spec any(any()) -> #test{} | not_test.
+any(#test{} = Test) -> Test;
+any(_) -> not_test.
+
+-spec any(any()) -> #test{field :: 42} | not_test.
+any(#test{} = Test) -> Test;
+any(_) -> not_test.
+
+-spec test42(#test{field :: 42} | bananas) -> #test{field :: 42} | not_test.
+test42(#test{} = Test) -> Test;
+test42(_) -> not_test.

--- a/test/should_pass/pattern_record.erl
+++ b/test/should_pass/pattern_record.erl
@@ -25,15 +25,3 @@ pat_match2(T) ->
         Test = #test{} -> Test;
         _ -> not_test
     end.
-
--spec any(any()) -> #test{} | not_test.
-any(#test{} = Test) -> Test;
-any(_) -> not_test.
-
--spec any(any()) -> #test{field :: 42} | not_test.
-any(#test{} = Test) -> Test;
-any(_) -> not_test.
-
--spec test42(#test{field :: 42} | bananas) -> #test{field :: 42} | not_test.
-test42(#test{} = Test) -> Test;
-test42(_) -> not_test.

--- a/test/should_pass/pattern_record.erl
+++ b/test/should_pass/pattern_record.erl
@@ -4,22 +4,22 @@
     field :: integer()
 }).
 
--spec clause_match(term()) -> #test{} | not_test.
+-spec clause_match(#test{} | whatever) -> #test{} | not_test.
 clause_match(#test{} = Test) -> Test;
 clause_match(_) -> not_test.
 
--spec clause_match2(term()) -> #test{} | not_test.
+-spec clause_match2(#test{} | whatever) -> #test{} | not_test.
 clause_match2(Test = #test{}) -> Test;
 clause_match2(_) -> not_test.
 
--spec pat_match(term()) -> #test{} | not_test.
+-spec pat_match(#test{} | whatever) -> #test{} | not_test.
 pat_match(T) ->
     case T of
         #test{} = Test -> Test;
         _ -> not_test
     end.
 
--spec pat_match2(term()) -> #test{} | not_test.
+-spec pat_match2(#test{} | whatever) -> #test{} | not_test.
 pat_match2(T) ->
     case T of
         Test = #test{} -> Test;

--- a/test/should_pass/pattern_record.erl
+++ b/test/should_pass/pattern_record.erl
@@ -37,6 +37,13 @@ pat_match2(T) ->
 }).
 
 -spec pass(#r1{} | #r2{}) -> integer().
-good(R = #r1{f = F}) -> R.f + F;
+good(R = #r1{f = F}) -> R#r1.f + F;
 good(_) -> 0.
 
+-record(r3, {
+    r :: #r1{} | #r2{}
+}).
+
+-spec multiple(#r3{} | #r2{}) -> integer().
+multiple(#r3{r = R = #r1{}}) -> R#r1.f;
+multiple(_) -> 0.

--- a/test/should_pass/pattern_record.erl
+++ b/test/should_pass/pattern_record.erl
@@ -27,3 +27,16 @@ pat_match2(T) ->
         Test = #test{} -> Test;
         _ -> not_test
     end.
+
+-record(r1, {
+    f :: integer()
+}).
+
+-record(r2, {
+    f :: atom()
+}).
+
+-spec pass(#r1{} | #r2{}) -> integer().
+good(R = #r1{f = F}) -> R.f + F;
+good(_) -> 0.
+

--- a/test/should_pass/pattern_record.erl
+++ b/test/should_pass/pattern_record.erl
@@ -1,5 +1,7 @@
 -module(pattern_record).
 
+-compile(export_all).
+
 -record(test, {
     field :: integer()
 }).


### PR DESCRIPTION
First draft to support the simple test case I've written:

```erlang
-record(test, {
    field :: integer()
}).

-spec clause_match(term()) -> #test{} | not_test.
clause_match(#test{} = Test) -> Test;
clause_match(_) -> not_test.
```

Anything else I should add? I'm thinking of adding a lot of other types but I'm not sure how realistically this could be useful. 

```erlang
fun_clause(1 = Integer) -> Integer;
```

I also feel like it might be a bit hackish. Will try to reuse another function to do the top-level binding for `match` on a var.