### PR TITLE
Add known problems regarding intersection with any

### DIFF
--- a/test/known_problems/should_fail/intersection_with_any_fail.erl
+++ b/test/known_problems/should_fail/intersection_with_any_fail.erl
@@ -1,0 +1,16 @@
+-module(intersection_with_any).
+
+-export([any_refined_using_guard/1,
+         intersection_using_constraits/1]).
+
+%% X :: any() & atom() by refinement
+-spec any_refined_using_guard(any()) -> 5.
+any_refined_using_guard(X) when is_atom(X) ->
+    X.
+
+%% X :: integer() & any() by the constraints
+-spec intersection_using_constraits(X) when X :: integer(),
+                                            X :: any() ->
+                                                      atom().
+intersection_using_constraits(X) ->
+    X.

--- a/test/should_pass/intersection_with_any.erl
+++ b/test/should_pass/intersection_with_any.erl
@@ -1,0 +1,12 @@
+-module(intersection_with_any).
+
+-export([any_refined_using_guard/1,
+         intersection_using_constraints/1]).
+
+-spec any_refined_using_guard(any()) -> 5.
+any_refined_using_guard(X) when is_integer(X) -> X.
+
+-spec intersection_using_constraints(X) when X :: integer(),
+                                             X :: any() ->
+                                                       5.
+intersection_using_constraints(X) -> X.


### PR DESCRIPTION
We could perhaps regard this as a feature request rather than a known problem. Anyway, it is highlighting what we currently do for intersection with any.

Since it's not possible use `&` in spec, other ways are used to represent this, e.g. type refinement.