### PR TITLE
easy: dead code

### DIFF
--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -62,10 +62,7 @@ type_check_file(File, Opts) ->
             ".beam" ->
                 gradualizer_file_utils:get_forms_from_beam(File);
             Ext ->
-                case filelib:is_dir(File) of
-                    true -> type_check_dir(File, Opts);
-                    false -> throw({unknown_file_extension, Ext})
-                end
+                throw({unknown_file_extension, Ext})
         end,
     case ParsedFile of
         {ok, Forms} ->


### PR DESCRIPTION
1. When being invoked from CL the branch with type_check_dir is never taken - since type_check_file_or_dir is called first
2. This branch is just logically incorrect - since type_check_dir doesn't return {ok, Forms} which is expected by the outer case