### PR TITLE
Refine pattern using unsatisfied guards

### DIFF
--- a/test/should_fail/pp_intersection.erl
+++ b/test/should_fail/pp_intersection.erl
@@ -1,5 +1,5 @@
 -module(pp_intersection).
--export([foo/1]).
+-export([foo/1, bar/1]).
 
 %% Mostly to make sure pretty printing intersection types doesn't crash.
 

--- a/test/should_fail/type_refinement.erl
+++ b/test/should_fail/type_refinement.erl
@@ -1,6 +1,8 @@
 -module(type_refinement).
 -export([guard_prevents_refinement/2, imprecision_prevents_refinement/2,
-         multi_pat_fail_1/2]).
+         multi_pat_fail_1/2,
+         guard_prevents_refinement2/1,
+         pattern_prevents_refinement/2]).
 
 -spec guard_prevents_refinement(1..2, boolean()) -> 2.
 guard_prevents_refinement(N, Guard) ->
@@ -16,3 +18,12 @@ imprecision_prevents_refinement(_, X) -> X.
 -spec multi_pat_fail_1(a|b, a|b) -> {b, b}.
 multi_pat_fail_1(a, a) -> {b, b};
 multi_pat_fail_1(A, B) -> {A, B}. %% Not only {b, b} here
+
+-spec guard_prevents_refinement2(timestamp()) -> ok.
+guard_prevents_refinement2(X) when is_integer(X), X rem 7 == 0 -> ok;
+guard_prevents_refinement2(infinity) -> ok. % can still be an integer
+
+-spec pattern_prevents_refinement(timestamp(), any()) -> atom().
+pattern_prevents_refinement(X, X)    when is_integer(X) -> ok;
+pattern_prevents_refinement(X, {_Y}) when is_integer(X) -> ok;
+pattern_prevents_refinement(Inf, _) -> Inf. % Inf can still be an integer

--- a/test/should_pass/refine_mismatch_using_guard_bifs.erl
+++ b/test/should_pass/refine_mismatch_using_guard_bifs.erl
@@ -17,9 +17,11 @@ refine_by_guards_1(X) when is_pid(X)       -> ok;
 refine_by_guards_1(X) when is_reference(X) -> ok;
 refine_by_guards_1(X)                      -> X.
 
--spec refine_by_guards_2(neg_integer() | 2..4 | boolean() | port() | ok) -> ok.
+-spec refine_by_guards_2(neg_integer() | 2..4 | boolean() |
+                         [a, ...] | port() | ok) -> ok.
 refine_by_guards_2(X) when is_integer(X) -> ok;
 refine_by_guards_2(X) when is_boolean(X) -> ok;
+refine_by_guards_2(X) when is_list(X)    -> ok;
 refine_by_guards_2(X) when is_port(X)    -> ok;
 refine_by_guards_2(X)                    -> X.
 

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -561,6 +561,27 @@ illegal_forms_test_() ->
                                    "f(1 + A) -> ok."]))
     ].
 
+int_range_diff_test_() ->
+    [
+     ?_assertEqual([{1, 2}, {6, 10}],
+                   typechecker:int_range_diff({1, 10}, {3, 5})),
+     ?_assertEqual([{neg_inf, -11}],
+                   typechecker:int_range_diff({neg_inf, -1}, {-10, pos_inf})),
+     ?_assertEqual([{neg_inf, -11}],
+                   typechecker:int_range_diff({neg_inf, pos_inf}, {-10, pos_inf})),
+     ?_assertEqual([{10, pos_inf}],
+                   typechecker:int_range_diff({neg_inf, pos_inf}, {neg_inf, 9})),
+     ?_assertEqual([{10, pos_inf}],
+                   typechecker:int_range_diff({0, pos_inf}, {neg_inf, 9})),
+     ?_assertEqual([],
+                   typechecker:int_range_diff({1, 10}, {neg_inf, pos_inf})),
+     ?_assertEqual([{1, 10}],
+                   typechecker:int_range_diff({1, 10}, {-10, -1})),
+     ?_assertEqual([{2, 2}],
+                   typechecker:int_range_diff({1, 2}, {1, 1})),
+     ?_assertEqual([{1, 1}],
+                   typechecker:int_range_diff({1, 2}, {2, 2}))
+    ].
 
 %%
 %% Helper functions


### PR DESCRIPTION
Solving one remaining kind of refinements:

```Erlang
-spec f(integer() | atom()) -> atom().
f(N) when is_integer(N) -> ok;
f(A) -> A. % here A :: atom()
```

Solves the known problem by moving it to should pass: https://github.com/josefs/Gradualizer/compare/master...zuiderkwast:refine_pattern_using_unsatisfied_guards?expand=1#diff-125dcd766b91e71dfbd59fffda480511