### PR TITLE
More known problems for bound variable patterns

### DIFF
--- a/test/known_problems/should_pass/pattern_bind_reuse.erl
+++ b/test/known_problems/should_pass/pattern_bind_reuse.erl
@@ -1,7 +1,29 @@
 -module(pattern_bind_reuse).
 
--compile(export_all).
+-export([test/2, guess_the_die/1, is_same/2]).
 
 -spec test(integer() | undefined, integer()) -> integer().
 test(I, I) -> I + I;
 test(_, I) -> I.
+
+%% Guess a number. Roll a die. If same, you win the points of the die.
+-spec guess_the_die(Guess :: integer()) -> Score :: 0..6.
+guess_the_die(Guess) ->
+    %% Match any() against a bound variable of type integer()
+    case roll_die() of
+        Guess ->
+            Guess; % :: integer(), but should be any() & integer()
+        _WrongGuess ->
+            0
+    end.
+
+%% Untyped helper; returns 1..6
+roll_die() ->
+    random:uniform(6).
+
+-spec is_same(integer(), integer()) -> boolean().
+is_same(N, N) ->
+    true;
+is_same(_, _) ->
+    %% False error: This clause can't be reached
+    false.


### PR DESCRIPTION
I looked into #270 and at first I thought it seemed fairly easy to fix.

The idea: When a pattern is matched against a bound variable, instead of checking that VarTy is a subtype of PatternTy, we should refine the variable type using `NewVarTy = glb(VarTy, PatternTy)`. Does this make sense?

(The current code handling this is here: https://github.com/josefs/Gradualizer/blob/master/src/typechecker.erl#L3530).

This however leads to two other problems:

1. Since the first occurrence of a free variable in a pattern is treated as a catch-all, the refinement kicks in an says that the second clause is unreachable.


   ```Erlang
   -spec test(integer() | undefined, integer()) -> integer().
   test(I, I) -> I + I;
   test(_, I) -> I.
   ```

   In @FrankBro's test case above, the first occurrence of `I` is treated as a free variable and the second occurrence of `I` is treated as a bound variable.

   This PR adds a test case (`is_same/2`) isolating this problem.

2. Since `glb(integer(), any()) => any()`, changing to GLB makes the following should_fail test case pass: (https://github.com/josefs/Gradualizer/blob/master/test/should_fail/var_pattern_bound.erl)

   ```Erlang
   -spec var_as_pattern(atom()) -> integer().
   var_as_pattern(Atom) ->
       case get_any() of
           Atom ->
	       %% at this point still Atom :: atom()
	       %% and not Atom :: any()
               Atom
       end.
   ```

   If we think that using GLB for refining the variable type is a good idea, perhaps we will have to accept that the above example passes. In this PR I have added `guess_the_die/1` which illustrates that any() is a better choice than integer() for the variable type in this situation.