### PR TITLE
Normalize types when recursively checking nested patterns

### DIFF
--- a/test/should_pass/user_type_in_pattern_body.erl
+++ b/test/should_pass/user_type_in_pattern_body.erl
@@ -1,0 +1,24 @@
+-module(user_type_in_pattern_body).
+
+%% Check that the pattern type is normalized when recursively checking a pattern
+
+
+-export([cons/1]).
+
+-type t()  :: {}.
+
+%% Cons: The element type t() should be normalized to {}, to check that the head
+%% pattern {} has type t().
+-spec cons([t()]) -> boolean().
+cons([{} | Xs]) -> true;
+cons([])        -> false.
+
+%% Map: Key {} and value {} are of type t()
+-spec map(#{t() => t()}) -> boolean().
+map(#{{} := {}}) -> true;
+map(#{})         -> false.
+
+%% record field type normalized in patterns
+-record(r, {a :: t()}).
+-spec rec(#r{}) -> ok.
+rec(#r{a = {}}) -> ok.


### PR DESCRIPTION
The following types are normalized and thus checked properly:

* the type of the head when checking cons patterns,
* the types of map values in patterns and
* the types of record fields in patterns.