### PR TITLE
Any type fix within complex patterns

### DIFF
--- a/test/should_pass/records.erl
+++ b/test/should_pass/records.erl
@@ -61,3 +61,6 @@ rec_index_subtype() ->
 -spec record_as_tuple(#r{}) -> tuple().
 record_as_tuple(R) ->
     R.
+
+-record(rec_any, {f}).
+f(#rec_any{f = F} = R) -> F.

--- a/test/should_pass/tuple_union_pat.erl
+++ b/test/should_pass/tuple_union_pat.erl
@@ -5,3 +5,11 @@
 -spec f(tuple() | integer()) -> ok.
 f({1, 2}) ->
     ok.
+
+-spec g({ok, binary()} | {error, term()}) -> integer().
+g({error, key_not_found} = _Response) ->
+    1;
+g({error, _} = _Response) ->
+    2;
+g({ok, _} = _Response) ->
+    3.

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -562,7 +562,7 @@ add_type_pat_test_() ->
     [{"Pattern matching list against any()",
       ?_assert(type_check_forms(["f([E|_]) -> E."]))},
      {"Pattern matching record against any()",
-      ?_assert(type_check_forms(["-record(f, {r}).",
+      ?_assert(type_check_forms(["-record(r, {f}).",
                                  "f(#r{f = F}) -> F."]))}
     ].
 


### PR DESCRIPTION
We uncovered a really weird bug: 

This gives an error:

`test.erl: The pattern error on line 6 at column 19 doesn't have the type ok`

```erlang
-spec process_response({ok, binary()} | {error, term()}) -> integer().
process_response({error, key_not_found} = _Response) ->
    1;
process_response({error, _} = _Response) ->
    2;
process_response({ok, _} = _Response) ->
    3.
```

While this does not:

```erlang
-spec process_response({ok, binary()} | {error, term()}) -> integer().
process_response({error, key_not_found}) ->
    1;
process_response({error, _}) ->
    2;
process_response({ok, _}) ->
    3.
```

The simple fact of binding the thing to a variable, even if not used, would cause refinement to go wrong for complex types (in this case, tuples and records).

Introduced a simple fix and everything passes.
