### PR TITLE
Add specs in constraints module

### DIFF
--- a/src/constraints.erl
+++ b/src/constraints.erl
@@ -7,28 +7,35 @@
 -type type() :: gradualizer_type:abstract_type().
 
 -record(constraints, {
-          lower_bounds = #{}        :: #{ atom() => [type()] },
-          upper_bounds = #{}        :: #{ atom() => [type()] },
-          exist_vars   = sets:new() :: sets:set(string())
+          lower_bounds = #{}        :: #{ var() => [type()] },
+          upper_bounds = #{}        :: #{ var() => [type()] },
+          exist_vars   = sets:new() :: sets:set(var())
          }).
 
 -type constraints() :: #constraints{}.
+-type var() :: atom() | string().
 
+-spec empty() -> constraints().
 empty() ->
     #constraints{}.
 
+-spec add_var(var(), constraints()) -> constraints().
 add_var(Var, Cs) ->
     Cs#constraints{ exist_vars = sets:add_element(Var, Cs#constraints.exist_vars) }.
 
+-spec upper(var(), type()) -> constraints().
 upper(Var, Ty) ->
     #constraints{ upper_bounds = #{ Var => [Ty] } }.
 
+-spec lower(var(), type()) -> constraints().
 lower(Var, Ty) ->
     #constraints{ lower_bounds = #{ Var => [Ty] } }.
 
+-spec combine(constraints(), constraints()) -> constraints().
 combine(C1, C2) ->
     combine([C1, C2]).
 
+-spec combine([constraints()]) -> constraints().
 combine([]) ->
     empty();
 combine([Cs]) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -88,6 +88,8 @@
              %,tyvenv  = #{}
              }).
 
+-include("gradualizer.hrl").
+
 %% Two types are compatible if one is a subtype of the other, or both.
 compatible(Ty1, Ty2, TEnv) ->
     case {subtype(Ty1, Ty2, TEnv), subtype(Ty2, Ty1, TEnv)} of
@@ -1127,7 +1129,7 @@ expect_record_type(Record, {type, _, union, Tys}, TEnv) ->
     expect_record_union(Record, Tys, TEnv);
 expect_record_type(Record, {var, _, Var}, _TEnv) ->
     {ok, constraints:add_var(Var,
-           constraints:upper(Var, {record, erl_anno:new(0), Record}))};
+           constraints:upper(Var, type_record(Record)))};
 expect_record_type(_, _, _) ->
     type_error.
 
@@ -1141,6 +1143,7 @@ expect_record_union(Record, [Ty | Tys], TEnv) ->
 expect_record_union(_Record, [], _TEnv) ->
     type_error.
 
+-spec new_type_var() -> constraints:var().
 new_type_var() ->
     I = erlang:unique_integer(),
     "_TyVar" ++ integer_to_list(I).

--- a/test/known_problems/should_pass/sets_set.erl
+++ b/test/known_problems/should_pass/sets_set.erl
@@ -1,0 +1,5 @@
+-module(sets_set).
+
+-spec add_var(string(), sets:set(string())) -> sets:set(string()).
+add_var(Var, Set) ->
+    sets:add_element(Var, Set).


### PR DESCRIPTION
I'm not sure that these new specs are correct. Notice that `atom()` is replaced with `string()` in `lower_bounds` and `upper_bounds`.

This worries me:

https://github.com/josefs/Gradualizer/blob/cabde8b7a74b8f2194e806783df2427882e29a11/src/typechecker.erl#L2475-L2480

`new_type_var() :: string()` but `type_var(atom()) -> af_type_variable()`. Should we instead have `-type var() :: atom().` and change the implementation of `new_type_var/0`?

The sets module is also [troublesome](https://github.com/blackberry/Erlang-OTP/blob/3ec06ce97019eed9472a2cf8950ed23d7a2e6b9b/lib/stdlib/src/sets.erl#L70-L75):

```
%% A declaration equivalent to the following one is hard-coded in erl_types.
%% That declaration contains hard-coded information about the #set{}
%% record and the types of its fields.  So, please make sure that any
%% changes to its structure are also propagated to erl_types.erl.
%%
%% -opaque set() :: #set{}.
```

I was therefore not able to override `sets:add_element/2` in a sets prelude I was about to make.
```
-module(sets).

-spec add_element(A, sets:set(A)) -> sets:set(A).
````

I managed to get this type error (for `constraints:add_var/2`) running `make gradualize`
> The record field on line 24 is expected to have type sets:set(A) but it has type sets:set(var())