### PR TITLE
error messages: always printing filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,30 +149,15 @@ cli-tests: bin/gradualizer
 	# 1. When checking a dir; printing filename is the default
 	bin/gradualizer test/dir \
 	2>&1|perl -0777 -ne 'm%^test/dir/test_in_dir.erl:% or die "CLI 1 ($$_)"'
-	# 2. --no-print-file with directory
-	bin/gradualizer --no_print_file test/dir \
-	2>&1|perl -0777 -ne '/^The/ or die "CLI 2 ($$_)"'
-	# 3. --print-module with directory
-	bin/gradualizer --print_module test/dir \
-	2>&1|perl -0777 -ne '/^test_in_dir:/ or die "CLI 3 ($$_)"'
-	# 4. --print-basename with directory
-	bin/gradualizer --print_basename test/dir \
-	2>&1|perl -0777 -ne '/^test_in_dir.erl:/ or die "CLI 4 ($$_)"'
-	# 5. Checking a single file; not printing filename is the default
-	bin/gradualizer test/dir/test_in_dir.erl \
-	2>&1|perl -0777 -ne '/^The/ or die "CLI 5 ($$_)"'
 	# 6. Brief formatting
-	bin/gradualizer --fmt_location brief --print_basename test/dir \
-	2>&1|perl -0777 -ne '/^test_in_dir.erl:6:12: The variable/ or die "CLI 6 ($$_)"'
+	bin/gradualizer --fmt_location brief test/dir \
+	2>&1|perl -0777 -ne '/^test\/dir\/test_in_dir.erl:6:12: The variable/ or die "CLI 6 ($$_)"'
 	# 7. Verbose formatting, without filename
-	bin/gradualizer --fmt_location verbose --no_print_file --no_fancy test/dir \
-	2>&1|perl -ne '/^The variable N on line 6 at column 12/ or die "CLI 7 ($$_)"'
-	# 8. No location, no filename
-	bin/gradualizer --fmt_location none --no_print_file --no_fancy test/dir/test_in_dir.erl \
-	2>&1|perl -ne '/^The variable N is expected/ or die "CLI 8 ($$_)"'
+	bin/gradualizer --fmt_location verbose --no_fancy test/dir \
+	2>&1|perl -ne '/^test\/dir\/test_in_dir.erl: The variable N on line 6 at column 12/ or die "CLI 7 ($$_)"'
 	# 9. Possible to exclude prelude (-0777 from https://stackoverflow.com/a/30594643/497116)
 	bin/gradualizer --no_prelude test/should_pass/cyclic_otp_specs.erl \
