### PR TITLE
Record update missing fields fix

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1513,7 +1513,7 @@ do_type_check_expr(Env, {record, Anno, Expr, Record, Fields}) ->
     RecTy = {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Record}]},
     {VB1, Cs1} = type_check_expr_in(Env, RecTy, Expr),
     Rec = get_record_fields(Record, Anno, Env#env.tenv),
-    {VB2, Cs2} = type_check_fields(Env, Rec, Fields),
+    {VB2, Cs2} = type_check_fields_for_update(Env, Rec, Fields),
     {RecTy, union_var_binds(VB1, VB2, Env#env.tenv), constraints:combine(Cs1, Cs2)};
 do_type_check_expr(Env, {record, Anno, Record, Fields}) ->
     RecTy    = {type, erl_anno:new(0), record, [{atom, erl_anno:new(0), Record}]},
@@ -1702,6 +1702,9 @@ type_check_fun(Env, Clauses) ->
 create_fun_type(Arity, RetTy) when is_integer(Arity) ->
     ParTys = lists:duplicate(Arity, type(any)),
     type('fun', [type(product, ParTys), RetTy]).
+
+type_check_fields_for_update(Env, Rec, Fields) ->
+    type_check_fields(Env, Rec, Fields, should_not_be_inspected).
 
 type_check_fields(Env, Rec, Fields) ->
     UnAssignedFields = get_unassigned_fields(Fields, Rec),

--- a/test/should_pass/records.erl
+++ b/test/should_pass/records.erl
@@ -64,3 +64,13 @@ record_as_tuple(R) ->
 
 -record(rec_any, {f}).
 f(#rec_any{f = F} = R) -> F.
+
+-record(nospec_update_bug, {
+    a :: integer(),
+    b :: integer()
+}).
+
+nospec_update_bug(Rec) ->
+    Rec#nospec_update_bug{
+        b = 0
+    }.


### PR DESCRIPTION
The record refinement update introduced this bug where it would try to typecheck missing fields even for record updates instead of simply type checking only the fields that are used. Confirmed test was broken before and pass now.

This is also specific to cases where the spec would be missing and the initial record would be compared to `any()`.