### PR TITLE
Fix record refinement attempt when not all field types are refined

### DIFF
--- a/test/should_pass/record_refinement.erl
+++ b/test/should_pass/record_refinement.erl
@@ -78,3 +78,9 @@ two_level2(#two_level1{two_level2 = #two_level2{value = undefined}}) ->
     0;
 two_level2(R1) ->
     R1#two_level1.two_level2#two_level2.value.
+
+-record(not_all_fields_refined_r, {a, b}).
+-type not_all_fields_refined_t() :: #not_all_fields_refined_r{b :: b | c}.
+
+-spec not_all_fields_refined() -> not_all_fields_refined_t().
+not_all_fields_refined() -> #not_all_fields_refined_r{b = c}.


### PR DESCRIPTION
When playing with an application of the typestate pattern in Erlang for a blog post, I encountered this bug. I'm positively surprised that with the fix applied, everything works fine - the pattern works with Gradualizer as the typechecker!