### PR TITLE
Case with same var exhaustiveness

### DIFF
--- a/test/known_problems/should_pass/case_same_var.erl
+++ b/test/known_problems/should_pass/case_same_var.erl
@@ -1,0 +1,9 @@
+-module(case_same_var).
+-export([test/1]).
+
+-spec test(integer()) -> integer() | zero.
+test(I) ->
+    case I of
+        0 -> zero;
+        I -> I
+    end.


### PR DESCRIPTION
```erlang
-module(test2).

-spec test1(integer()) -> integer() | zero.
test1(0) -> zero;
test1(I) -> I.

-spec test2(integer()) -> integer() | zero.
test2(I) ->
    case I of
        0 -> zero;
        I -> I
    end.
```

I would say both are equivalent but the second fail with this

```text
Nonexhaustive patterns on line 10 at column 9
Example values which are not covered: [-1]
```

Probably need a special case for matching on the same variable, which would always be true.