-	2>&1|perl -0777 -ne '/^The type spec/g or die "CLI 9 ($$_)"'
+	2>&1|perl -0777 -ne '/^test\/should_pass\/cyclic_otp_specs.erl: The type spec/g or die "CLI 9 ($$_)"'
 	# 10. Excluding prelude and then including it is a no-op
 	bin/gradualizer --no_prelude --specs_override_dir priv/prelude \
 	  test/should_pass/cyclic_otp_specs.erl || (echo "CLI 10"; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,9 @@ test/any.beam: test/should_pass/any.erl
 test/records.beam: test/should_pass/records.erl
 	erlc $(ERLC_OPTS) -o test $<
 
+test/arg.beam: test/should_fail/arg.erl
+	erlc $(ERLC_OPTS) -o test $<
+
 .PHONY: build_test_data
 test_data_erls = $(wildcard test/known_problems/**/*.erl test/should_fail/*.erl test/should_pass/*.erl)
 build_test_data:
@@ -144,21 +147,24 @@ eunit: compile-tests
 	erl -noinput -pa ebin -pa test -eval \
 	 '$(erl_run_eunit), halt().'
 
-cli-tests: bin/gradualizer
+cli-tests: bin/gradualizer test/arg.beam
 	# CLI test cases
-	# 1. When checking a dir; printing filename is the default
+	# 1. When checking a dir with erl files, erl file names are printed
 	bin/gradualizer test/dir \
 	2>&1|perl -0777 -ne 'm%^test/dir/test_in_dir.erl:% or die "CLI 1 ($$_)"'
-	# 6. Brief formatting
+	# 2. When checking a beam file; beam file name is printed
+	bin/gradualizer test/arg.beam \
+	2>&1|perl -0777 -ne 'm%^test/arg.beam:% or die "CLI 1 ($$_)"'
+	# 4. Brief formatting
 	bin/gradualizer --fmt_location brief test/dir \
 	2>&1|perl -0777 -ne '/^test\/dir\/test_in_dir.erl:6:12: The variable/ or die "CLI 6 ($$_)"'
-	# 7. Verbose formatting, without filename
+	# 5. Verbose formatting, without filename
 	bin/gradualizer --fmt_location verbose --no_fancy test/dir \
 	2>&1|perl -ne '/^test\/dir\/test_in_dir.erl: The variable N on line 6 at column 12/ or die "CLI 7 ($$_)"'
-	# 9. Possible to exclude prelude (-0777 from https://stackoverflow.com/a/30594643/497116)
+	# 6. Possible to exclude prelude (-0777 from https://stackoverflow.com/a/30594643/497116)
 	bin/gradualizer --no_prelude test/should_pass/cyclic_otp_specs.erl \
 	2>&1|perl -0777 -ne '/^test\/should_pass\/cyclic_otp_specs.erl: The type spec/g or die "CLI 9 ($$_)"'
-	# 10. Excluding prelude and then including it is a no-op
+	# 7. Excluding prelude and then including it is a no-op
 	bin/gradualizer --no_prelude --specs_override_dir priv/prelude \
 	  test/should_pass/cyclic_otp_specs.erl || (echo "CLI 10"; exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -155,16 +155,16 @@ cli-tests: bin/gradualizer test/arg.beam
 	# 2. When checking a beam file; beam file name is printed
 	bin/gradualizer test/arg.beam \
 	2>&1|perl -0777 -ne 'm%^test/arg.beam:% or die "CLI 1 ($$_)"'
-	# 4. Brief formatting
+	# 3. Brief formatting
 	bin/gradualizer --fmt_location brief test/dir \
 	2>&1|perl -0777 -ne '/^test\/dir\/test_in_dir.erl:6:12: The variable/ or die "CLI 6 ($$_)"'
-	# 5. Verbose formatting, without filename
+	# 4. Verbose formatting
 	bin/gradualizer --fmt_location verbose --no_fancy test/dir \
 	2>&1|perl -ne '/^test\/dir\/test_in_dir.erl: The variable N on line 6 at column 12/ or die "CLI 7 ($$_)"'
-	# 6. Possible to exclude prelude (-0777 from https://stackoverflow.com/a/30594643/497116)
+	# 5. Possible to exclude prelude (-0777 from https://stackoverflow.com/a/30594643/497116)
 	bin/gradualizer --no_prelude test/should_pass/cyclic_otp_specs.erl \
 	2>&1|perl -0777 -ne '/^test\/should_pass\/cyclic_otp_specs.erl: The type spec/g or die "CLI 9 ($$_)"'
-	# 7. Excluding prelude and then including it is a no-op
+	# 6. Excluding prelude and then including it is a no-op
 	bin/gradualizer --no_prelude --specs_override_dir priv/prelude \
 	  test/should_pass/cyclic_otp_specs.erl || (echo "CLI 10"; exit 1)
 

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -196,7 +196,7 @@ type_check_forms(File, Forms, Opts) ->
             ok;
         {false, [_|_]} ->
             Opts1 = add_source_file_and_forms_to_opts(File, Forms, Opts),
-            typechecker:print_errors(Errors, Opts1),
+            gradualizer_fmt:print_errors(Errors, Opts1),
             nok
     end.
 

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -6,8 +6,6 @@
 %%% - `stop_on_first_error': if `true' stop type checking at the first error,
 %%%   if `false' continue checking all functions in the given file and all files
 %%%   in the given directory.
-%%% - `{print_file, true | false | module | basename}': if `true' prefix error
-%%%   printouts with the file name the error is from. Default `false'.
 %%% - `crash_on_error': if `true' crash on the first produced error
 %%% - `return_errors': if `true', turns off error printing and errors
 %%%   (in their internal format) are returned in a list instead of being
@@ -71,21 +69,9 @@ type_check_file(File, Opts) ->
         end,
     case ParsedFile of
         {ok, Forms} ->
-            Opts2 = add_filename_to_opts(File, Opts),
-            type_check_forms(File, Forms, Opts2);
+            type_check_forms(File, Forms, Opts);
         Error ->
             throw(Error)
-    end.
-
-%% @doc Prepends `{filename, string()}', depending on whether and how the
-%%      filename should be printed according to the print_file option in Opts.
-add_filename_to_opts(Filename, Opts) ->
-    case proplists:get_value(print_file, Opts, false) of
-        false    -> Opts;
-        true     -> [{filename, Filename} | Opts];
-        basename -> [{filename, filename:basename(Filename)} | Opts];
-        module   -> [{filename, filename:rootname(
-                                  filename:basename(Filename))} | Opts]
     end.
 
 %% @doc Type check a module
@@ -201,7 +187,7 @@ type_check_forms(File, Forms, Opts) ->
     end.
 
 add_source_file_and_forms_to_opts(File, Forms, Opts) ->
-    Opts1 = [{forms, Forms}|Opts],
+    Opts1 = [{filename, File}, {forms, Forms} | Opts],
     case filename:extension(File) == ".erl" andalso filelib:is_file(File) of
         true -> [{source_file, File} | Opts1];
         false -> Opts1

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -29,27 +29,12 @@ handle_args(Args) ->
                 HasVersion -> version;
                 Rest =:= [] -> {error, "No files specified to check (try --)"};
                 true ->
-                    Opts1 = add_default_print_file_to_opts(Rest, Opts),
-                    {ok, Rest, Opts1}
+                    {ok, Rest, Opts}
             end
     catch
         error:Message when is_list(Message) ->
             {error, Message}
     end.
-
-%% Adds print_file option if there are more than one file to check and
-%% the print_file is not already specified.
--spec add_default_print_file_to_opts(FilesToCheck :: list(),
-                                     gradualizer:options()) ->
-                                            gradualizer:options().
-add_default_print_file_to_opts(Files, Opts) ->
-    [print_file || not proplists:is_defined(print_file, Opts),
-                   is_multiple_files(Files)] ++ Opts.
-
--spec is_multiple_files(FilesToCheck :: list()) -> boolean().
-is_multiple_files([])     -> false;
-is_multiple_files([Path]) -> filelib:is_dir(Path);
-is_multiple_files(_)      -> true.
 
 -spec get_ver(atom()) -> string().
 get_ver(App) ->
@@ -77,13 +62,6 @@ print_usage() ->
     io:format("                                 the code path; see erl -pa             [string]~n"),
     io:format("  -I                             Include path for Erlang source files; see -I in~n"),
     io:format("                                 the manual page erlc(1)~n"),
-    io:format("       --print_file              prefix error printouts with the file name~n"),
-    io:format("                                  - the default when checking a directory or more~n"),
-    io:format("                                    than one file~n"),
-    io:format("       --print_basename          prefix error printouts with the file basename~n"),
-    io:format("       --print_module            prefix error printouts with the module~n"),
-    io:format("       --no_print_file           inverse of --print-file~n"),
-    io:format("                                  - the default when checking a single file~n"),
     io:format("       --stop_on_first_error     stop type checking at the first error~n"),
     io:format("       --no_stop_on_first_error  inverse of --stop-on-first-error~n"),
     io:format("                                  - the default behaviour~n"),
@@ -117,10 +95,6 @@ parse_opts([A | Args], Opts) ->
         "-pa"                      -> handle_path_add(A, Args, Opts);
         "--path_add"               -> handle_path_add(A, Args, Opts);
         "-I"                       -> handle_include_path(A, Args, Opts);
-        "--print_file"             -> parse_opts(Args, [print_file | Opts]);
-        "--print_module"           -> parse_opts(Args, [{print_file, module} | Opts]);
-        "--print_basename"         -> parse_opts(Args, [{print_file, basename} | Opts]);
-        "--no_print_file"          -> parse_opts(Args, [{print_file, false} | Opts]);
         "--stop_on_first_error"    -> parse_opts(Args, [stop_on_first_error | Opts]);
         "--no_stop_on_first_error" -> parse_opts(Args, [{stop_on_first_error, false} | Opts]);
         "--crash_on_error"         -> parse_opts(Args, [crash_on_error | Opts]);

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -1,5 +1,5 @@
 -module(gradualizer_fmt).
--export([format_location/2, format_type_error/2]).
+-export([format_location/2, format_type_error/2, print_errors/2, handle_type_error/2]).
 
 -include("typelib.hrl").
 
@@ -490,3 +490,20 @@ pp_type(Ty, Opts) ->
         true  -> [?color_type, PP, ?color_end];
         false -> PP
     end.
+
+print_errors(Errors, Opts) ->
+    [print_error(Error, Opts) || Error <- Errors],
+    ok.
+
+print_error(Error, Opts) ->
+    File = proplists:get_value(filename, Opts),
+    FmtLoc = proplists:get_value(fmt_location, Opts, verbose),
+    case File of
+        undefined -> ok;
+        _ when FmtLoc =:= brief -> io:format("~s:", [File]);
+        _  -> io:format("~s: ", [File])
+    end,
+    handle_type_error(Error, Opts).
+
+handle_type_error(Error, Opts) ->
+    io:put_chars(gradualizer_fmt:format_type_error(Error, Opts)).

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1,9 +1,7 @@
 -module(typechecker).
 
 %% API used by gradualizer.erl
--export([type_check_forms/2,
-         print_errors/2
-        ]).
+-export([type_check_forms/2]).
 
 %% Export all for easier testing and debugging while the project is
 %% still in an early stage
@@ -4501,24 +4499,6 @@ number_of_exported_functions(Forms) ->
         true -> length(ParseData#parsedata.functions);
         false -> length(ParseData#parsedata.exports)
     end.
-
-%% TODO: Move these functions to gradualizer or gradualizer_fmt.
-print_errors(Errors, Opts) ->
-    [print_error(Error, Opts) || Error <- Errors],
-    ok.
-
-print_error(Error, Opts) ->
-    File = proplists:get_value(filename, Opts),
-    FmtLoc = proplists:get_value(fmt_location, Opts, verbose),
-    case File of
-        undefined -> ok;
-        _ when FmtLoc =:= brief -> io:format("~s:", [File]);
-        _  -> io:format("~s: ", [File])
-    end,
-    handle_type_error(Error, Opts).
-
-handle_type_error(Error, Opts) ->
-    io:put_chars(gradualizer_fmt:format_type_error(Error, Opts)).
 
 line_no(Expr) ->
     erl_anno:line(element(2, Expr)).

--- a/test/gradualizer_cli_tests.erl
+++ b/test/gradualizer_cli_tests.erl
@@ -16,16 +16,6 @@ help_output_no_halt_test() ->
 version_test() ->
     ?assertEqual(version, gradualizer_cli:handle_args(["--version"])).
 
-defaults_single_file_test() ->
-    ?assertEqual({ok, ["file.erl"], []},
-                 gradualizer_cli:handle_args(["file.erl"])).
-defaults_multi_file_test() ->
-    ?assertEqual({ok, ["m1.erl", "m2.erl"], [print_file]},
-                 gradualizer_cli:handle_args(["m1.erl", "m2.erl"])).
-defaults_dir_test() ->
-    ?assertEqual({ok, ["test/dir"], [print_file]},
-                 gradualizer_cli:handle_args(["test/dir"])).
-
 no_file_test() ->
     ?assertMatch({error, "No files"++_},
                  gradualizer_cli:handle_args(["--infer"])).
@@ -66,19 +56,6 @@ pa_test_() ->
      ?_assertMatch({error, "No files"++_}, gradualizer_cli:handle_args(["--path_add", "ebin", "file.erl"])),
      ?_assertMatch({error, "No files"++_}, gradualizer_cli:handle_args(["-pa", "ebin", "file.erl"])),
      ?_assertMatch({error, "Missing "++_}, gradualizer_cli:handle_args(["-pa", "--", "file.erl"]))].
-
-print_file_true_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--print_file", "file.erl"]),
-    ?assertEqual(true, proplists:get_value(print_file, Opts)).
-print_file_module_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--print_module", "file.erl"]),
-    ?assertEqual(module, proplists:get_value(print_file, Opts)).
-print_file_basename_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--print_basename", "file.erl"]),
-    ?assertEqual(basename, proplists:get_value(print_file, Opts)).
-print_file_false_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no_print_file", "file.erl"]),
-    ?assertEqual(false, proplists:get_value(print_file, Opts)).
 
 stop_on_first_error_test() ->
     {ok, _Files, Opts} = gradualizer_cli:handle_args(["--stop_on_first_error", "file.erl"]),

--- a/test/test.erl
+++ b/test/test.erl
@@ -41,7 +41,7 @@ gen_should_fail() ->
                     %% Test that error formatting doesn't crash
                     Opts = [{fmt_location, brief},
                         {fmt_expr_fun, fun erl_prettypr:format/1}],
-                    lists:foreach(fun({_, Error}) -> typechecker:handle_type_error(Error, Opts) end, Errors),
+                    lists:foreach(fun({_, Error}) -> gradualizer_fmt:handle_type_error(Error, Opts) end, Errors),
                     {ok, Forms} = gradualizer_file_utils:get_forms_from_erl(File, []),
                     ExpectedErrors = typechecker:number_of_exported_functions(Forms),
                     ?assertEqual(ExpectedErrors, length(Errors))

--- a/test/undefined_errors_test.erl
+++ b/test/undefined_errors_test.erl
@@ -20,7 +20,7 @@ undefined_errors_test_() ->
         %% Test that error formatting doesn't crash
         Opts = [{fmt_location, brief},
                 {fmt_expr_fun, fun erl_prettypr:format/1}],
-        lists:foreach(fun({_, Error}) -> typechecker:handle_type_error(Error, Opts) end, Errors),
+        lists:foreach(fun({_, Error}) -> gradualizer_fmt:handle_type_error(Error, Opts) end, Errors),
         {ok, Forms} = gradualizer_file_utils:get_forms_from_erl(File, []),
         ExpectedErrors = typechecker:number_of_exported_functions(Forms),
         ?assertEqual(ExpectedErrors, length(Errors))


### PR DESCRIPTION
Per discussion in https://github.com/josefs/Gradualizer/issues/300#issuecomment-743126933

This PR:
- error printing is moved from typechecker into gradualizer_fmt
- Filename is always printed (no matter what). Fewer options, fewer code paths
- Tests are modified accordingly: tests checking how different options (about filename) are propagated down the line are just removed from `gradualizer_cli.erl`
- `cli-tests` in Makefile are modified accordingly. - Also testing that `*.beam` vs `*.erl` files are reported correctly.

----

The default/only format of printing - `filename: verbose message (XXX at line L column C ...)` vs `filename:L short message (XXX ...)` - is out of scope of this PR and can be discussed/PRed separately. 