### PR TITLE
Remove most warnings when compiling the test suite

### DIFF
--- a/test/known_problems/should_fail/guard_fail.erl
+++ b/test/known_problems/should_fail/guard_fail.erl
@@ -1,6 +1,6 @@
 -module(guard_fail).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec wrong_arity(fun((any()) -> any()) | other) -> fun((any()) -> any()) | not_function.
 wrong_arity(F) when is_function(F, 2) -> F;

--- a/test/known_problems/should_fail/rigid_type_variables.erl
+++ b/test/known_problems/should_fail/rigid_type_variables.erl
@@ -1,5 +1,6 @@
 -module(rigid_type_variables).
--compile(export_all).
+
+-compile([export_all, nowarn_export_all]).
 
 -spec foo(A) -> A.
 foo(X) -> {X, X}.

--- a/test/known_problems/should_pass/fun_subtyping.erl
+++ b/test/known_problems/should_pass/fun_subtyping.erl
@@ -1,6 +1,6 @@
 -module(fun_subtyping).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec return_fun_intersection() -> fun((number()) -> number()).
 return_fun_intersection() -> fun number/1.

--- a/test/known_problems/should_pass/generator_var_shadow.erl
+++ b/test/known_problems/should_pass/generator_var_shadow.erl
@@ -1,5 +1,7 @@
 -module(generator_var_shadow).
--export([f/2]).
+
+-compile([export_all, nowarn_export_all]).
+-compile([nowarn_shadow_vars, nowarn_unused_vars]).
 
 -spec f(boolean(), [integer()]) -> [integer()].
 f(X, Xs) ->

--- a/test/known_problems/should_pass/list_tail.erl
+++ b/test/known_problems/should_pass/list_tail.erl
@@ -1,6 +1,6 @@
 -module(list_tail).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 %% Improper list in type inference - currently considered a type error
 atom_tail() ->

