### PR TITLE
Normalize away term() to any()

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -657,6 +657,8 @@ normalize(Type, _TEnv) ->
 -spec expand_builtin_aliases(type()) -> type().
 expand_builtin_aliases({var, Ann, '_'}) ->
     {type, Ann, any, []};
+expand_builtin_aliases({type, Ann, term, []}) ->
+    {type, Ann, any, []};
 expand_builtin_aliases({type, Ann, binary, []}) ->
     {type, Ann, binary, [{integer, Ann, 0}, {integer, Ann, 8}]};
 expand_builtin_aliases({type, Ann, bitstring, []}) ->

--- a/test/should_fail/map_pattern.erl
+++ b/test/should_fail/map_pattern.erl
@@ -10,7 +10,7 @@ f(#{bepa := Bepa}) ->
 -spec badkey(#{apa => atom()}) -> ok.
 badkey(#{bepa := _Bepa}) -> ok.
 
--spec map_term(term()) -> any().
+-spec map_term(gradualizer:top()) -> any().
 map_term(#{k := V}) ->
     %% at this point V :: term()
     atom_to_list(V).


### PR DESCRIPTION
Removing `term()` during normalization will enable us to ignore
this type and simplify the typechecker. Currently, we have
a few odd bugs because we don't remove `term()`.

Thanks to @zuiderkwast for identifying the problem in #248