### PR TITLE
Fix gradualizer_db resolving local types in the context of remote types

### DIFF
--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -315,8 +315,8 @@ handle_get_type(M, T, Args, RequireExported, ExpandOpaque, State) ->
                  #typeinfo{params = Vars,
                            body = Type0} ->
                      VarMap = maps:from_list(lists:zip(Vars, Args)),
-                     Type1 = typelib:substitute_type_vars(Type0, VarMap),
-                     Type2 = typelib:annotate_user_types(M, Type1),
+                     Type1 = typelib:annotate_user_types(M, Type0),
+                     Type2 = typelib:substitute_type_vars(Type1, VarMap),
                      {reply, {ok, Type2}, State}
              end;
         _NoMatch ->

--- a/test/should_pass/other_module.erl
+++ b/test/should_pass/other_module.erl
@@ -1,0 +1,14 @@
+-module(other_module).
+
+-compile([export_all, nowarn_export_all]).
+
+%% these exported types are used in remote_types module
+-export_type([my_generic/1]).
+
+% -type other_module_type() :: other_module.
+
+%% v-- Either a local type (my_tuple) to this module or a remote user type
+-type my_generic(RetType) :: my_shadowed_type() | {ok, RetType}.
+%% A type to be shadowed by a type with the same name in a local module.
+%% To be used in `user_types:my_generic(my_shadowed_type())`
+-type my_shadowed_type() :: other_module.

--- a/test/should_pass/other_module.erl
+++ b/test/should_pass/other_module.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 %% these exported types are used in remote_types module
--export_type([my_generic/1]).
+-export_type([my_generic/1, nested_generic/1]).
 
 % -type other_module_type() :: other_module.
 
@@ -12,3 +12,5 @@
 %% A type to be shadowed by a type with the same name in a local module.
 %% To be used in `user_types:my_generic(my_shadowed_type())`
 -type my_shadowed_type() :: other_module.
+
+-type nested_generic(RetType) :: nested_generic | my_generic(RetType).

--- a/test/should_pass/remote_types.erl
+++ b/test/should_pass/remote_types.erl
@@ -45,3 +45,8 @@ local_type_with_same_name_as_remote_type(_) -> {ok, {ok, remote_types}}.
 %% Just as above, this should resolve the opaque type from this module
 -spec generic_remote_opaque() -> user_types:my_generic(my_opaque()).
 generic_remote_opaque() -> {ok, remote_types}.
+
+-spec local_type_nested_generic(atom()) -> other_module:nested_generic(my_shadowed_type()).
+local_type_nested_generic('1') -> nested_generic;
+local_type_nested_generic('2') -> other_module;
+local_type_nested_generic(_) -> {ok, remote_types}.

--- a/test/should_pass/user_types.erl
+++ b/test/should_pass/user_types.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 %% these exported types are used in remote_types module
--export_type([my_tuple/0, my_list/0, my_union/0, my_opaque/0, my_empty_record/0]).
+-export_type([my_tuple/0, my_list/0, my_union/0, my_opaque/0, my_empty_record/0, my_generic/1]).
 
 -record(r, {}).
 -type my_empty_record() :: #r{}.
@@ -11,6 +11,13 @@
 -type my_tuple() :: {my_atom(), integer()}.
 -type my_list() :: list(my_atom()).
 -type my_union() :: float() | my_tuple().
+
+%% v-- Either a local type (my_tuple) to this module or a remote user type
+-type my_generic(RetType) :: my_shadowed_type() | {ok, RetType}.
+%% A type to be shadowed by a type with the same name in a local module.
+%% i.e. `user_types:my_generic(my_shadowed_type())` where `my_shadowed_type()`
+%% is defined in the module using the remoty type `my_generic` above.
+-type my_shadowed_type() :: user_types.
 
 -opaque my_opaque() :: integer().
 

--- a/test/test.erl
+++ b/test/test.erl
@@ -18,6 +18,7 @@ gen_should_pass() ->
              %% user_types.erl is referenced by remote_types.erl and opaque.erl.
              %% It is not in the sourcemap of the DB so let's import it manually
              gradualizer_db:import_erl_files(["test/should_pass/user_types.erl"]),
+             gradualizer_db:import_erl_files(["test/should_pass/other_module.erl"]),
              %% imported.erl references any.erl
              gradualizer_db:import_erl_files(["test/should_pass/any.erl"])
      end,


### PR DESCRIPTION
Fixes #326

I found a fix that was much much simpler than described in #326.
Essentially, reordering the operations in `get_type` to expand generics after resolving annotated types
made it more lazy.
The function that annotates types does not recurse in remote types so nested generics worked but not
if they were using a type with a similar name.
By expanding generics later, it does not recurse nor incorrectly annotate user types from the local module.

Three test case were added as well as a dummy module for tests:
1. The first test for nesting generics from different modules.
2. The second test for generics with an opaque type.
3. The third test for nesting generics within the same module.

Should I add a test case for records?