### PR TITLE
Issue: arith_op_arg_types/2 for '-' and non_neg_integer() is too restricitve

### DIFF
--- a/test/known_problems/should_pass/arith_op_arg_types.erl
+++ b/test/known_problems/should_pass/arith_op_arg_types.erl
@@ -1,0 +1,15 @@
+-module(arith_op_arg_types).
+
+-export([arg1/0, arg2/0]).
+
+%% The issue is that arith_op_arg_types/2 for '-' and non_neg_integer() as return type is too
+%% restricitve.
+%% "The integer is expected to have type pos_integer() but it has type 0"
+-spec arg1() -> non_neg_integer().
+arg1() ->
+    0 - 0.
+
+%% "The integer is expected to have type 1 but it has type 2"
+-spec arg2() -> non_neg_integer().
+arg2() ->
+    3 - 2.


### PR DESCRIPTION
Historically this function was probably used to encode:
IF A :: pos_integer() AND B :: 1 => (A - B) :: non_neg_integer()

However the logic is now flipped:
IF (A - B) :: non_neg_integer() => A :: pos_integer() AND B :: 1

I only hit this particular [clause](https://github.com/josefs/Gradualizer/blob/d973b3ee/src/typechecker.erl#L2531), but there could be further issues given the flip