### PR TITLE
Compile test data before gradualizing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test/covertool.hrl
 /gradualizer
 /_build
 /bin/
+/test_data/

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ clean:
 	rm -rf bin/gradualizer ebin cover test/*.beam
 
 .PHONY: tests eunit compile-tests cli-tests
-tests: eunit cli-tests
+tests: build_test_data eunit cli-tests
 
 test_erls=$(wildcard test/*.erl)
 test_beams=$(test_erls:test/%.erl=test/%.beam)
@@ -124,6 +124,12 @@ test/any.beam: test/should_pass/any.erl
 
 test/records.beam: test/should_pass/records.erl
 	erlc $(ERLC_OPTS) -o test $<
+
+.PHONY: build_test_data
+test_data_erls = $(wildcard test/known_problems/**/*.erl test/should_fail/*.erl test/should_pass/*.erl)
+build_test_data:
+	mkdir -p "test_data"
+	erlc -o test_data $(test_data_erls)
 
 EUNIT_OPTS =
 

--- a/test/known_problems/should_fail/intersection_with_any_fail.erl
+++ b/test/known_problems/should_fail/intersection_with_any_fail.erl
@@ -1,20 +1,12 @@
 -module(intersection_with_any_fail).
 
 -export([any_refined_using_guard/1,
-         intersection_using_constraits/1,
          var_as_pattern/1,
          var_inside_pattern/1]).
 
 %% X :: any() & atom() by refinement
 -spec any_refined_using_guard(any()) -> 5.
 any_refined_using_guard(X) when is_atom(X) ->
-    X.
-
-%% X :: integer() & any() by the constraints
--spec intersection_using_constraits(X) when X :: integer(),
-                                            X :: any() ->
-                                                      atom().
-intersection_using_constraits(X) ->
     X.
 
 -spec var_as_pattern(atom()) -> integer().

--- a/test/known_problems/should_pass/refine_bound_var_on_mismatch.erl
+++ b/test/known_problems/should_pass/refine_bound_var_on_mismatch.erl
@@ -3,8 +3,7 @@
 %% Note: Here we're refining an already bound variable
 
 -export([refined_var_not_matching_itself/1,
-         refine_bound_var_by_pattern_mismatch/1,
-         refine_bound_var_by_guard_bifs/1]).
+         refine_bound_var_by_pattern_mismatch/1]).
 
 %% Current error: Var is expected to have type y | z but has type x | y | z
 -spec refined_var_not_matching_itself(x | y | z) -> ok.

--- a/test/should_fail/intersection_with_any.erl
+++ b/test/should_fail/intersection_with_any.erl
@@ -1,0 +1,8 @@
+-module(intersection_with_any).
+
+-export([intersection_using_constraints/1]).
+
+%% X :: integer() & any() by the constraints
+-spec intersection_using_constraints(X) -> 5 when X :: integer(), X :: any().
+intersection_using_constraints(X) ->
+    X.

--- a/test/should_fail/named_fun_infer.erl
+++ b/test/should_fail/named_fun_infer.erl
@@ -1,4 +1,4 @@
--module(named_fun).
+-module(named_fun_infer).
 
 -gradualizer(infer).
 -export([bar/0, sum/1]).

--- a/test/should_fail/send.erl
+++ b/test/should_fail/send.erl
@@ -1,4 +1,4 @@
--module(send_expr).
+-module(send).
 
 -export([foo/2, bar/2]).
 

--- a/test/should_fail/type_refinement.erl
+++ b/test/should_fail/type_refinement.erl
@@ -19,11 +19,11 @@ imprecision_prevents_refinement(_, X) -> X.
 multi_pat_fail_1(a, a) -> {b, b};
 multi_pat_fail_1(A, B) -> {A, B}. %% Not only {b, b} here
 
--spec guard_prevents_refinement2(timestamp()) -> ok.
+-spec guard_prevents_refinement2(erlang:timestamp()) -> ok.
 guard_prevents_refinement2(X) when is_integer(X), X rem 7 == 0 -> ok;
 guard_prevents_refinement2(infinity) -> ok. % can still be an integer
 
--spec pattern_prevents_refinement(timestamp(), any()) -> atom().
+-spec pattern_prevents_refinement(erlang:timestamp(), any()) -> atom().
 pattern_prevents_refinement(X, X)    when is_integer(X) -> ok;
 pattern_prevents_refinement(X, {_Y}) when is_integer(X) -> ok;
 pattern_prevents_refinement(Inf, _) -> Inf. % Inf can still be an integer

--- a/test/should_pass/annotated_types.erl
+++ b/test/should_pass/annotated_types.erl
@@ -2,7 +2,7 @@
 
 -export([f/1, g/0, h/1, i/1]).
 
--include_lib("gradualizer/include/gradualizer.hrl").
+-include_lib("../../include/gradualizer.hrl").
 
 f(Expr) ->
     {call, _, _Name, Args} = Expr,

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -7,8 +7,8 @@ atom(A) when is_atom(A) -> A;
 atom(_) -> not_atom.
 
 -spec atom2(atom() | integer()) -> atom() | not_atom.
-atom(A) when erlang:is_atom(A) -> A;
-atom(_) -> not_atom.
+atom2(A) when erlang:is_atom(A) -> A;
+atom2(_) -> not_atom.
 
 -spec binary(binary() | atom()) -> binary() | not_binary.
 binary(B) when is_binary(B) -> B;

--- a/test/should_pass/intersection_with_any.erl
+++ b/test/should_pass/intersection_with_any.erl
@@ -7,9 +7,9 @@
 -spec any_refined_using_guard(any()) -> 5.
 any_refined_using_guard(X) when is_integer(X) -> X.
 
--spec intersection_using_constraints(X) when X :: integer(),
-                                             X :: any() ->
-                                                       5.
+-spec intersection_using_constraints(X) -> X when
+                                                X :: integer(),
+                                                X :: any().
 intersection_using_constraints(X) -> X.
 
 -spec guess_two_dice(integer(), integer()) -> 0..6.

--- a/test/should_pass/named_fun_infer.erl
+++ b/test/should_pass/named_fun_infer.erl
@@ -1,4 +1,4 @@
--module(named_fun).
+-module(named_fun_infer).
 
 -gradualizer(infer).
 -export([atom_sum/1]).

--- a/test/should_pass/pattern_record.erl
+++ b/test/should_pass/pattern_record.erl
@@ -36,7 +36,7 @@ pat_match2(T) ->
     f :: atom()
 }).
 
--spec pass(#r1{} | #r2{}) -> integer().
+-spec good(#r1{} | #r2{}) -> integer().
 good(R = #r1{f = F}) -> R#r1.f + F;
 good(_) -> 0.
 

--- a/test/should_pass/send.erl
+++ b/test/should_pass/send.erl
@@ -1,4 +1,4 @@
--module(send_expr).
+-module(send).
 
 -export([foo/2, bar/2]).
 


### PR DESCRIPTION
1. Check that test files (in `test/known_problems`, `test/should_fail` and `test/should_pass`) are compilable. (Checking this revealed that there were some nits/flaws/typos in test files - and sometimes failure was not attributed correctly, - eg `intersection_using_constraits` - it had a parse error, which was considered as gradualizer error).
2. Fixing broken test files. - The most interesting cases are `intersection_using_constraints` - which actually worked, but were reported incorrectly because of parse errors.

- See CI status: https://github.com/ilya-klyuchnikov/Gradualizer/commits/upstream-test

![Screenshot 2020-12-10 at 23 41 30](https://user-images.githubusercontent.com/273180/101843032-4155ff00-3b41-11eb-9d78-5a34aa7cc2aa.png)

Not trying to compile `mix` - since it has `undefined_errors.erl` - many of them are caught by the compiler in the first place (undefined var, undefined local funs, etc).

-------------

Next possible step - to introduce "snapshot" testing of errors - https://github.com/ilya-klyuchnikov/Gradualizer/commit/8b4784f3f8221b06393fdd6ef598c97291c8f0ba - which makes reviewing of PRs easier and more comprehensible - having both input and precise expected output (with locations/highlighting) for a test case in the repo.

