### PR TITLE
do not normalize types recursively (#fixes 322)

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -638,8 +638,7 @@ normalize({user_type, P, Name, Args} = Type, TEnv) ->
             case TEnv#tenv.types of
                 #{TypeId := {Vars, Type0}} ->
                     VarMap = maps:from_list(lists:zip(Vars, Args)),
-                    Type1 = typelib:substitute_type_vars(Type0, VarMap),
-                    normalize(Type1, TEnv);
+                    typelib:substitute_type_vars(Type0, VarMap);
                 _NotFound ->
                     throw({undef, user_type, P, {Name, length(Args)}})
             end

--- a/test/known_problems/should_pass/recursive_types.erl
+++ b/test/known_problems/should_pass/recursive_types.erl
@@ -1,0 +1,8 @@
+-module(recursive_types).
+
+-compile([export_all, nowarn_export_all]).
+
+-type rec(A) :: A | {rec, rec(A)}.
+
+-spec unwrap(rec(rec(atom()))) -> rec(atom()).
+unwrap({rec, Elem}) -> Elem.

--- a/test/known_problems/should_pass/type_pattern.erl
+++ b/test/known_problems/should_pass/type_pattern.erl
@@ -1,0 +1,15 @@
+%%% @doc Test cases for `add_type_pat/4'
+-module(type_pattern).
+
+-compile([export_all, nowarn_export_all]).
+
+-type mychar() :: char().
+
+%% The user type `mychar()' inside a list is not normalized when
+%% `add_types_pats/4' is called, but postponed later within
+%% `subtype(string(), [mychar()], TEnv)'. There was a typo that
+%% specifically in case of a string pattern VEnv was passed instead of
+%% TEnv.
+-spec f([mychar()]) -> any().
+f("foo") ->
+    ok.

--- a/test/should_pass/type_pattern.erl
+++ b/test/should_pass/type_pattern.erl
@@ -3,17 +3,6 @@
 
 -compile([export_all, nowarn_export_all]).
 
--type mychar() :: char().
-
-%% The user type `mychar()' inside a list is not normalized when
-%% `add_types_pats/4' is called, but postponed later within
-%% `subtype(string(), [mychar()], TEnv)'. There was a typo that
-%% specifically in case of a string pattern VEnv was passed instead of
-%% TEnv.
--spec f([mychar()]) -> any().
-f("foo") ->
-    ok.
-
 -type ok_tuple() :: {ok}.
 
 -spec g([ok_tuple()]) -> list().


### PR DESCRIPTION
For the `recursive_types.erl` example, - the problem has been tracked down to recursive normalization of types in `typechecker:normalize/2` when normalizing type aliases (user defined types).

Stop recursive normalization is a possible fix against going into infinite loop.

Restricting normalization this way, however, makes `type_pattern:f` example fail (because the "inner alias" is not expanded/normalized anymore). - Moving it into `known_problems` then.

```
known_problems/should_pass/type_pattern.erl: 
The pattern "foo" on line 14 at column 3 doesn't have the type [mychar()]
```

While `recursive_types/unwrap/1` from #322 stops falling into the infinite loop of normalization, it's not treated as well typed by Gradualizer - adding it to `known_problems` too.

```
recursive_types.erl: The variable on line 8 at column 24 is expected to have type 
rec(atom()) 
but it has type 
rec(atom()) | {rec, rec(rec(atom()))}

-spec unwrap(rec(rec(atom()))) -> rec(atom()).
unwrap({rec, Elem}) -> Elem.
                       ^^^^
```

----

A bit more context about `recursive_types` example: a similar example is accepted by Typed Racket as well-typed:

```racket
#lang typed/racket

(define-type
  (MyRec a)
  (U a (Pair 'rec (MyRec a))))

(: unwrap (-> (MyRec (MyRec Symbol)) (MyRec Symbol)))
(define (unwrap my_rec)
  (match my_rec [(cons 'rec elem) elem]))
```
