### PR TITLE
Expand dirs in rebar so exclusion works

### DIFF
--- a/src/rebar_prv_gradualizer.erl
+++ b/src/rebar_prv_gradualizer.erl
@@ -54,13 +54,21 @@ files_to_check(App) ->
     Files = lists:flatmap(fun (Pattern) ->
             filelib:wildcard(filename:absname(Pattern, Cwd))
         end, Patterns),
+    ExpandedFiles = lists:flatmap(fun (Dir) ->
+            case filelib:is_dir(Dir) of
+                true ->
+                    filelib:wildcard(filename:join(Dir, "*.{erl,beam}"));
+                false ->
+                    [Dir]
+            end
+        end, Files),
     ExpandedExclude = lists:flatmap(fun (Pattern) ->
                 filelib:wildcard(filename:absname(Pattern, Cwd))
             end, Exclude),
     lists:filter(
         fun (File) ->
             not lists:member(File, ExpandedExclude)
-        end, Files).
+        end, ExpandedFiles).
 
 -spec format_error(any()) -> string().
 format_error(_) ->


### PR DESCRIPTION
In the rebar portion of `gradualizer_opts`, `include` and `exclude` are supposed to work in tandem. According to https://github.com/josefs/Gradualizer/blob/master/examples/rebar3/README.md#exclude, excludes are substracted from includes. The problem is if you include folders but try to exclude specific files, this will not work.

In the include you would get `src/folder` and the exclude you would have `src/folder/file.erl`, the file would still be included. This fixes this issue.

There's not really any tests for this but I ran across this while integrating. The file is even ignored in the test coverage.