### PR TITLE
typechecker: toggle exhaustiveness checking for records

### DIFF
--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -47,11 +47,9 @@ format_type_error({type_error, Expression, ActualType, ExpectedType}, Opts)
     format_expr_type_error(Expression, ActualType, ExpectedType, Opts);
 format_type_error({nonexhaustive, Anno, Example}, Opts) ->
     FormattedExample =
-        case Example of
-            X when not is_list(X) -> io_lib:format("~p", [X]);
-            %% X is a list, only records are formatted as io_lists,
-            %% Add a newline for readability and formatting
-            X -> ["\n", X]
+        case io_lib:deep_char_list(Example) of
+            true -> ["\n", Example];
+            false -> io_lib:format("~p", [Example])
         end,
     io_lib:format(
       "~sNonexhaustive patterns~s~n"

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -47,13 +47,16 @@ format_type_error({type_error, Expression, ActualType, ExpectedType}, Opts)
     format_expr_type_error(Expression, ActualType, ExpectedType, Opts);
 format_type_error({nonexhaustive, Anno, Example}, Opts) ->
     FormattedExample =
-        case io_lib:deep_char_list(Example) of
-            true -> ["\n", Example];
-            false -> io_lib:format("~p", [Example])
+        case Example of
+            [X | Xs] ->
+                lists:foldl(fun(A, Acc) ->
+                    [erl_pp:expr(A), $\n | Acc]
+                end, [erl_pp:expr(X)], Xs);
+            X -> erl_pp:expr(X)
         end,
     io_lib:format(
       "~sNonexhaustive patterns~s~n"
-      "Example values which are not covered: ~s~n",
+      "Example values which are not covered:~n\t~s~n",
       [format_location(Anno, brief, Opts),
        format_location(Anno, verbose, Opts),
        FormattedExample]);

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -46,12 +46,19 @@ format_type_error({type_error, Expression, ActualType, ExpectedType}, Opts)
   when is_tuple(Expression) ->
     format_expr_type_error(Expression, ActualType, ExpectedType, Opts);
 format_type_error({nonexhaustive, Anno, Example}, Opts) ->
+    FormattedExample =
+        case Example of
+            X when not is_list(X) -> io_lib:format("~p", [X]);
+            %% X is a list, only records are formatted as io_lists,
+            %% Add a newline for readability and formatting
+            X -> ["\n", X]
+        end,
     io_lib:format(
       "~sNonexhaustive patterns~s~n"
-      "Example values which are not covered: ~p~n",
+      "Example values which are not covered: ~s~n",
       [format_location(Anno, brief, Opts),
        format_location(Anno, verbose, Opts),
-       Example]);
+       FormattedExample]);
 format_type_error({call_undef, Anno, Func, Arity}, Opts) ->
     io_lib:format(
       "~sCall to undefined function ~p/~p~s~n",

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -49,9 +49,11 @@ format_type_error({nonexhaustive, Anno, Example}, Opts) ->
     FormattedExample =
         case Example of
             [X | Xs] ->
-                lists:foldl(fun(A, Acc) ->
-                    [erl_pp:expr(A), $\n | Acc]
-                end, [erl_pp:expr(X)], Xs);
+                lists:reverse(
+                    lists:foldl(fun(A, Acc) ->
+                        [erl_pp:expr(A), $\n | Acc]
+                    end, [erl_pp:expr(X)], Xs)
+                );
             X -> erl_pp:expr(X)
         end,
     io_lib:format(

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -51,7 +51,7 @@ format_type_error({nonexhaustive, Anno, Example}, Opts) ->
             [X | Xs] ->
                 lists:reverse(
                     lists:foldl(fun(A, Acc) ->
-                        [erl_pp:expr(A), $\n | Acc]
+                        [erl_pp:expr(A), "\n\t" | Acc]
                     end, [erl_pp:expr(X)], Xs)
                 );
             X -> erl_pp:expr(X)

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -9,7 +9,7 @@
 -define(type(T), {type, _, T, []}).
 -define(type(T, A), {type, _, T, A}).
 
-%% Prettyprinting Records nesting spaces (or tabs)
+%% Number of space used when prettyprinting records for nesting
 -define(PP_RECORD_NESTING_OFFSET, 2).
 
 %% merge_with for maps. Similar to merge_with for dicts.
@@ -144,6 +144,7 @@ prettyprint(Record) ->
         end,
     prettypr:format(Doc).
 
+-spec pp_record(gradualizer_type:abstract_type()) -> prettyprint:document() | [prettyprint:document()].
 pp_record(?type(record, [{atom, _, RecName} | Fields])) ->
     PPFields = pp_record_fields(Fields),
     %% We return a list instead of a document to achieve "C-style" nesting of tuples/records.
@@ -151,19 +152,20 @@ pp_record(?type(record, [{atom, _, RecName} | Fields])) ->
     %% to align the field nesting with the name of the field;
     %% otherwise, the nesting would be aligned with the name of the record.
     [
-        prettypr:text(["#", atom_to_list(RecName), "{"]),
+        prettypr:text(lists:concat(["#", atom_to_list(RecName), "{"])),
         prettypr:nest(?PP_RECORD_NESTING_OFFSET, PPFields),
         prettypr:text("}")
     ];
 pp_record(?type(field_type, [{atom, _, FieldName}, FieldValue])) ->
     Val = lists:flatten([pp_record(FieldValue)]),
     prettypr:par([
-        prettypr:text([atom_to_list(FieldName), " ="])
+        prettypr:text(atom_to_list(FieldName) ++ " =")
         | Val
     ], 0);
 pp_record(Value) ->
     prettypr:text(io_lib:format("~p", [pick_value(Value)])).
 
+-spec pp_record_fields([gradualizer_type:abstract_type()]) -> prettyprint:document().
 pp_record_fields([X | Tail]) ->
     %% Format all fields with a separator between
     %% The fold of prettypr:beside is not done in one go because
@@ -175,6 +177,7 @@ pp_record_fields([X | Tail]) ->
 pp_record_fields(_) ->
     prettypr:empty().
 
+% -spec pp_record_fields([prettyprint:document()], [prettyprint:document()]) -> prettyprint:document().
 pp_record_fields([], Acc) ->
     Acc;
 pp_record_fields([X, sep | Tail], Acc) ->

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -109,6 +109,8 @@ pick_value(?type(tuple, any)) ->
     {};
 pick_value(?type(tuple, Tys)) ->
     list_to_tuple([pick_value(Ty) || Ty <- Tys]);
+pick_value(Rec = ?type(record, _)) ->
+    typelib:pp_type(Rec);
 pick_value(?type(list)) ->
     [];
 pick_value(?type(list,_)) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3463,6 +3463,8 @@ refinable(?type(union,Tys)) when is_list(Tys) ->
     lists:all(fun refinable/1, Tys);
 refinable(?type(tuple, Tys)) when is_list(Tys) ->
     lists:all(fun refinable/1, Tys);
+refinable(?type(record, [_ | Fields])) ->
+    lists:all(fun refinable/1, [X || ?type(field_type, X) <- Fields]);
 refinable(_) ->
     false.
 

--- a/test/should_fail/record_exhaustive.erl
+++ b/test/should_fail/record_exhaustive.erl
@@ -1,0 +1,53 @@
+-module(record_exhaustive).
+
+-compile(export_all).
+
+-record(inner, {
+    field :: integer()
+}).
+
+-record(record_one_field, {
+    inner_rec :: #inner{} | undefined
+}).
+
+-record(record_two_fields, {
+    a :: #record_one_field{},
+    b :: integer() | undefined
+}).
+
+-spec one_field(#record_one_field{} | undefined) -> integer().
+one_field(#record_one_field{inner_rec = InnerRec = #inner{}}) -> InnerRec#inner.field;
+%% unhandled
+%%one_field(#record_one_field{field = undefined}) -> -1;
+one_field(undefined) -> 0.
+
+-spec two_fields(#record_two_fields{} | undefined) -> integer().
+two_fields(#record_two_fields{a = #record_one_field{inner_rec = InnerRec = #inner{}}}) -> InnerRec#inner.field;
+%% unhandled
+%%two_fields(#record_two_fields{a = #record_one_field{inner_rec = undefined}}) -> 2;
+two_fields(#record_two_fields{b = undefined}) -> 0;
+%% unhandled
+%%two_fields(#record_two_fields{b = B}) when is_integer(B) -> B;
+two_fields(undefined) -> 0.
+
+%% -spec test5(#record_two_fields{} | undefined) -> integer().
+%% test5(#record_two_fields{a = #record_one_field{field = Field = #inner{}}}) -> Field#inner.field;
+%% %% unhandled
+%% %%test5(#record_two_fields{a = #record_one_field{field = undefined}}) -> 2;
+%% test5(#record_two_fields{b = B}) when is_integer(B) -> B;
+%% %% unhandled
+%% %%test5(#record_two_fields{b = undefined}) -> 1;
+%% test5(undefined) -> 0.
+
+
+-record(union_rec, {
+    field :: a | b | c
+}).
+-spec union_rec(#union_rec{}) -> integer().
+union_rec(#union_rec{field = a}) ->
+    0;
+union_rec(#union_rec{field = b}) ->
+    1.
+%% unhandled
+%% union_rec(#union_rec{field = c}) ->
+%%     2.

--- a/test/should_fail/record_exhaustive.erl
+++ b/test/should_fail/record_exhaustive.erl
@@ -15,31 +15,41 @@
     b :: integer() | undefined
 }).
 
+%% expected error message in the console:
+%%     Example values which are not covered:
+%%     #record_one_field{
+%%       inner_rec = undefined
+%%     }
 -spec one_field(#record_one_field{} | undefined) -> integer().
 one_field(#record_one_field{inner_rec = InnerRec = #inner{}}) -> InnerRec#inner.field;
 %% unhandled
 %%one_field(#record_one_field{field = undefined}) -> -1;
 one_field(undefined) -> 0.
 
+%% expected error message in the console:
+%%     Example values which are not covered:
+%%     #record_two_fields{
+%%       a = #record_one_field{
+%%         inner_rec = undefined
+%%       },
+%%       b = 0
+%%     }
 -spec two_fields(#record_two_fields{} | undefined) -> integer().
 two_fields(#record_two_fields{a = #record_one_field{inner_rec = InnerRec = #inner{}}}) -> InnerRec#inner.field;
 %% unhandled
 %%two_fields(#record_two_fields{a = #record_one_field{inner_rec = undefined}}) -> 2;
 two_fields(#record_two_fields{b = undefined}) -> 0;
 %% unhandled
-%%two_fields(#record_two_fields{b = B}) when is_integer(B) -> B;
+%%two_fields(#record_two_fields{b = B}) -> B;
 two_fields(undefined) -> 0.
 
-%% -spec test5(#record_two_fields{} | undefined) -> integer().
-%% test5(#record_two_fields{a = #record_one_field{field = Field = #inner{}}}) -> Field#inner.field;
-%% %% unhandled
-%% %%test5(#record_two_fields{a = #record_one_field{field = undefined}}) -> 2;
-%% test5(#record_two_fields{b = B}) when is_integer(B) -> B;
-%% %% unhandled
-%% %%test5(#record_two_fields{b = undefined}) -> 1;
-%% test5(undefined) -> 0.
 
 
+%% expected error message in the console:
+%%     Example values which are not coverd:
+%%     #union_rec{
+%%       field = c
+%%     }
 -record(union_rec, {
     field :: a | b | c
 }).
@@ -49,5 +59,5 @@ union_rec(#union_rec{field = a}) ->
 union_rec(#union_rec{field = b}) ->
     1.
 %% unhandled
-%% union_rec(#union_rec{field = c}) ->
-%%     2.
+%%union_rec(#union_rec{field = c}) ->
+%%    2.

--- a/test/should_fail/record_exhaustive.erl
+++ b/test/should_fail/record_exhaustive.erl
@@ -46,18 +46,20 @@ two_fields(undefined) -> 0.
 
 
 %% expected error message in the console:
-%%     Example values which are not coverd:
+%%     Example values which are not covered:
 %%     #union_rec{
-%%       field = c
+%%       foo = c
+%%       bar = 0.0
 %%     }
 -record(union_rec, {
-    field :: a | b | c
+    foo :: a | b | c,
+    bar :: float()       %% non-refinable field
 }).
 -spec union_rec(#union_rec{}) -> integer().
-union_rec(#union_rec{field = a}) ->
+union_rec(#union_rec{foo = a}) ->
     0;
-union_rec(#union_rec{field = b}) ->
+union_rec(#union_rec{foo = b}) ->
     1.
 %% unhandled
-%%union_rec(#union_rec{field = c}) ->
+%%union_rec(#union_rec{foo = c}) ->
 %%    2.

--- a/test/should_fail/record_exhaustive.erl
+++ b/test/should_fail/record_exhaustive.erl
@@ -49,17 +49,21 @@ two_fields(undefined) -> 0.
 %%     Example values which are not covered:
 %%     #union_rec{
 %%       foo = c
-%%       bar = 0.0
+%%       bar = -1
 %%     }
 -record(union_rec, {
     foo :: a | b | c,
     bar :: float()       %% non-refinable field
 }).
 -spec union_rec(#union_rec{}) -> integer().
-union_rec(#union_rec{foo = a}) ->
-    0;
-union_rec(#union_rec{foo = b}) ->
-    1.
+union_rec(#union_rec{foo = a}) -> 0;
+union_rec(#union_rec{foo = b}) -> 1.
 %% unhandled
-%%union_rec(#union_rec{foo = c}) ->
-%%    2.
+%%union_rec(#union_rec{foo = c}) -> 2.
+
+%% expected error message:
+%%     Example values which are not covered:
+%%     #empty_rec{}
+-record(empty_rec, {}).
+-spec empty_rec(#empty_rec{} | undefined) -> integer().
+empty_rec(undefined) -> 1.

--- a/test/should_fail/record_exhaustive.erl
+++ b/test/should_fail/record_exhaustive.erl
@@ -1,6 +1,6 @@
 -module(record_exhaustive).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -record(inner, {
     field :: integer()


### PR DESCRIPTION
This toggles exhaustiveness checking for records.

While testing, I discovered that type guards weren't handled in the refinement for record fields.
This will be fixed in an upcoming PR.

``` console
$ bin/gradualizer test/should_fail/record_exhaustive.erl
test/should_fail/record_exhaustive.erl: Nonexhaustive patterns on line 19 at column 1
Example values which are not covered: ["#record_one_field{inner_rec :: undefined}"]
test/should_fail/record_exhaustive.erl: Nonexhaustive patterns on line 25 at column 1
Example values which are not covered: ["#record_two_fields{a ::\n                                 #record_one_field{inner_rec ::\n                                                       undefined},\n                             b :: integer()}"]
test/should_fail/record_exhaustive.erl: Nonexhaustive patterns on line 47 at column 1
Example values which are not covered: ["#union_rec{field :: c}"]
```

The formatting would need some improvement.