### PR TITLE
Use epp:open/1 for OTP-24+

### DIFF
--- a/src/gradualizer_file_utils.erl
+++ b/src/gradualizer_file_utils.erl
@@ -37,7 +37,7 @@ epp_parse_file(File, Includes) ->
         {ok, Fd} ->
             try
                 StartLocation = {1, 1},
-                case epp:open(File, Fd, StartLocation, Includes, []) of
+                case epp_open(File, Fd, StartLocation, Includes) of
                     {ok, Epp} ->
                         %% The undocumented `epp:parse_file/1' just
                         %% takes an internal state, and calls the
@@ -54,6 +54,20 @@ epp_parse_file(File, Includes) ->
             end;
         Error1 ->
             Error1
+    end.
+
+% epp:open/5 was removed in OTP-24
+% https://github.com/erlang/otp/commit/5281a8c7f77d45a3c36fca9c1a2e4d3812f6fc3d#diff-580a349c49b1d9b5415166e18f5279728d934efe0cebc4ee5a87823055ec3413
+epp_open(File, Fd, StartLocation, Includes) ->
+    code:ensure_loaded(epp),
+    case erlang:function_exported(epp, open, 5) of
+        true ->
+            epp:open(File, Fd, StartLocation, Includes, []);
+        false ->
+            epp:open([{name, File},
+                      {location, StartLocation},
+                      {includes, Includes},
+                      {fd, Fd}])
     end.
 
 %% Accepts a filename or the beam code as a binary


### PR DESCRIPTION
`epp:open/5` was removed in OTP-24 (https://github.com/erlang/otp/commit/5281a8c7f77d45a3c36fca9c1a2e4d3812f6fc3d#diff-580a349c49b1d9b5415166e18f5279728d934efe0cebc4ee5a87823055ec3413). This fix checks if `epp:open/5` is exported otherwise it uses `epp:open/1` instead.