### PR TITLE
Remove position and annotations as early as possible

### DIFF
--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -26,6 +26,11 @@
 
 %% Types for the Erlang Abstract Format
 -type type() :: gradualizer_type:abstract_type().
+-type typed_record_field() :: {typed_record_field,
+                               {record_field, erl_anno:anno(),
+                                Name :: atom(),
+                                Default :: erl_parse:abstract_expr()},
+                               type()}.
 
 %% Compiled regular expression
 -type regexp() :: {re_pattern, _, _, _, _}.
@@ -78,7 +83,7 @@ get_opaque_type(M, T, A) ->
 
 %% @doc Fetches a record type defined in the module.
 -spec get_record_type(Module :: module(),
-                      Name :: atom()) -> {ok, [type()]} | not_found.
+                      Name :: atom()) -> {ok, [typed_record_field()]} | not_found.
 get_record_type(Module, Name) ->
     call({get_record_type, Module, Name}).
 

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -84,6 +84,7 @@ parse_type(Src) ->
 %% Removes all annotations from type, except filename in two cases: Filename is
 %% kept for user-defined types and record types. Filename is used to
 %% disambiguate between types with the same name from different modules.
+%% Annotated types as in Name :: Type are also removed.
 -spec remove_pos(type()) -> type().
 remove_pos({Type, _, Value})
   when Type == atom; Type == integer; Type == char; Type == var ->
@@ -115,7 +116,8 @@ remove_pos({remote_type, _, [Mod, Name, Params]}) ->
     Params1 = lists:map(fun remove_pos/1, Params),
     {remote_type, erl_anno:new(0), [Mod, Name, Params1]};
 remove_pos({ann_type, _, [Var, Type]}) ->
-    {ann_type, erl_anno:new(0), [Var, remove_pos(Type)]};
+    %% Also remove annotated types one the form Name :: Type
+    remove_pos(Type);
 remove_pos({op, _, Op, Type}) ->
     {op, erl_anno:new(0), Op, remove_pos(Type)};
 remove_pos({op, _, Op, Type1, Type2}) ->


### PR DESCRIPTION
This commit sets the location annotation in types to 0 as early as possible using `typelib:remove_pos/1`, i.e. when the types are loaded from beam or erl code, fetched from gradualizer_db or created.

Annotated types (Name :: Type) are also removed in `typelib:remove_pos/1`, so those don't need to be handled anywhere else.