### PR TITLE
Bit syntax integer signedness

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3969,7 +3969,7 @@ type_of_bin_element({bin_element, _P, Expr, _Size, Specifiers}, Source) ->
                       end,
     IsSigned =
         case Source of
-            pattern -> length([signed || signed <- Specifiers]) > 0;
+            pattern -> lists:member(signed, Specifiers);
             expr -> true
         end,
     Types =

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4012,10 +4012,11 @@ type_of_bin_element({bin_element, _P, Expr, _Size, Specifiers}, OccursAs) ->
             %% <<"abc">>
             type(string);
         [] when IsSigned ->
-            %% <<X>>
+            %% As expr: <<X>>
+            %% As pattern: <<X/signed>>
             type(integer);
         [] when not IsSigned ->
-            %% <<X>>
+            %% As pattern: <<X>> or <<X/unsigned>>
             type(non_neg_integer);
         [T] ->
             T

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4015,6 +4015,7 @@ type_of_bin_element({bin_element, _P, Expr, _Size, Specifiers}, OccursAs) ->
             %% <<X>>
             type(integer);
         [] when not IsSigned ->
+            %% <<X>>
             type(non_neg_integer);
         [T] ->
             T

--- a/test/should_fail/bc.erl
+++ b/test/should_fail/bc.erl
@@ -1,5 +1,5 @@
 -module(bc).
--export([f/0, non_bin_expr/0]).
+-export([f/0, non_bin_expr/0, integer_signed_wrong/1]).
 
 -spec f() -> binary().
 f() ->
@@ -7,3 +7,9 @@ f() ->
 
 non_bin_expr() ->
     << (list_to_integer(X)) || X <- ["42"] >>.
+
+-spec integer_signed_wrong(binary()) -> non_neg_integer().
+integer_signed_wrong(B) ->
+    <<A/signed>> = B,
+    A.
+

--- a/test/should_pass/bc.erl
+++ b/test/should_pass/bc.erl
@@ -58,3 +58,18 @@ union_of_bitstrings(false) -> <<"xyz"/utf16-little>>.
 union_of_lists(N) when N > 42 -> [<<>>, <<N/utf16>>];
 union_of_lists(N)             -> [<<42:3>>, <<N:9>>].
 
+-spec integer_default(binary()) -> non_neg_integer().
+integer_default(B) ->
+    <<A>> = B,
+    A.
+
+-spec integer_unsigned(binary()) -> non_neg_integer().
+integer_unsigned(B) ->
+    <<A/unsigned>> = B,
+    A.
+
+-spec integer_signed(binary()) -> integer().
+integer_signed(B) ->
+    <<A/signed>> = B,
+    A.
+

--- a/test/should_pass/bc.erl
+++ b/test/should_pass/bc.erl
@@ -33,7 +33,7 @@ bc9(N) ->
 bc10(Str) ->
     << <<B:2/bytes>> || <<B:4/bytes>> <= list_to_binary(Str) >>.
 
--spec bc11(integer()) -> bitstring().
+-spec bc11(non_neg_integer()) -> bitstring().
 bc11(N) ->
     << <<B/bitstring>> || B <- union_of_lists(N), N > 0 >>.
 
@@ -43,7 +43,7 @@ ipv4_to_binary({A, B, C, D}) ->
     <<A, B, C, D>>.
 
 %% Returns a bitstring of a fixed size plus a multiple of some size
--spec unusually_sized_bitstring(integer()) -> <<_:17, _:_*3>>.
+-spec unusually_sized_bitstring(non_neg_integer()) -> <<_:17, _:_*3>>.
 unusually_sized_bitstring($a) -> <<1:17, 3:3>>;
 unusually_sized_bitstring($b) -> <<2:17, 3:6>>;
 unusually_sized_bitstring(N)  -> <<3:17, N:9>>.
@@ -54,7 +54,7 @@ union_of_bitstrings(true) -> <<0:42>>;
 union_of_bitstrings(false) -> <<"xyz"/utf16-little>>.
 
 %% Returns a union of lists of some bitstring type
--spec union_of_lists(integer()) -> [<<_:_*3>>] | [<<_:_*16>>].
+-spec union_of_lists(non_neg_integer()) -> [<<_:_*3>>] | [<<_:_*16>>].
 union_of_lists(N) when N > 42 -> [<<>>, <<N/utf16>>];
 union_of_lists(N)             -> [<<42:3>>, <<N:9>>].
 

--- a/test/should_pass/bc.erl
+++ b/test/should_pass/bc.erl
@@ -33,7 +33,7 @@ bc9(N) ->
 bc10(Str) ->
     << <<B:2/bytes>> || <<B:4/bytes>> <= list_to_binary(Str) >>.
 
--spec bc11(non_neg_integer()) -> bitstring().
+-spec bc11(integer()) -> bitstring().
 bc11(N) ->
     << <<B/bitstring>> || B <- union_of_lists(N), N > 0 >>.
 
@@ -43,7 +43,7 @@ ipv4_to_binary({A, B, C, D}) ->
     <<A, B, C, D>>.
 
 %% Returns a bitstring of a fixed size plus a multiple of some size
--spec unusually_sized_bitstring(non_neg_integer()) -> <<_:17, _:_*3>>.
+-spec unusually_sized_bitstring(integer()) -> <<_:17, _:_*3>>.
 unusually_sized_bitstring($a) -> <<1:17, 3:3>>;
 unusually_sized_bitstring($b) -> <<2:17, 3:6>>;
 unusually_sized_bitstring(N)  -> <<3:17, N:9>>.
@@ -54,7 +54,7 @@ union_of_bitstrings(true) -> <<0:42>>;
 union_of_bitstrings(false) -> <<"xyz"/utf16-little>>.
 
 %% Returns a union of lists of some bitstring type
--spec union_of_lists(non_neg_integer()) -> [<<_:_*3>>] | [<<_:_*16>>].
+-spec union_of_lists(integer()) -> [<<_:_*3>>] | [<<_:_*16>>].
 union_of_lists(N) when N > 42 -> [<<>>, <<N/utf16>>];
 union_of_lists(N)             -> [<<42:3>>, <<N:9>>].
 

--- a/test/should_pass/bc.erl
+++ b/test/should_pass/bc.erl
@@ -73,3 +73,18 @@ integer_signed(B) ->
     <<A/signed>> = B,
     A.
 
+-spec expr_vs_pat_default() -> non_neg_integer().
+expr_vs_pat_default() ->
+    <<A>> = <<-1>>,
+    A.
+
+-spec expr_vs_pat_unsigned() -> non_neg_integer().
+expr_vs_pat_unsigned() ->
+    <<A/unsigned>> = <<-1>>,
+    A.
+
+-spec expr_vs_pat_signed() -> integer().
+expr_vs_pat_signed() ->
+    <<A/signed>> = <<-1>>,
+    A.
+


### PR DESCRIPTION
According to https://erlang.org/doc/programming_examples/bit_syntax.html#defaults

The default signedness for integer is `unsigned`. Feed on the specifiers to control signedness and make the default `unsigned`, which leads to unspecified signedness going from `integer()` to `non_neg_integer()`.