### PR TITLE
A first stab at typechecking automatically from the repl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ebin/gradualizer.app: src/gradualizer.app.src | ebin
 
 .PHONY: shell
 shell: app
-	erl -pa ebin
+	erl -pz ebin
 
 .PHONY: escript
 escript: bin/gradualizer

--- a/src/user_default.erl
+++ b/src/user_default.erl
@@ -2,7 +2,7 @@
 
 -export([c/1]).
 
-c(File) ->
+c(File) when not is_atom(File) ->
     % TODO: we can be a lot more clever about recognizing
     % if the argument is a file or a module, just like
     % shell_default:c/1.
@@ -11,4 +11,7 @@ c(File) ->
             shell_default:c(File);
         Err ->
             Err
-    end.
+    end;
+c(File) ->
+    shell_default:c(File).
+

--- a/src/user_default.erl
+++ b/src/user_default.erl
@@ -1,0 +1,14 @@
+-module(user_default).
+
+-export([c/1]).
+
+c(File) ->
+    % TODO: we can be a lot more clever about recognizing
+    % if the argument is a file or a module, just like
+    % shell_default:c/1.
+    case gradualizer:type_check_file(File) of
+        ok ->
+            shell_default:c(File);
+        Err ->
+            Err
+    end.


### PR DESCRIPTION
When the module 'user_default' is loaded it will override
the compile command in the repl so that files are typechecked
before compiled.

There are plenty of ways this implementation can be improved.
Right now the command only accepts strings as filepaths pointing
to source code files.
Secondly, it parses the file and passes it on to gradualizer.
After typechecking the absform is completely discarded and the
compiler starts parsing from scratch.