### PR TITLE
Make sure not to recurse forever in typechecker:normalize()

### DIFF
--- a/test/known_problems/should_pass/recursive_types.erl
+++ b/test/known_problems/should_pass/recursive_types.erl
@@ -1,0 +1,8 @@
+-module(recursive_types).
+
+-compile([export_all, nowarn_export_all]).
+
+-type rec(A) :: A | {rec, rec(A)}.
+
+-spec unwrap(rec(rec(atom()))) -> rec(atom()).
+unwrap({rec, Elem}) -> Elem.


### PR DESCRIPTION
Given a recursive type, typechecker:normalize() can recurse forever if
we don't take care to stop the recursion. This patch adds a set to
keep track of the types that `normalize` has unfolded so far and stops
unfolding if asked to normalize a type that has already been unfolded.

@ilya-klyuchnikov  identified the problem with recursives types in #322 and offered
a nice example program to demonstrate the problem.

Fixes #322 although the program is still not accepted as it should be
so I'm adding it to the known problems.