### PR TITLE
Fix var bind in function heads for tuple and records when not spec

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -430,6 +430,12 @@ glb(T1, T2, A, TEnv) ->
             end
     end.
 
+%% none() is the bottom of the hierarchy
+glb_ty({type, _, none, []} = Ty1, _Ty2, _A, _TEnv) ->
+    ret(Ty1);
+glb_ty(_Ty1, {type, _, none, []} = Ty2, _A, _TEnv) ->
+    ret(Ty2);
+
 %% We don't know anything if either type is any()
 glb_ty({type, _, any, []} = Ty1, _Ty2, _A, _TEnv) ->
     ret(Ty1);
@@ -441,12 +447,6 @@ glb_ty(?top(), Ty2, _A, _TEnv) ->
     ret(Ty2);
 glb_ty(Ty1, ?top(), _A, _TEnv) ->
     ret(Ty1);
-
-%% none() is the bottom of the hierarchy
-glb_ty({type, _, none, []} = Ty1, _Ty2, _A, _TEnv) ->
-    ret(Ty1);
-glb_ty(_Ty1, {type, _, none, []} = Ty2, _A, _TEnv) ->
-    ret(Ty2);
 
 %% glb is idempotent
 glb_ty(Ty, Ty, _A, _TEnv) ->

--- a/test/should_pass/varbind_in_function_head.erl
+++ b/test/should_pass/varbind_in_function_head.erl
@@ -1,0 +1,17 @@
+-module(varbind_in_function_head).
+
+-compile([export_all, nowarn_export_all]).
+-compile([nowarn_shadow_vars, nowarn_unused_vars]).
+
+a({Key, Value, undefined} = _Unused) ->
+    {Key, Value, 0};
+a({Key, Value, Timestamp}) ->
+    {Key, Value, 2}.
+
+-record(b, {
+    field1 :: atom()
+}).
+b(#b{field1 = undefined} = _Unused) ->
+    1;
+b(#b{field1 = _}) ->
+    2.

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -174,9 +174,9 @@ glb_test_() ->
 
     [
      %% any()
-     [ ?glb( ?t(any()),  T, ?t(any()) )   || T <- Ts ],
+     [ ?glb( ?t(any()),  T, ?t(any()) )   || T <- Ts, T /= ?t(none()) ],
      [ ?glb( ?t(gradualizer:top()), T, T) || T <- Ts ],
-     [ ?glb( ?t(none()), T, ?t(none()) )  || T <- Ts, T /= ?t(any()) ],
+     [ ?glb( ?t(none()), T, ?t(none()) )  || T <- Ts ],
 
      %% Integer types
      ?glb( ?t(-5..10), ?t(2..3 | 5..15), ?t(2..3 | 5..10) ),


### PR DESCRIPTION
If a function is not `spec` and the function head pattern matches against a tuple or a record, the special `none()` type is inferred for the record/tuple expression, but the `any()` type is inferred for the var bind.
These types are then passed down to `glb()` and `glb_ty`, which returns `any()` instead of `none()`, leading to eager "unreachable clause" because the resulting varbind expression `:: any()`.

This bug was discovered thanks to #315.
To test, simply move the `glb()` case for `none()` after the `any()` case and run the `varbind_in_function_head.erl` test.
```
test/should_pass/varbind_in_function_head.erl: The clause on line 8 at column 1 cannot be reached
test/should_pass/varbind_in_function_head.erl: The clause on line 16 at column 1 cannot be reached
```