### PR TITLE
Record refinement

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1176,16 +1176,10 @@ expect_record_type(Union = {type, _, union, UnionTys}, Record, TEnv) ->
             {fields_tys, Tyss, Cs}
     end;
 expect_record_type({var, _, Var}, Record, #tenv{records = REnv}) ->
-%%    Not sure how to make this work
-%%    TyVar = new_type_var(),
-%%    {fields_ty
-%%        ,{var, erl_anno:new(0), TyVar}
-%%        ,constraints:add_var(Var,
-%%            constraints:upper(Var, type_record(Record)))
-%%    };
     case REnv of
         #{Record := Fields} ->
-            {fields_ty, Fields, constraints:empty()};
+            Cs = constraints:add_var(Var, constraints:upper(Var, type_record(Record))),
+            {fields_ty, Fields, Cs};
         _NotFound ->
             {type_error, Record}
     end;

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1713,9 +1713,15 @@ type_check_fields(Env, Rec, [{record_field, _, {var, _, '_'}, Expr} | Fields]
                                      ,{atom, erl_anno:new(0), Field}, Expr}
                                      || Field <- UnAssignedFields]
                                   ,should_not_be_inspected),
-    {VB2, Cs2} = type_check_fields(Env, Rec, Fields, UnAssignedFields),
+    {VB1, Cs1};
+type_check_fields(_Env, _Rec, [], should_not_be_inspected) ->
+    {#{}, constraints:empty()};
+type_check_fields(Env, Rec, [], [UnAssignedField|UnAssignedFields]) ->
+    FieldTy = get_rec_field_type({atom, erl_anno:new(0), UnAssignedField}, Rec),
+    {VB1, Cs1} = type_check_expr_in(Env, FieldTy, {atom, erl_anno:new(0), undefined}),
+    {VB2, Cs2} = type_check_fields(Env, Rec, [], UnAssignedFields),
     {union_var_binds(VB1, VB2, Env#env.tenv), constraints:combine(Cs1,Cs2)};
-type_check_fields(_Env, _Rec, [], _U) ->
+type_check_fields(_Env, _Rec, [], []) ->
     {#{}, constraints:empty()}.
 
 get_unassigned_fields(Fields, All) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -2158,7 +2158,13 @@ do_type_check_expr_in(Env, ResTy, {record, Anno, Name, Fields} = Record) ->
             {VarBinds, Cs2} = type_check_fields(Env, Rec, Fields),
             {VarBinds, constraints:combine(Cs1, Cs2)};
         {fields_tys, Tyss, Cs1} ->
-            todo;
+            case type_check_record_union_in(Env, Tyss, Fields) of
+                none ->
+                    {Ty, _VB, _Cs} = type_check_expr(Env#env{infer = true}, Record),
+                    throw({type_error, Record, Ty, ResTy});
+                {VBs, Cs2} ->
+                    {union_var_binds(VBs, Env#env.tenv), constraints:combine(Cs1, Cs2)}
+            end;
         any ->
             Rec = get_record_fields(Name, Anno, Env#env.tenv),
             type_check_fields(Env, Rec, Fields);

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1695,6 +1695,14 @@ type_check_fields(Env, Rec, Fields) ->
     UnAssignedFields = get_unassigned_fields(Fields, Rec),
     type_check_fields(Env, Rec, Fields, UnAssignedFields).
 
+%% type_check_fields for multiple cases, split by function head
+%% 1. The field is present with a value, need to make sure that field type checks that value
+%% 2. There is a _ present with a value, need to make sure all the remaining fields type checks that value
+%% 3. If case 2 was present, we have type checked all the fields and we can stop
+%% 4. If case 2 was absent, we need to make sure all the fields that were not type checked support:
+%%      In the case of having a default value: putting the default value
+%%      In the case of not having a default value: that it supports `undefined`
+%% 5. If case 2 was absent, we have type checked all the unassigned fields.
 type_check_fields(Env, Rec, [{record_field, _, {atom, _, _} = FieldWithAnno, Expr} | Fields]
                  ,UnAssignedFields) ->
     FieldTy = get_rec_field_type(FieldWithAnno, Rec),
@@ -4310,6 +4318,7 @@ add_var_binds(VEnv, VarBinds, TEnv) ->
     Glb = fun(_K, Ty1, Ty2) -> {Ty, _C} = glb(Ty1, Ty2, TEnv), Ty end,
     gradualizer_lib:merge_with(Glb, VEnv, VarBinds).
 
+%% From a record field name, find the default value from the typed list of record field definitions
 get_rec_field_default({atom, _, FieldName},
                     [{typed_record_field,
                         {record_field, _, {atom, _, FieldName}, Default}, _}|_]) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1703,29 +1703,29 @@ type_check_fields(Env, Rec, Fields) ->
 %%      In the case of having a default value: putting the default value
 %%      In the case of not having a default value: that it supports `undefined`
 %% 5. If case 2 was absent, we have type checked all the unassigned fields.
-type_check_fields(Env, Rec, [{record_field, _, {atom, _, _} = FieldWithAnno, Expr} | Fields]
+type_check_fields(Env, TypedRecFields, [{record_field, _, {atom, _, _} = FieldWithAnno, Expr} | Fields]
                  ,UnAssignedFields) ->
-    FieldTy = get_rec_field_type(FieldWithAnno, Rec),
+    FieldTy = get_rec_field_type(FieldWithAnno, TypedRecFields),
     {VB1, Cs1} = type_check_expr_in(Env, FieldTy, Expr),
-    {VB2, Cs2} = type_check_fields(Env, Rec, Fields, UnAssignedFields),
+    {VB2, Cs2} = type_check_fields(Env, TypedRecFields, Fields, UnAssignedFields),
     {union_var_binds(VB1, VB2, Env#env.tenv), constraints:combine(Cs1,Cs2)};
-type_check_fields(Env, Rec, [{record_field, _, {var, _, '_'}, Expr} | Fields]
+type_check_fields(Env, TypedRecFields, [{record_field, _, {var, _, '_'}, Expr} | Fields]
                  ,UnAssignedFields) ->
-    {VB1, Cs1} = type_check_fields(Env, Rec
+    {VB1, Cs1} = type_check_fields(Env, TypedRecFields
                                   ,[ {record_field, erl_anno:new(0)
                                      ,{atom, erl_anno:new(0), Field}, Expr}
                                      || Field <- UnAssignedFields]
                                   ,should_not_be_inspected),
     {VB1, Cs1};
-type_check_fields(_Env, _Rec, [], should_not_be_inspected) ->
+type_check_fields(_Env, _TypedRecFields, [], should_not_be_inspected) ->
     {#{}, constraints:empty()};
-type_check_fields(Env, Rec, [], [UnAssignedField|UnAssignedFields]) ->
-    FieldTy = get_rec_field_type({atom, erl_anno:new(0), UnAssignedField}, Rec),
-    FieldDefault = get_rec_field_default({atom, erl_anno:new(0), UnAssignedField}, Rec),
+type_check_fields(Env, TypedRecFields, [], [UnAssignedField|UnAssignedFields]) ->
+    FieldTy = get_rec_field_type({atom, erl_anno:new(0), UnAssignedField}, TypedRecFields),
+    FieldDefault = get_rec_field_default({atom, erl_anno:new(0), UnAssignedField}, TypedRecFields),
     {VB1, Cs1} = type_check_expr_in(Env, FieldTy, FieldDefault),
-    {VB2, Cs2} = type_check_fields(Env, Rec, [], UnAssignedFields),
+    {VB2, Cs2} = type_check_fields(Env, TypedRecFields, [], UnAssignedFields),
     {union_var_binds(VB1, VB2, Env#env.tenv), constraints:combine(Cs1,Cs2)};
-type_check_fields(_Env, _Rec, [], []) ->
+type_check_fields(_Env, _TypedRecFields, [], []) ->
     {#{}, constraints:empty()}.
 
 get_unassigned_fields(Fields, All) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3342,12 +3342,10 @@ refine_ty(_Ty, ?type(none), _TEnv) ->
     throw(no_refinement);
 refine_ty(?type(T, A), ?type(T, A), _) ->
     type(none);
-refine_ty(?type(record, [{atom, _, Name}]), ?type(record, [{atom, _, Name}]), _) ->
+refine_ty(?type(record, [{atom, _, Name} | _]), ?type(record, [{atom, _, Name}]), _TEnv) ->
     type(none);
 refine_ty(?type(record, [{atom, Anno, Name}]), Refined = ?type(record, [{atom, _, Name} | _]), TEnv) ->
     refine_ty(expand_record(Name, Anno, TEnv), Refined, TEnv);
-refine_ty(?type(record, [{atom, _, Name} | _]), ?type(record, [{atom, _, Name}]), _TEnv) ->
-    type(none);
 refine_ty(?type(record, [Name|FieldTys1]), ?type(record, [Name|FieldTys2]), TEnv)
   when length(FieldTys1) > 0, length(FieldTys1) == length(FieldTys2) ->
     % Record without just the name

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3844,9 +3844,6 @@ add_type_pat({bin, _P, BinElements} = Bin, Ty, TEnv, VEnv) ->
 add_type_pat({record, P, Record, Fields}, Ty, TEnv, VEnv) ->
     case expect_record_type(Ty, Record, TEnv) of
         any ->
-            %% FIXME: If record() is used and we try to bind, every field types
-            %% - should be any(). add_any_types_pat won't work, will need a
-            %% - add_any_type_pat_fields
             {type(none)
                 ,Ty
                 ,union_var_binds([add_any_types_pat(Field, VEnv) || Field <- Fields], TEnv)

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -37,8 +37,6 @@ pp_type({type, _, bounded_fun, [FunType, []]}) ->
     %% Bounded fun with empty constraints gets printed with a trailing "when"
     %% when pretty-printed as a spec (next clause)
     pp_type(?assert_type(FunType, function_type()));
-pp_type({type, Anno, record, [Name|Fields]}) when length(Fields) > 0 ->
-    pp_type({type, Anno, record, [Name]});
 pp_type(Type = {type, _, bounded_fun, _}) ->
     %% erl_pp can't handle bounded_fun in type definitions
     %% We invent our own syntax here, e.g. "fun((A) -> ok when A :: atom())"
@@ -94,9 +92,6 @@ remove_pos({Type, _, Value})
 remove_pos({user_type, Anno, Name, Params}) when is_list(Params) ->
     {user_type, anno_keep_only_filename(Anno), Name,
      lists:map(fun remove_pos/1, Params)};
-remove_pos({type, Anno, record, Params = [{atom, AtomAnno, Name}|Fields0]}) ->
-    Fields = [remove_pos(Field) || Field <- Fields0],
-    {type, anno_keep_only_filename(Anno), record, [{atom, anno_keep_only_filename(AtomAnno), Name}|Fields]};
 remove_pos({type, _, bounded_fun, [FT, Cs]}) ->
     {type, erl_anno:new(0), bounded_fun, [remove_pos(FT)
                                          ,lists:map(fun remove_pos/1, Cs)]};

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -92,6 +92,10 @@ remove_pos({Type, _, Value})
 remove_pos({user_type, Anno, Name, Params}) when is_list(Params) ->
     {user_type, anno_keep_only_filename(Anno), Name,
      lists:map(fun remove_pos/1, Params)};
+% Might need to bring this back but will need to support more params since the records can be refined now
+% One thing to be careful is that we can "redefine" some fields for a specific record instance as well
+% remove_pos({type, Anno, record, Params = [{atom, AtomAnno, Name}]}) ->	
+%     {type, anno_keep_only_filename(Anno), record, [{atom, anno_keep_only_filename(AtomAnno), Name}]};
 remove_pos({type, _, bounded_fun, [FT, Cs]}) ->
     {type, erl_anno:new(0), bounded_fun, [remove_pos(FT)
                                          ,lists:map(fun remove_pos/1, Cs)]};

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -37,6 +37,8 @@ pp_type({type, _, bounded_fun, [FunType, []]}) ->
     %% Bounded fun with empty constraints gets printed with a trailing "when"
     %% when pretty-printed as a spec (next clause)
     pp_type(?assert_type(FunType, function_type()));
+pp_type({type, Anno, record, [Name|Fields]}) when length(Fields) > 0 ->
+    pp_type({type, Anno, record, [Name]});
 pp_type(Type = {type, _, bounded_fun, _}) ->
     %% erl_pp can't handle bounded_fun in type definitions
     %% We invent our own syntax here, e.g. "fun((A) -> ok when A :: atom())"
@@ -92,8 +94,9 @@ remove_pos({Type, _, Value})
 remove_pos({user_type, Anno, Name, Params}) when is_list(Params) ->
     {user_type, anno_keep_only_filename(Anno), Name,
      lists:map(fun remove_pos/1, Params)};
-remove_pos({type, Anno, record, Params = [{atom, AtomAnno, Name}]}) ->
-    {type, anno_keep_only_filename(Anno), record, [{atom, anno_keep_only_filename(AtomAnno), Name}]};
+remove_pos({type, Anno, record, Params = [{atom, AtomAnno, Name}|Fields0]}) ->
+    Fields = [remove_pos(Field) || Field <- Fields0],
+    {type, anno_keep_only_filename(Anno), record, [{atom, anno_keep_only_filename(AtomAnno), Name}|Fields]};
 remove_pos({type, _, bounded_fun, [FT, Cs]}) ->
     {type, erl_anno:new(0), bounded_fun, [remove_pos(FT)
                                          ,lists:map(fun remove_pos/1, Cs)]};

--- a/test/known_problems/should_pass/pattern_record.erl
+++ b/test/known_problems/should_pass/pattern_record.erl
@@ -1,8 +1,0 @@
--module(pattern_record).
-
--compile(export_all).
-
--record(test, {n :: integer()}).
--spec test42(#test{n :: 42} | bananas) -> #test{n :: 42} | not_test.
-test42(#test{} = Test) -> Test;
-test42(_) -> not_test.

--- a/test/should_fail/record.erl
+++ b/test/should_fail/record.erl
@@ -1,9 +1,14 @@
 -module(record).
 
--export([g/0]).
+-export([g/0, h/0]).
 
 -record(rec, { apa :: integer()}).
 
 -spec g() -> integer().
 g() ->
     #rec{apa = 1}.
+
+-spec h() -> integer().
+h() ->
+    Rec = #rec{},
+    Rec#rec.apa.

--- a/test/should_fail/record_refinement_fail.erl
+++ b/test/should_fail/record_refinement_fail.erl
@@ -1,0 +1,9 @@
+-module(record_refinement_fail).
+
+-compile(export_all).
+
+-record(one_field, {a :: integer() | undefined}).
+
+-spec one_field(#one_field{}, integer()) -> integer().
+one_field(#one_field{a = I}, _) -> I;
+one_field(_, I) -> I.

--- a/test/should_fail/record_refinement_fail.erl
+++ b/test/should_fail/record_refinement_fail.erl
@@ -11,3 +11,8 @@ one_field(_, I) -> I.
 -spec one_field2(#one_field{}, integer()) -> integer().
 one_field2(R, _) -> R#one_field.a;
 one_field2(_, I) -> I.
+
+-record(refined_field, {f :: integer() | undefined}).
+-spec refined_field(#refined_field{}) -> #refined_field{f :: atom()}.
+refined_field(#refined_field{f = undefined}) -> #refined_field{f = 0};
+refined_field(R) -> R.

--- a/test/should_fail/record_refinement_fail.erl
+++ b/test/should_fail/record_refinement_fail.erl
@@ -7,3 +7,7 @@
 -spec one_field(#one_field{}, integer()) -> integer().
 one_field(#one_field{a = I}, _) -> I;
 one_field(_, I) -> I.
+
+-spec one_field2(#one_field{}, integer()) -> integer().
+one_field2(R, _) -> R#one_field.a;
+one_field2(_, I) -> I.

--- a/test/should_fail/record_refinement_fail.erl
+++ b/test/should_fail/record_refinement_fail.erl
@@ -13,6 +13,10 @@ one_field2(R, _) -> R#one_field.a;
 one_field2(_, I) -> I.
 
 -record(refined_field, {f :: integer() | undefined}).
--spec refined_field(#refined_field{}) -> #refined_field{f :: atom()}.
-refined_field(#refined_field{f = undefined}) -> #refined_field{f = 0};
+-spec refined_field(#refined_field{}) -> #refined_field{f :: integer()}.
 refined_field(R) -> R.
+
+-spec refined_field2(#refined_field{}) -> #refined_field{f :: atom()}.
+refined_field2(#refined_field{f = undefined}) -> #refined_field{f = 0};
+refined_field2(R) -> R.
+

--- a/test/should_fail/record_refinement_fail.erl
+++ b/test/should_fail/record_refinement_fail.erl
@@ -20,3 +20,21 @@ refined_field(R) -> R.
 refined_field2(#refined_field{f = undefined}) -> #refined_field{f = 0};
 refined_field2(R) -> R.
 
+-record(two_level2, {value :: undefined | binary()}).
+-record(two_level1, {two_level2 :: undefined | #two_level2{}}).
+
+-spec two_level1(#two_level1{}) -> integer().
+two_level1(#two_level1{two_level2 = undefined}) -> 
+    0;
+two_level1(#two_level1{two_level2 = #two_level2{value = undefined}}) -> 
+    0;
+two_level1(#two_level1{two_level2 = #two_level2{value = Value}}) ->
+    Value.
+
+-spec two_level2(#two_level1{}) -> integer().
+two_level2(#two_level1{two_level2 = undefined}) -> 
+    0;
+two_level2(#two_level1{two_level2 = #two_level2{value = undefined}}) -> 
+    0;
+two_level2(R1) ->
+    R1#two_level1.two_level2#two_level2.value.

--- a/test/should_pass/pattern_bind_reuse.erl
+++ b/test/should_pass/pattern_bind_reuse.erl
@@ -1,6 +1,6 @@
 -module(pattern_bind_reuse).
 
--export([test/2, guess_the_die/1, is_same/2]).
+-export([test/2, guess_the_die/1, is_same/2, record/2]).
 
 -spec test(integer() | undefined, integer()) -> integer().
 test(I, I) -> I + I;
@@ -27,3 +27,11 @@ is_same(N, N) ->
 is_same(_, _) ->
     %% False error: This clause can't be reached
     false.
+
+-record(r, { f :: integer() | undefined }).
+
+-spec record(#r{}, integer()) -> integer().
+record(#r{f = I}, I) -> I;
+record(#r{f = undefined}, I) -> I;
+record(#r{f = I}, _) -> I.
+

--- a/test/should_pass/record_refinement.erl
+++ b/test/should_pass/record_refinement.erl
@@ -1,0 +1,47 @@
+-module(record_refinement).
+
+-record(one_field, {a :: integer() | undefined}).
+
+-spec one_field(#one_field{}, integer()) -> integer().
+one_field(#one_field{a = undefined}, I) -> I;
+one_field(#one_field{a = I}, _) -> I.
+
+-spec one_field2(#one_field{}, integer()) -> integer().
+one_field2(#one_field{a = undefined}, I) -> I;
+one_field2(R, _) -> R#one_field.a.
+
+-record(two_field, {a :: atom(), b :: integer() | undefined}).
+
+-spec two_field(#two_field{}, integer()) -> integer().
+two_field(#two_field{b = undefined}, I) -> I;
+two_field(#two_field{b = I}, _) -> I.
+
+-record(multiple, {a :: integer() | undefined, b :: integer() | undefined}).
+
+-spec multiple(#multiple{}) -> integer().
+multiple(#multiple{a = undefined, b = undefined}) -> 0;
+multiple(#multiple{a = undefined, b = B}) -> B;
+multiple(#multiple{a = A, b = undefined}) -> A;
+multiple(#multiple{a = A, b = B}) -> A + B.
+
+-record(underscore, {a :: integer() | undefined, b :: integer() | undefined, c :: integer() | undefined}).
+
+-spec underscore(#underscore{}) -> integer().
+underscore(#underscore{_ = undefined}) -> 0;
+underscore(#underscore{a = A, _ = undefined}) -> A;
+underscore(#underscore{b = B, _ = undefined}) -> B;
+underscore(#underscore{c = C, _ = undefined}) -> C;
+underscore(#underscore{a = A, b = B, _ = undefined}) -> A + B;
+underscore(#underscore{a = A, c = C, _ = undefined}) -> A + C;
+underscore(#underscore{b = B, c = C, _ = undefined}) -> B + C;
+underscore(#underscore{a = A, b = B, c = C}) -> A + B + C.
+
+-record(type_var, {f :: integer()}).
+-spec type_var([#type_var{}]) -> [integer()].
+type_var(Rs) -> lists:map(fun (R) -> R#type_var.f end, Rs).
+
+-record(any, {f :: integer()}).
+without_spec(R) -> with_spec(R#any.f).
+
+-spec with_spec(integer()) -> integer().
+with_spec(I) -> I + 1.

--- a/test/should_pass/record_refinement.erl
+++ b/test/should_pass/record_refinement.erl
@@ -69,7 +69,6 @@ two_level1(#two_level1{two_level2 = #two_level2{value = undefined}}) ->
 two_level1(#two_level1{two_level2 = #two_level2{value = Value}}) ->
     Value.
 
-
 -spec two_level2(#two_level1{}) -> integer().
 two_level2(#two_level1{two_level2 = undefined}) -> 
     0;
@@ -77,4 +76,3 @@ two_level2(#two_level1{two_level2 = #two_level2{value = undefined}}) ->
     0;
 two_level2(R1) ->
     R1#two_level1.two_level2#two_level2.value.
-

--- a/test/should_pass/record_refinement.erl
+++ b/test/should_pass/record_refinement.erl
@@ -50,3 +50,10 @@ with_spec(I) -> I + 1.
 -spec refined_field(#refined_field{}) -> #refined_field{f :: integer()}.
 refined_field(#refined_field{f = undefined}) -> #refined_field{f = 0};
 refined_field(R) -> R.
+
+-spec refined_field_safe(#refined_field{f :: integer()}) -> #refined_field{f :: integer()}.
+refined_field_safe(#refined_field{f = I}) -> #refined_field{f = I + 1}.
+
+-spec refined_field_unsafe(#refined_field{}) -> #refined_field{}.
+refined_field_unsafe(R = #refined_field{f = undefined}) -> R;
+refined_field_unsafe(R) -> refined_field_safe(R).

--- a/test/should_pass/record_refinement.erl
+++ b/test/should_pass/record_refinement.erl
@@ -45,3 +45,8 @@ without_spec(R) -> with_spec(R#any.f).
 
 -spec with_spec(integer()) -> integer().
 with_spec(I) -> I + 1.
+
+-record(refined_field, {f :: integer() | undefined}).
+-spec refined_field(#refined_field{}) -> #refined_field{f :: integer()}.
+refined_field(#refined_field{f = undefined}) -> #refined_field{f = 0};
+refined_field(R) -> R.

--- a/test/should_pass/record_refinement.erl
+++ b/test/should_pass/record_refinement.erl
@@ -57,3 +57,24 @@ refined_field_safe(#refined_field{f = I}) -> #refined_field{f = I + 1}.
 -spec refined_field_unsafe(#refined_field{}) -> #refined_field{}.
 refined_field_unsafe(R = #refined_field{f = undefined}) -> R;
 refined_field_unsafe(R) -> refined_field_safe(R).
+
+-record(two_level2, {value :: undefined | integer()}).
+-record(two_level1, {two_level2 :: undefined | #two_level2{}}).
+
+-spec two_level1(#two_level1{}) -> integer().
+two_level1(#two_level1{two_level2 = undefined}) -> 
+    0;
+two_level1(#two_level1{two_level2 = #two_level2{value = undefined}}) -> 
+    0;
+two_level1(#two_level1{two_level2 = #two_level2{value = Value}}) ->
+    Value.
+
+
+-spec two_level2(#two_level1{}) -> integer().
+two_level2(#two_level1{two_level2 = undefined}) -> 
+    0;
+two_level2(#two_level1{two_level2 = #two_level2{value = undefined}}) -> 
+    0;
+two_level2(R1) ->
+    R1#two_level1.two_level2#two_level2.value.
+

--- a/test/should_pass/records.erl
+++ b/test/should_pass/records.erl
@@ -1,6 +1,6 @@
 -module(records).
 
--export([f/0, g/1, h/0, i/0, j/0,
+-export([f/0, g/1, h/0, i/0, j/0, l/0,
          rec_field_subtype/1,
          rec_index_subtype/0,
          record_as_tuple/1]).
@@ -31,6 +31,15 @@ i() ->
 -spec j() -> 3.
 j() ->
     #r.f2.
+
+-record(test, {
+    field :: integer() | undefined
+}).
+
+-spec l() -> integer() | undefined.
+l() ->
+    Test = #test{},
+    Test#test.field.
 
 -spec rec_field_subtype(#r{}) -> number().
 rec_field_subtype(R) ->

--- a/test/should_pass/records.erl
+++ b/test/should_pass/records.erl
@@ -1,6 +1,6 @@
 -module(records).
 
--export([f/0, g/1, h/0, i/0, j/0, l/0,
+-export([f/0, g/1, h/0, i/0, j/0, k/0, l/0,
          rec_field_subtype/1,
          rec_index_subtype/0,
          record_as_tuple/1]).
@@ -32,14 +32,23 @@ i() ->
 j() ->
     #r.f2.
 
--record(test, {
+-record(test_k, {
     field :: integer() | undefined
 }).
 
--spec l() -> integer() | undefined.
+-spec k() -> integer() | undefined.
+k() ->
+    Test = #test_k{},
+    Test#test_k.field.
+
+-record(test_l, {
+    field = 0 :: integer()
+}).
+
+-spec l() -> integer().
 l() ->
-    Test = #test{},
-    Test#test.field.
+    Test = #test_l{},
+    Test#test_l.field.
 
 -spec rec_field_subtype(#r{}) -> number().
 rec_field_subtype(R) ->


### PR DESCRIPTION
This is still a work in progress but I managed to have test cases passing so I thought I'd create it. It resolves #245.

Some code paths are not covered because I have yet to make test cases for everything.

The way I've solved this problem is by expanding the fields for refinement when needed. For example:

```erlang
-record(r, {f :: integer() | undefined}).
-spec test(#r{}, integer()) -> integer().
test(#r{f = undefined}, I) -> I;
test(#r{f = I}, _) -> I.
```

This is now supported. The `ArgsTy` basically goes like this

```erlang
% First call
[{type, _, record, [{atom, _, r}]}, integer()]
% After refinement of first call
[{type, _, record, [{atom, _, r}, {type, _, integer, []}]}, integer()]
```

Trying to find test cases that break stuff now. A lot of the code is straight up a ripoff of the tuple logic (if you check `expect_record_type`).

Also, we have to make sure we squash all those garbage commits when we merge it.