--- a/test/known_problems/should_pass/map_union.erl
+++ b/test/known_problems/should_pass/map_union.erl
@@ -1,6 +1,6 @@
 -module(map_union).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec union_value2(#{a => b | c}) -> #{a => b} | #{a => c}.
 union_value2(M) -> M.

--- a/test/known_problems/should_pass/refine_list_tail.erl
+++ b/test/known_problems/should_pass/refine_list_tail.erl
@@ -1,6 +1,6 @@
 -module(refine_list_tail).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 %% Currently fails with:
 %% "The variable 'T' has type [] | [any(), ...] but is expected to have type [any(), ...]"

--- a/test/known_problems/should_pass/sets_set.erl
+++ b/test/known_problems/should_pass/sets_set.erl
@@ -1,5 +1,7 @@
 -module(sets_set).
 
+-compile([export_all, nowarn_export_all]).
+
 -spec add_var(string(), sets:set(string())) -> sets:set(string()).
 add_var(Var, Set) ->
     sets:add_element(Var, Set).

--- a/test/should_fail/arg.erl
+++ b/test/should_fail/arg.erl
@@ -6,6 +6,6 @@
 f(N) ->
     N.
 
--spec g(bool()) -> bool().
+-spec g(boolean()) -> boolean().
 g(N) ->
     f(N).

--- a/test/should_fail/branch.erl
+++ b/test/should_fail/branch.erl
@@ -1,6 +1,6 @@
 -module(branch).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec c(boolean()) -> integer().
 c(X) ->

--- a/test/should_fail/branch2.erl
+++ b/test/should_fail/branch2.erl
@@ -2,7 +2,7 @@
 
 -export([c/1]).
 
--spec c(bool()) -> integer().
+-spec c(boolean()) -> integer().
 c(true) ->
     1;
 c(false) ->

--- a/test/should_fail/covariant_map_keys.erl
+++ b/test/should_fail/covariant_map_keys.erl
@@ -1,5 +1,6 @@
 -module(covariant_map_keys).
 
+-compile([nowarn_unused_function]).
 -export([not_good/1]).
 
 -spec good(#{ good := A }) -> A.

--- a/test/should_fail/cyclic_type_vars.erl
+++ b/test/should_fail/cyclic_type_vars.erl
@@ -1,6 +1,6 @@
 -module(cyclic_type_vars).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec foo(A) -> B when
     A :: true | B,

--- a/test/should_fail/guard_fail.erl
+++ b/test/should_fail/guard_fail.erl
@@ -1,6 +1,6 @@
 -module(guard_fail).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec wrong_guard(integer() | atom()) -> atom() | not_atom.
 wrong_guard(A) when is_integer(A) -> A;
@@ -44,6 +44,6 @@ compare_still_float(_) ->
 
 -spec equal_still_float(number()) -> list().
 equal_still_float(N) when 0 == N ->
-    list_to_integer(0); % error: N can still be float, since 0.0 == 0
+    integer_to_list(N); % error: N can still be float, since 0.0 == 0
 equal_still_float(_) ->
     "X".

--- a/test/should_fail/map_fail.erl
+++ b/test/should_fail/map_fail.erl
@@ -1,6 +1,6 @@
 -module(map_fail).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec mandatory_fail(#{a => b}) -> #{a := b}.
 mandatory_fail(M) -> M.

--- a/test/should_fail/pattern.erl
+++ b/test/should_fail/pattern.erl
@@ -5,5 +5,5 @@
 -spec pattern_test(integer()) -> {}.
 pattern_test(1) ->
     true;
-pattern_test(X) ->
+pattern_test(_) ->
     {}.

--- a/test/should_fail/pattern_record_fail.erl
+++ b/test/should_fail/pattern_record_fail.erl
@@ -1,6 +1,6 @@
 -module(pattern_record_fail).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -record(r1, {
     f

--- a/test/should_fail/record_refinement_fail.erl
+++ b/test/should_fail/record_refinement_fail.erl
@@ -1,6 +1,6 @@
 -module(record_refinement_fail).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -record(one_field, {a :: integer() | undefined}).
 

--- a/test/should_fail/shortcut_ops.erl
+++ b/test/should_fail/shortcut_ops.erl
@@ -1,6 +1,6 @@
 -module(shortcut_ops).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec andalso_too_precise1(true, number()) -> number().
 andalso_too_precise1(True, N) -> True andalso N.

--- a/test/should_fail/unary_plus_fail.erl
+++ b/test/should_fail/unary_plus_fail.erl
@@ -1,13 +1,13 @@
 -module(unary_plus_fail).
--export([m/1, o/0, p/0]).
+-export([m/1, o/1, p/0]).
 
 -spec m(+1) -> {}.
 m(+2) ->
     {}.
 
--spec o() -> boolean().
-o() ->
-    +true.
+-spec o(boolean()) -> boolean().
+o(X) ->
+    +X.
 
 p() ->   
     +m(+1).

--- a/test/should_pass/alias_in_pattern.erl
+++ b/test/should_pass/alias_in_pattern.erl
@@ -1,11 +1,17 @@
 -module(alias_in_pattern).
--export([foo/1, issue32/1]).
+
+-compile([export_all, nowarn_export_all]).
 
 -spec foo(tuple() | integer()) -> tuple().
 foo(Left = {_X, _Y})       -> Left;
-foo({_,_,_} = Right)       -> Right;
-foo({Inside, _} = {{}, 0}) -> Inside;
 foo(42 = N)                -> {N+N}.
+
+-spec bar(tuple() | integer()) -> tuple().
+bar({_,_,_} = Right) -> Right;
+bar(N = 33)          -> {N+N}.
+
+-spec baz(tuple() | integer()) -> tuple().
+baz({Inside, _} = {{}, 0}) -> Inside.
 
 -spec issue32({atom1, atom2} | atom4) -> {atom1, atom2} | atom3.
 issue32(Stuff) ->

--- a/test/should_pass/andalso_any.erl
+++ b/test/should_pass/andalso_any.erl
@@ -1,6 +1,6 @@
 -module(andalso_any).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec f1() -> boolean().
 f1() ->

--- a/test/should_pass/any.erl
+++ b/test/should_pass/any.erl
@@ -1,6 +1,6 @@
 -module(any).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec any(any()) -> any().
 

--- a/test/should_pass/bc.erl
+++ b/test/should_pass/bc.erl
@@ -1,5 +1,7 @@
 -module(bc).
 
+-compile([export_all, nowarn_export_all]).
+
 bc1() ->
     << <<X:4, Y:4>> || X <- [$a, $b], <<Y:4>> <= <<"xy">> >>.
 

--- a/test/should_pass/bitstring.erl
+++ b/test/should_pass/bitstring.erl
@@ -1,6 +1,6 @@
 -module(bitstring).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec bin1(binary()) -> any().
 bin1(<<A:4, B:4, _/binary>>) ->

--- a/test/should_pass/bool.erl
+++ b/test/should_pass/bool.erl
@@ -1,8 +1,8 @@
 -module(bool).
 
--export([b/2]).
+-compile([export_all, nowarn_export_all]).
 
--spec b(boolean(), bool()) -> bool().
+-spec b(boolean(), boolean()) -> boolean().
 b(B1, B2) ->
     B1 andalso B2.
 

--- a/test/should_pass/case.erl
+++ b/test/should_pass/case.erl
@@ -1,6 +1,6 @@
 -module('case').
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 cse(X) ->
     case X of

--- a/test/should_pass/cyclic_otp_specs.erl
+++ b/test/should_pass/cyclic_otp_specs.erl
@@ -1,6 +1,6 @@
 -module(cyclic_otp_specs).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 %% We shouldn't fail on cyclic dependencies in OTP specs.
 %% Either make them work, or override the specs.

--- a/test/should_pass/float.erl
+++ b/test/should_pass/float.erl
@@ -1,6 +1,6 @@
 -module(float).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec f() -> float().
 f() ->

--- a/test/should_pass/fun_capture.erl
+++ b/test/should_pass/fun_capture.erl
@@ -1,5 +1,8 @@
 -module(fun_capture).
 
+-compile([nowarn_unused_vars, nowarn_shadow_vars]).
+-compile([export_all, nowarn_export_all]).
+
 -spec f(integer()) -> fun(([atom()]) -> [atom()]).
 f(X) ->
     (fun (X) ->

--- a/test/should_pass/fun_spec.erl
+++ b/test/should_pass/fun_spec.erl
@@ -1,4 +1,6 @@
 -module(fun_spec).
 
+-compile([export_all, nowarn_export_all]).
+
 -spec f() -> fun((any()) -> any()).
 f() -> fun (X) -> X end.

--- a/test/should_pass/guard.erl
+++ b/test/should_pass/guard.erl
@@ -1,6 +1,6 @@
 -module(guard).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec atom(atom() | integer()) -> atom() | not_atom.
 atom(A) when is_atom(A) -> A;

--- a/test/should_pass/int.erl
+++ b/test/should_pass/int.erl
@@ -1,6 +1,6 @@
 -module(int).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec f(integer()) -> integer().
 f(N) ->

--- a/test/should_pass/intersection.erl
+++ b/test/should_pass/intersection.erl
@@ -1,6 +1,6 @@
 -module(intersection).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec f(integer()) -> integer();
        (boolean()) -> boolean().

--- a/test/should_pass/intersection_with_any.erl
+++ b/test/should_pass/intersection_with_any.erl
@@ -1,8 +1,6 @@
 -module(intersection_with_any).
 
--export([any_refined_using_guard/1,
-         intersection_using_constraints/1,
-         guess_two_dice/2]).
+-compile([export_all, nowarn_export_all]).
 
 -spec any_refined_using_guard(any()) -> 5.
 any_refined_using_guard(X) when is_integer(X) -> X.
@@ -23,4 +21,4 @@ guess_two_dice(X, Y) ->
 
 %% untyped helper returning {1..6, 1..6}
 roll_two_dice() ->
-    {random:uniform(6), random:uniform(6)}.
+    {rand:uniform(6), rand:uniform(6)}.

--- a/test/should_pass/lc.erl
+++ b/test/should_pass/lc.erl
@@ -1,5 +1,7 @@
 -module(lc).
 
+-compile([export_all, nowarn_export_all]).
+
 bin_gen_1() ->
     [X || <<X>> <= bin_fixed_size()].
 

--- a/test/should_pass/list.erl
+++ b/test/should_pass/list.erl
@@ -1,6 +1,6 @@
 -module(list).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec f([integer()]) -> integer().
 

--- a/test/should_pass/listsspecs.erl
+++ b/test/should_pass/listsspecs.erl
@@ -1,6 +1,6 @@
 -module(listsspecs).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec append([integer()]) -> [integer()].
 append(X) ->
@@ -52,7 +52,7 @@ join() ->
 
 -spec foreach() -> ok.
 foreach() ->
-    lists:foreach(fun (X) -> X+1, ok end, [1, 2, 3]).
+    lists:foreach(fun (X) -> X+1 end, [1, 2, 3]).
 
 -spec last() -> 1.
 last() ->

--- a/test/should_pass/map.erl
+++ b/test/should_pass/map.erl
@@ -1,6 +1,6 @@
 -module(map).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec unknown_map1(#{a => b}) -> map().
 unknown_map1(M) -> M.

--- a/test/should_pass/map_as_argument_update.erl
+++ b/test/should_pass/map_as_argument_update.erl
@@ -1,5 +1,6 @@
 -module(map_as_argument_update).
--compile(export_all).
+
+-compile([export_all, nowarn_export_all]).
 
 %% See https://github.com/josefs/Gradualizer/pull/233 for the bug report,
 %% and https://github.com/josefs/Gradualizer/pull/237 for the fix.

--- a/test/should_pass/map_pattern.erl
+++ b/test/should_pass/map_pattern.erl
@@ -1,5 +1,7 @@
 -module(map_pattern).
 
+-compile([export_all, nowarn_export_all]).
+
 -type t() :: #{apa := integer(), bepa := boolean()}.
 
 -spec f(t()) -> boolean().

--- a/test/should_pass/messaging.erl
+++ b/test/should_pass/messaging.erl
@@ -5,9 +5,6 @@
 -spec ok() -> ok.
 ok() -> ok.
 
--spec nok() -> nok.
-nok() -> nok.
-
 server() ->
   receive
     quit ->

--- a/test/should_pass/minus.erl
+++ b/test/should_pass/minus.erl
@@ -1,5 +1,7 @@
 -module(minus).
 
+-compile([export_all, nowarn_export_all]).
+
 -spec m(-1) -> {}.
 m(-1) ->
     {}.

--- a/test/should_pass/nonempty_cons.erl
+++ b/test/should_pass/nonempty_cons.erl
@@ -1,5 +1,7 @@
 -module(nonempty_cons).
 
+-compile([export_all, nowarn_export_all]).
+
 -spec t() -> [integer(), ...].
 t() ->
     [1].

--- a/test/should_pass/opaque.erl
+++ b/test/should_pass/opaque.erl
@@ -1,6 +1,7 @@
 -module(opaque).
 
 -export([external/2, internal/2, use_internal/2]).
+-export_type([my_opaque/0]).
 
 -spec external(user_types:my_opaque(), integer() | undefined) -> integer().
 external(_, undefined) -> 0;

--- a/test/should_pass/operator_pattern.erl
+++ b/test/should_pass/operator_pattern.erl
@@ -1,6 +1,6 @@
 -module(operator_pattern).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec f1(float()) -> {}.
 f1(1.0+1.0)   -> {};

--- a/test/should_pass/pattern_bind_reuse.erl
+++ b/test/should_pass/pattern_bind_reuse.erl
@@ -19,7 +19,7 @@ guess_the_die(Guess) ->
 
 %% Untyped helper; returns 1..6
 roll_die() ->
-    random:uniform(6).
+    rand:uniform(6).
 
 -spec is_same(integer(), integer()) -> boolean().
 is_same(N, N) ->

--- a/test/should_pass/pattern_record.erl
+++ b/test/should_pass/pattern_record.erl
@@ -1,6 +1,6 @@
 -module(pattern_record).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -record(test, {
     field :: integer()

--- a/test/should_pass/preludes.erl
+++ b/test/should_pass/preludes.erl
@@ -1,6 +1,6 @@
 -module(preludes).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 %% use lists:sort (which only accepts list() not all term()) to test
 %% that V* is any()

--- a/test/should_pass/record_refinement.erl
+++ b/test/should_pass/record_refinement.erl
@@ -1,5 +1,7 @@
 -module(record_refinement).
 
+-compile([export_all, nowarn_export_all]).
+
 -record(one_field, {a :: integer() | undefined}).
 
 -spec one_field(#one_field{}, integer()) -> integer().

--- a/test/should_pass/refine_comparison.erl
+++ b/test/should_pass/refine_comparison.erl
@@ -1,6 +1,6 @@
 -module(refine_comparison).
 
--export([comp1/1, comp2/1, comp3/1, comp4/1, compatom1/1]).
+-compile([export_all, nowarn_export_all]).
 
 -spec comp1(integer()) -> pos_integer() | neg_integer().
 comp1(N) when 0 < N -> N;

--- a/test/should_pass/remote_types.erl
+++ b/test/should_pass/remote_types.erl
@@ -1,6 +1,6 @@
 -module(remote_types).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -type local_tuple() :: {atom(), integer()}.
 -type local_list() :: list(atom()).

--- a/test/should_pass/return_fun.erl
+++ b/test/should_pass/return_fun.erl
@@ -1,6 +1,6 @@
 -module(return_fun).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec return_fun_term() -> term().
 return_fun_term() -> fun nil/0.

--- a/test/should_pass/scope.erl
+++ b/test/should_pass/scope.erl
@@ -1,6 +1,6 @@
 -module(scope).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all, nowarn_unused_vars]).
 
 f(X) ->
     case g(X) of
@@ -20,7 +20,7 @@ g(_X) ->
 %     (X = 5) + X.
 
 t() ->
-    { X = 5, Y = 4 },
+    _ = { X = 5, Y = 4 },
 % Fails
 %    { X = 5, Y = 4, X },
     X.

--- a/test/should_pass/shortcut_ops.erl
+++ b/test/should_pass/shortcut_ops.erl
@@ -1,6 +1,6 @@
 -module(shortcut_ops).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec andalso_check1(boolean(), number()) -> false | number().
 andalso_check1(B, N) -> B andalso N.

--- a/test/should_pass/stuff_as_top.erl
+++ b/test/should_pass/stuff_as_top.erl
@@ -16,7 +16,7 @@ tuple_pat_as_top({X, Y}) ->
 cons_as_top() -> [x, y].
 
 -spec cons_pat_as_top(gradualizer:top()) -> any().
-cons_pat_as_top([X|Xs]) -> X.
+cons_pat_as_top([X|_]) -> X.
 
 -spec fun_as_top() -> gradualizer:top().
 fun_as_top() -> fun (X) -> X + 1 end.

--- a/test/should_pass/try.erl
+++ b/test/should_pass/try.erl
@@ -1,11 +1,11 @@
 -module('try').
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all, nowarn_unused_vars]).
 
 -spec t() -> 2..4.
 t()->
     try A = 1 of
-        ok ->
+        1 ->
             %% a:b(A), unsafe
             B = 2
     catch _:_ ->
@@ -25,7 +25,7 @@ t()->
 
 r()->
     try A = 1 of
-        ok ->
+        1 ->
             %% a:b(A), unsafe
             B = 2
     catch _:_ ->

--- a/test/should_pass/tuple.erl
+++ b/test/should_pass/tuple.erl
@@ -1,9 +1,9 @@
 -module(tuple).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec tup({any(),any(),any()}) -> any().
-tup({A,B,C}) ->
+tup({A,_,_}) ->
     A.
 
 tup2(A,B) ->

--- a/test/should_pass/tuple_union_pat.erl
+++ b/test/should_pass/tuple_union_pat.erl
@@ -1,6 +1,6 @@
 -module(tuple_union_pat).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec f(tuple() | integer()) -> ok.
 f({1, 2}) ->

--- a/test/should_pass/type_decl.erl
+++ b/test/should_pass/type_decl.erl
@@ -1,6 +1,8 @@
 -module(type_decl).
 
--type a_type() :: bool().
+-export_type([a_type/0, an_opaque_type/0, parameterized/1]).
+
+-type a_type() :: boolean().
 -opaque an_opaque_type() :: integer().
 
 -type parameterized(A) :: {A,A}.

--- a/test/should_pass/type_pattern.erl
+++ b/test/should_pass/type_pattern.erl
@@ -1,6 +1,8 @@
 %%% @doc Test cases for `add_type_pat/4'
 -module(type_pattern).
 
+-compile([export_all, nowarn_export_all]).
+
 -type mychar() :: char().
 
 %% The user type `mychar()' inside a list is not normalized when

--- a/test/should_pass/type_refinement.erl
+++ b/test/should_pass/type_refinement.erl
@@ -1,12 +1,6 @@
 -module(type_refinement).
 
--export([basic_type_refinement/1,
-         int_literals_1/1, int_literals_2/1, int_literals_3/1,
-         disjoint_stuff_1/1, disjoint_stuff_2/1,
-         disjoint_stuff_3/1, disjoint_stuff_4/1,
-         var_pat/2, nil_elimination/1,
-         tuple_union/1, beside_match_all/2, beside_singleton/2,
-         refine_bound_var_by_guard_bifs/1]).
+-compile([export_all, nowarn_export_all]).
 
 %% Test that Value is not considered to be string() | false.
 -spec basic_type_refinement(string()) -> string().
@@ -53,7 +47,7 @@ disjoint_stuff_4(3) -> 4; %% doesn't affect mismatching singleton and range
 disjoint_stuff_4(X) -> X.
 
 -spec var_pat(N :: 1..2, X :: 1..2) -> 2.
-var_pat(1, X) -> 2;
+var_pat(1, _) -> 2;
 var_pat(N, _) -> N.
 
 -spec nil_elimination([atom()]) -> nonempty_list(atom()).

--- a/test/should_pass/type_variable.erl
+++ b/test/should_pass/type_variable.erl
@@ -1,6 +1,6 @@
 -module(type_variable).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -spec fff() -> Result when Result :: integer().
 fff() -> 0.

--- a/test/should_pass/unary_plus.erl
+++ b/test/should_pass/unary_plus.erl
@@ -1,5 +1,7 @@
 -module(unary_plus).
 
+-compile([export_all, nowarn_export_all]).
+
 -spec m(+1) -> {}.
 m(+1) ->
     {}.

--- a/test/should_pass/underscore.erl
+++ b/test/should_pass/underscore.erl
@@ -1,6 +1,6 @@
 -module(underscore).
 
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -spec underscore(_) -> _.
 underscore(1) ->

--- a/test/should_pass/user_type_in_pattern_body.erl
+++ b/test/should_pass/user_type_in_pattern_body.erl
@@ -2,15 +2,14 @@
 
 %% Check that the pattern type is normalized when recursively checking a pattern
 
-
--export([cons/1]).
+-compile([export_all, nowarn_export_all]).
 
 -type t()  :: {}.
 
 %% Cons: The element type t() should be normalized to {}, to check that the head
 %% pattern {} has type t().
 -spec cons([t()]) -> boolean().
-cons([{} | Xs]) -> true;
+cons([{} | _]) -> true;
 cons([])        -> false.
 
 %% Map: Key {} and value {} are of type t()

--- a/test/should_pass/user_types.erl
+++ b/test/should_pass/user_types.erl
@@ -1,6 +1,6 @@
 -module(user_types).
 
--export([f/1]).
+-compile([export_all, nowarn_export_all]).
 
 %% these exported types are used in remote_types module
 -export_type([my_tuple/0, my_list/0, my_union/0, my_opaque/0, my_empty_record/0]).

--- a/test/should_pass/var_fun.erl
+++ b/test/should_pass/var_fun.erl
@@ -1,6 +1,6 @@
 -module(var_fun).
 
--export([f/0,apa/1,bepa/1]).
+-compile([export_all, nowarn_export_all]).
 
 f() ->
     lists:map(fun (F) -> F(5) end, [ fun ?MODULE:F/1 || F <- [apa, bepa]]).

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -47,6 +47,12 @@ subtype_test_() ->
      ?_assert(subtype(?t( integer()         ), ?t( number()         ))),
      ?_assert(subtype(?t( float()           ), ?t( number()         ))),
 
+     %% Boolean
+     %% We support both the new boolean() and the deprecated bool()
+     %% and they're both equivalent.
+     ?_assert(subtype(?t( bool()            ), ?t( boolean()        ))),
+     ?_assert(subtype(?t( boolean()         ), ?t( bool()           ))),
+
      %% Atom
      ?_assert(subtype(?t( a                 ), ?t( atom()           ))),
      ?_assert(subtype(?t( a                 ), ?t( a                ))),


### PR DESCRIPTION
Warnings can be useful even when compiling the test suite so I've
taken some time to remove as many warnings as I can.

I've replaced some `export` pragmas with
`-compile([export_all,nowarn_export_all])`. I don't think it makes
sense to maintain an export list in the test suite, as there isn't
any abstraction defined in those modules that is in need of protection
by not exporting all functions.

There are a few types of warnings that I haven't been able to
remove, and if someone knows how, I'd be interested in learning:

* "this clause cannot match because a previous clause at line 6 always
  matches"
  In some tests we explicitly want to test overlapping matches, e.g.
  type refinement, so this warning is not helpful.
* "this expression will fail with a 'badarg' exception"
  We want to test guards where the types are not correct to make sure
  that they fail in Gradualizer.
* "this expression will fail with a 'badarith' exception"
  Similar to above, we want to test that typechecking fails when
  arithmetic expressions are given the wrong type of arguments.
* "type bool() is now called boolean(); please use the new name
  instead"
  We want to support the old bool() type so we want to have tests for
  it.