### PR TITLE
Fix variable capture in 'fun'

### DIFF
--- a/test/should_pass/fun_capture.erl
+++ b/test/should_pass/fun_capture.erl
@@ -1,0 +1,7 @@
+-module(fun_capture).
+
+-spec f(integer()) -> fun(([atom()]) -> [atom()]).
+f(X) ->
+    (fun (X) ->
+	     X ++ []
+     end).


### PR DESCRIPTION
There's been a long-standing TODO about how variable capture
is dealt with in certain situations when adding types to
variables in clauses. This is handled differently between
'fun's and other types of constructs which have clauses
such as 'case' and 'receive'.

This patch passes around information to make sure that when
variables are handled in clauses, it is possible to know whether
variables should be bound or captured. It's a bigish diff but
it's mostly pretty boring.

Fixes #138