### PR TITLE
Non-trivial sum type exhaustiveness checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ test/arg.beam: test/should_fail/arg.erl
 test_data_erls = $(wildcard test/known_problems/**/*.erl test/should_fail/*.erl test/should_pass/*.erl)
 build_test_data:
 	mkdir -p "test_data"
-	erlc -o test_data $(test_data_erls)
+	erlc $(ERLC_OPTS) -o test_data $(test_data_erls)
 
 EUNIT_OPTS =
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ erls = $(wildcard src/*.erl)
 beams = $(erls:src/%.erl=ebin/%.beam)
 
 ERLC_OPTS = -I include -pa ebin +debug_info
+TEST_ERLC_OPTS = +debug_info
 
 app: $(beams) ebin/gradualizer.app
 
@@ -132,7 +133,7 @@ test/arg.beam: test/should_fail/arg.erl
 test_data_erls = $(wildcard test/known_problems/**/*.erl test/should_fail/*.erl test/should_pass/*.erl)
 build_test_data:
 	mkdir -p "test_data"
-	erlc $(ERLC_OPTS) -o test_data $(test_data_erls)
+	erlc $(TEST_ERLC_OPTS) -o test_data $(test_data_erls)
 
 EUNIT_OPTS =
 

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -2,7 +2,7 @@
 
 -module(gradualizer_lib).
 
--export([merge_with/3, top_sort/1, get_user_type_definition/4,
+-export([merge_with/3, top_sort/1, get_user_type_definition/2,
          pick_value/2, fold_ast/3, get_ast_children/1,
          empty_tenv/0, create_tenv/3]).
 -export_type([graph/1, tenv/0]).
@@ -91,7 +91,16 @@ reverse_graph(G) ->
     from_edges(maps:keys(G), [ {J, I} || {I, Js} <- maps:to_list(G), J <- Js ]).
 
 
-get_user_type_definition(Types, Anno, Name, Args) ->
+%% Look up `UserTy' definition:
+%% first in `gradualizer_db', then, if not found, in provided `Types' map.
+%% `UserTy' is actually an unexported `gradualizer_type:af_user_defined_type()'.
+
+-spec get_user_type_definition(UserTy, Types) -> Ty when
+      UserTy :: gradualizer_type:abstract_type(),
+      Types :: #{{Name :: atom(), arity()} => {Params :: [atom()],
+                                               Body :: gradualizer_type:abstract_type()}},
+      Ty :: gradualizer_type:abstract_type().
+get_user_type_definition({user_type, Anno, Name, Args}, Types) ->
     %% Let's check if the type is a known remote type.
     case typelib:get_module_from_annotation(Anno) of
         {ok, Module} ->

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -95,7 +95,7 @@ get_user_type_definition(Types, Anno, Name, Args) ->
     %% Let's check if the type is a known remote type.
     case typelib:get_module_from_annotation(Anno) of
         {ok, Module} ->
-            case gradualizer_db:get_type(Module, Name, Args) of
+            case gradualizer_db:get_opaque_type(Module, Name, Args) of
                 {ok, Ty} ->
                     {ok, Ty};
                 not_found ->

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -195,7 +195,8 @@ pick_value(Type, TEnv)
         {ok, Ty} ->
             pick_value(Ty, TEnv);
         opaque ->
-            {var, Anno, '_Opaque'};
+            UniqueOpaque = list_to_atom("Opaque" ++ integer_to_list(erlang:unique_integer([positive]))),
+            {var, Anno, UniqueOpaque};
         not_found ->
             throw({undef, Kind, Anno, {Name, length(Args)}})
     end.

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -92,21 +92,21 @@ reverse_graph(G) ->
 
 
 get_user_type_definition(Types, Anno, Name, Args) ->
-    %% Let's check if the type is defined in the context of this module.
-    case maps:get({Name, length(Args)}, Types, not_found) of
-        {_Params, Ty} ->
-            {ok, Ty};
-        not_found ->
-            %% Let's check if the type is a known remote type.
-            case typelib:get_module_from_annotation(Anno) of
-                {ok, Module} ->
-                    case gradualizer_db:get_type(Module, Name, Args) of
-                        {ok, Ty} ->
-                            {ok, Ty};
-                        not_found ->
-                            not_found
-                    end;
-                none ->
+    %% Let's check if the type is a known remote type.
+    case typelib:get_module_from_annotation(Anno) of
+        {ok, Module} ->
+            case gradualizer_db:get_type(Module, Name, Args) of
+                {ok, Ty} ->
+                    {ok, Ty};
+                not_found ->
+                    not_found
+            end;
+        none ->
+            %% Let's check if the type is defined in the context of this module.
+            case maps:get({Name, length(Args)}, Types, not_found) of
+                {_Params, Ty} ->
+                    {ok, Ty};
+                not_found ->
                     not_found
             end
     end.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3213,7 +3213,7 @@ check_exhaustiveness(Env = #env{tenv = TEnv}, ArgsTy, Clauses, RefinedArgsTy, Va
           is_list(RefinedArgsTy) andalso lists:any(fun (T) -> T =/= type(none) end, RefinedArgsTy)} of
         {true, true, true, true} ->
             [{clause, P, _, _, _}|_] = Clauses,
-            throw({nonexhaustive, P, gradualizer_lib:pick_value(RefinedArgsTy, TEnv#tenv.types)});
+            throw({nonexhaustive, P, gradualizer_lib:pick_value(RefinedArgsTy, TEnv)});
         _ ->
             ok
     end,
@@ -3473,8 +3473,6 @@ refinable(?type(tuple, Tys), TEnv, Trace) when is_list(Tys) ->
     lists:all(fun (Ty) -> refinable(Ty, TEnv, Trace) end, Tys);
 refinable(?type(record, [_ | Fields]), TEnv, Trace) ->
     lists:all(fun (Ty) -> refinable(Ty, TEnv, Trace) end, [X || ?type(field_type, X) <- Fields]);
-refinable({var, _, _TypeVar}, _TEnv, _Trace) ->
-    true;
 refinable(RefinableTy, TEnv, Trace)
   when element(1, RefinableTy) =:= remote_type; element(1, RefinableTy) =:= user_type ->
     case sets:is_element(RefinableTy, Trace) of
@@ -3485,7 +3483,7 @@ refinable(RefinableTy, TEnv, Trace)
             %% Refinability will be determined by the variants which are not (mutually) recursive.
             true;
         false ->
-            case gradualizer_lib:get_type_definition(RefinableTy, TEnv#tenv.types) of
+            case gradualizer_lib:get_type_definition(RefinableTy, TEnv) of
                 {ok, Ty} -> refinable(Ty, TEnv, sets:add_element(RefinableTy, Trace));
                 opaque -> true;
                 not_found -> false

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3473,7 +3473,7 @@ refinable(?type(tuple, Tys), TEnv, Trace) when is_list(Tys) ->
     lists:all(fun (Ty) -> refinable(Ty, TEnv, Trace) end, Tys);
 refinable(?type(record, [_ | Fields]), TEnv, Trace) ->
     lists:all(fun (Ty) -> refinable(Ty, TEnv, Trace) end, [X || ?type(field_type, X) <- Fields]);
-refinable(RefinableTy = {user_type, Anno, Name, Args}, TEnv, Trace) ->
+refinable(RefinableTy = {user_type, _Anno, _Name, _Args}, TEnv, Trace) ->
     case sets:is_element(RefinableTy, Trace) of
         true ->
             %% We're searching down the variants of a recursive type and we've
@@ -3482,7 +3482,7 @@ refinable(RefinableTy = {user_type, Anno, Name, Args}, TEnv, Trace) ->
             %% Refinability will be determined by the variants which are not (mutually) recursive.
             true;
         false ->
-            case gradualizer_lib:get_user_type_definition(TEnv#tenv.types, Anno, Name, Args) of
+            case gradualizer_lib:get_user_type_definition(RefinableTy, TEnv#tenv.types) of
                 {ok, Ty} -> refinable(Ty, TEnv, sets:add_element(RefinableTy, Trace));
                 not_found -> false
             end

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3484,6 +3484,7 @@ refinable(RefinableTy = {user_type, _Anno, _Name, _Args}, TEnv, Trace) ->
         false ->
             case gradualizer_lib:get_user_type_definition(RefinableTy, TEnv#tenv.types) of
                 {ok, Ty} -> refinable(Ty, TEnv, sets:add_element(RefinableTy, Trace));
+                opaque -> false;
                 not_found -> false
             end
     end;

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3213,7 +3213,7 @@ check_exhaustiveness(Env = #env{tenv = TEnv}, ArgsTy, Clauses, RefinedArgsTy, Va
           is_list(RefinedArgsTy) andalso lists:any(fun (T) -> T =/= type(none) end, RefinedArgsTy)} of
         {true, true, true, true} ->
             [{clause, P, _, _, _}|_] = Clauses,
-            throw({nonexhaustive, P, gradualizer_lib:pick_value(TEnv#tenv.types, RefinedArgsTy)});
+            throw({nonexhaustive, P, gradualizer_lib:pick_value(RefinedArgsTy, TEnv#tenv.types)});
         _ ->
             ok
     end,

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3213,7 +3213,7 @@ check_exhaustiveness(Env = #env{tenv = TEnv}, ArgsTy, Clauses, RefinedArgsTy, Va
           is_list(RefinedArgsTy) andalso lists:any(fun (T) -> T =/= type(none) end, RefinedArgsTy)} of
         {true, true, true, true} ->
             [{clause, P, _, _, _}|_] = Clauses,
-            throw({nonexhaustive, P, gradualizer_lib:pick_value(RefinedArgsTy)});
+            throw({nonexhaustive, P, gradualizer_lib:pick_value(TEnv#tenv.types, RefinedArgsTy)});
         _ ->
             ok
     end,

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3473,6 +3473,10 @@ refinable(?type(tuple, Tys), TEnv, Trace) when is_list(Tys) ->
     lists:all(fun (Ty) -> refinable(Ty, TEnv, Trace) end, Tys);
 refinable(?type(record, [_ | Fields]), TEnv, Trace) ->
     lists:all(fun (Ty) -> refinable(Ty, TEnv, Trace) end, [X || ?type(field_type, X) <- Fields]);
+refinable(?top(), _TEnv, _Trace) ->
+    %% This clause prevents incorrect exhaustiveness warnings
+    %% when `gradualizer:top()' is used explicitly.
+    false;
 refinable(RefinableTy, TEnv, Trace)
   when element(1, RefinableTy) =:= remote_type; element(1, RefinableTy) =:= user_type ->
     case sets:is_element(RefinableTy, Trace) of

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3203,13 +3203,14 @@ check_clauses(Env = #env{tenv = TEnv}, ArgsTy, ResTy, Clauses, Caps) ->
                     end,
                     {[], [], ArgsTy, Env#env.venv},
                     Clauses),
-    % Checking for exhaustive patternmatching
-    case {Env#env.exhaust
-         ,ArgsTy =/= any andalso
-          lists:all(fun refinable/1, ArgsTy)
-         ,lists:all(fun no_guards/1, Clauses)
-         ,is_list(RefinedArgsTy) andalso
-          lists:any(fun (T) -> T =/= type(none) end, RefinedArgsTy)} of
+    % Checking for exhaustive pattern matching
+    check_exhaustiveness(Env, ArgsTy, Clauses, RefinedArgsTy, VarBindsList, Css).
+
+check_exhaustiveness(Env = #env{}, ArgsTy, Clauses, RefinedArgsTy, VarBindsList, Css) ->
+    case {Env#env.exhaust,
+          ArgsTy =/= any andalso lists:all(fun refinable/1, ArgsTy),
+          lists:all(fun no_guards/1, Clauses),
+          is_list(RefinedArgsTy) andalso lists:any(fun (T) -> T =/= type(none) end, RefinedArgsTy)} of
         {true, true, true, true} ->
             [{clause, P, _, _, _}|_] = Clauses,
             throw({nonexhaustive, P, gradualizer_lib:pick_value(RefinedArgsTy)});

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3482,23 +3482,9 @@ refinable(TEnv = #tenv{}, RefinableTy = {user_type, Anno, Name, Args}, Trace) ->
             %% Refinability will be determined by the variants which are not (mutually) recursive.
             true;
         false ->
-            %% Let's check if the type is defined in the context of this module.
-            case maps:get({Name, length(Args)}, TEnv#tenv.types, not_found) of
-                {_Params, Ty} ->
-                    refinable(TEnv, Ty, sets:add_element(RefinableTy, Trace));
-                not_found ->
-                    %% Let's check if the type is a known remote type.
-                    case typelib:get_module_from_annotation(Anno) of
-                        {ok, Module} ->
-                            case gradualizer_db:get_type(Module, Name, Args) of
-                                {ok, Ty} ->
-                                    refinable(TEnv, Ty, sets:add_element(RefinableTy, Trace));
-                                not_found ->
-                                    false
-                            end;
-                        none ->
-                            false
-                    end
+            case gradualizer_lib:get_user_type_definition(TEnv#tenv.types, Anno, Name, Args) of
+                {ok, Ty} -> refinable(TEnv, Ty, sets:add_element(RefinableTy, Trace));
+                not_found -> false
             end
     end;
 refinable(_, _, _) ->

--- a/test/known_problems/should_fail/exhaustive_map_variants.erl
+++ b/test/known_problems/should_fail/exhaustive_map_variants.erl
@@ -1,0 +1,16 @@
+-module(exhaustive_map_variants).
+
+%% This extends cases from test/should_fail/exhaustive_user_type.erl to variants defined as maps.
+
+-export([map_variants/1]).
+
+-export_type([map_sum_t/0]).
+
+-type map_sum_t() :: #{field_one := _}
+                   | #{field_two := _}.
+
+-spec map_variants(map_sum_t()) -> ok.
+map_variants(T) ->
+    case T of
+        #{field_one := _} -> ok
+    end.

--- a/test/known_problems/should_fail/exhaustive_remote_map_variants.erl
+++ b/test/known_problems/should_fail/exhaustive_remote_map_variants.erl
@@ -1,0 +1,15 @@
+-module(exhaustive_remote_map_variants).
+
+%% This is the remote type counterpart
+%% of test/known_problems/should_fail/exhaustive_map_variants.erl
+%%
+%% See also test/should_fail/exhaustive_user_type.erl
+%% and test/should_fail/exhaustive_remote_user_type.erl
+
+-export([remote_map_variants/1]).
+
+-spec remote_map_variants(exhaustive_user_type:map_sum_t()) -> ok.
+remote_map_variants(T) ->
+    case T of
+        #{field_one := _} -> ok
+    end.

--- a/test/should_fail/exhaustive_remote_user_type.erl
+++ b/test/should_fail/exhaustive_remote_user_type.erl
@@ -1,0 +1,18 @@
+-module(exhaustive_remote_user_type).
+
+-export([local_alias/1,
+         remote/1]).
+
+-type alias_t() :: exhaustive_user_type:t().
+
+-spec local_alias(alias_t()) -> ok.
+local_alias(T) ->
+    case T of
+        {true, _} -> ok
+    end.
+
+-spec remote(exhaustive_user_type:t()) -> ok.
+remote(T) ->
+    case T of
+        {true, _} -> ok
+    end.

--- a/test/should_fail/exhaustive_remote_user_type.erl
+++ b/test/should_fail/exhaustive_remote_user_type.erl
@@ -1,14 +1,22 @@
 -module(exhaustive_remote_user_type).
 
 -export([local_alias/1,
+         local_alias_to_recursive_type/1,
          remote/1]).
 
 -type alias_t() :: exhaustive_user_type:t().
+-type recursive_t() :: exhaustive_user_type:recursive_t().
 
 -spec local_alias(alias_t()) -> ok.
 local_alias(T) ->
     case T of
         {true, _} -> ok
+    end.
+
+-spec local_alias_to_recursive_type(recursive_t()) -> ok.
+local_alias_to_recursive_type(T) ->
+    case T of
+        ok -> ok
     end.
 
 -spec remote(exhaustive_user_type:t()) -> ok.

--- a/test/should_fail/exhaustive_remote_user_type.erl
+++ b/test/should_fail/exhaustive_remote_user_type.erl
@@ -2,7 +2,9 @@
 
 -export([local_alias/1,
          local_alias_to_recursive_type/1,
-         remote/1]).
+         remote/1,
+         generic_with_remote_opaque/1,
+         remote_opaque/1]).
 
 -type alias_t() :: exhaustive_user_type:t().
 -type recursive_t() :: exhaustive_user_type:recursive_t().
@@ -23,4 +25,18 @@ local_alias_to_recursive_type(T) ->
 remote(T) ->
     case T of
         {true, _} -> ok
+    end.
+
+-type g(T) :: ok | {generic, T}.
+
+-spec generic_with_remote_opaque(g(exhaustive_user_type:opaque_t())) -> ok.
+generic_with_remote_opaque(T) ->
+    case T of
+        ok -> ok
+    end.
+
+-spec remote_opaque(exhaustive_user_type:opaque_t()) -> ok.
+remote_opaque(T) ->
+    case T of
+        left -> ok
     end.

--- a/test/should_fail/exhaustive_remote_user_type.erl
+++ b/test/should_fail/exhaustive_remote_user_type.erl
@@ -4,7 +4,8 @@
          local_alias_to_recursive_type/1,
          remote/1,
          generic_with_remote_opaque/1,
-         remote_opaque/1]).
+         remote_opaque/1,
+         remote_record_variants/1]).
 
 -type alias_t() :: exhaustive_user_type:t().
 -type recursive_t() :: exhaustive_user_type:recursive_t().
@@ -39,4 +40,12 @@ generic_with_remote_opaque(T) ->
 remote_opaque(T) ->
     case T of
         left -> ok
+    end.
+
+-include("exhaustive_user_type.hrl").
+
+-spec remote_record_variants(exhaustive_user_type:record_sum_t()) -> ok.
+remote_record_variants(T) ->
+    case T of
+        #variant1{} -> ok
     end.

--- a/test/should_fail/exhaustive_user_type.erl
+++ b/test/should_fail/exhaustive_user_type.erl
@@ -6,7 +6,8 @@
          recursive/1,
          mutually_recursive/1]).
 
--export_type([t/0]).
+-export_type([t/0,
+              recursive_t/0]).
 
 -type info() :: integer().
 

--- a/test/should_fail/exhaustive_user_type.erl
+++ b/test/should_fail/exhaustive_user_type.erl
@@ -1,0 +1,14 @@
+-module(exhaustive_user_type).
+
+-export([test/1]).
+
+-type info() :: integer().
+
+-type t() :: {true, info()}
+           | {false, info()}.
+
+-spec test(t()) -> ok.
+test(T) ->
+    case T of
+        {true, _} -> ok
+    end.

--- a/test/should_fail/exhaustive_user_type.erl
+++ b/test/should_fail/exhaustive_user_type.erl
@@ -6,6 +6,8 @@
          recursive/1,
          mutually_recursive/1]).
 
+-export_type([t/0]).
+
 -type info() :: integer().
 
 -type t() :: {true, info()}

--- a/test/should_fail/exhaustive_user_type.erl
+++ b/test/should_fail/exhaustive_user_type.erl
@@ -1,14 +1,35 @@
 -module(exhaustive_user_type).
 
--export([test/1]).
+-compile(debug_info).
+
+-export([simple/1,
+         recursive/1,
+         mutually_recursive/1]).
 
 -type info() :: integer().
 
 -type t() :: {true, info()}
            | {false, info()}.
 
--spec test(t()) -> ok.
-test(T) ->
+-spec simple(t()) -> ok.
+simple(T) ->
     case T of
         {true, _} -> ok
+    end.
+
+-type recursive_t() :: ok | {r, recursive_t()}.
+
+-spec recursive(recursive_t()) -> ok.
+recursive(T) ->
+    case T of
+        ok -> ok
+    end.
+
+-type mutually_recursive1_t() :: ok | {mr1, mutually_recursive2_t()}.
+-type mutually_recursive2_t() :: ok | {mr2, mutually_recursive1_t()}.
+
+-spec mutually_recursive(mutually_recursive1_t()) -> ok.
+mutually_recursive(T) ->
+    case T of
+        ok -> ok
     end.

--- a/test/should_fail/exhaustive_user_type.erl
+++ b/test/should_fail/exhaustive_user_type.erl
@@ -1,7 +1,5 @@
 -module(exhaustive_user_type).
 
--compile(debug_info).
-
 -export([simple/1,
          recursive/1,
          mutually_recursive/1,

--- a/test/should_fail/exhaustive_user_type.erl
+++ b/test/should_fail/exhaustive_user_type.erl
@@ -4,7 +4,8 @@
 
 -export([simple/1,
          recursive/1,
-         mutually_recursive/1]).
+         mutually_recursive/1,
+         generic/1]).
 
 -export_type([t/0,
               recursive_t/0]).
@@ -33,6 +34,14 @@ recursive(T) ->
 
 -spec mutually_recursive(mutually_recursive1_t()) -> ok.
 mutually_recursive(T) ->
+    case T of
+        ok -> ok
+    end.
+
+-type g(T) :: ok | {generic, T}.
+
+-spec generic(g(integer())) -> ok.
+generic(T) ->
     case T of
         ok -> ok
     end.

--- a/test/should_fail/exhaustive_user_type.erl
+++ b/test/should_fail/exhaustive_user_type.erl
@@ -5,11 +5,13 @@
          mutually_recursive/1,
          generic/1,
          local_opaque/1,
-         generic_with_local_opaque/1]).
+         generic_with_local_opaque/1,
+         record_variants/1]).
 
 -export_type([t/0,
               recursive_t/0,
-              opaque_t/0]).
+              opaque_t/0,
+              record_sum_t/0]).
 
 -type info() :: integer().
 
@@ -59,4 +61,15 @@ local_opaque(T) ->
 generic_with_local_opaque(T) ->
     case T of
         ok -> ok
+    end.
+
+-include("exhaustive_user_type.hrl").
+
+-type record_sum_t() :: #variant1{}
+                      | #variant2{}.
+
+-spec record_variants(record_sum_t()) -> ok.
+record_variants(T) ->
+    case T of
+        #variant1{} -> ok
     end.

--- a/test/should_fail/exhaustive_user_type.erl
+++ b/test/should_fail/exhaustive_user_type.erl
@@ -5,10 +5,13 @@
 -export([simple/1,
          recursive/1,
          mutually_recursive/1,
-         generic/1]).
+         generic/1,
+         local_opaque/1,
+         generic_with_local_opaque/1]).
 
 -export_type([t/0,
-              recursive_t/0]).
+              recursive_t/0,
+              opaque_t/0]).
 
 -type info() :: integer().
 
@@ -42,6 +45,20 @@ mutually_recursive(T) ->
 
 -spec generic(g(integer())) -> ok.
 generic(T) ->
+    case T of
+        ok -> ok
+    end.
+
+-opaque opaque_t() :: left | right.
+
+-spec local_opaque(opaque_t()) -> ok.
+local_opaque(T) ->
+    case T of
+        left -> ok
+    end.
+
+-spec generic_with_local_opaque(g(opaque_t())) -> ok.
+generic_with_local_opaque(T) ->
     case T of
         ok -> ok
     end.

--- a/test/should_fail/exhaustive_user_type.erl
+++ b/test/should_fail/exhaustive_user_type.erl
@@ -11,7 +11,8 @@
 -export_type([t/0,
               recursive_t/0,
               opaque_t/0,
-              record_sum_t/0]).
+              record_sum_t/0,
+              map_sum_t/0]).
 
 -type info() :: integer().
 
@@ -73,3 +74,13 @@ record_variants(T) ->
     case T of
         #variant1{} -> ok
     end.
+
+-type map_sum_t() :: #{field_one := _}
+                   | #{field_two := _}.
+
+%% See test/known_problems/should_fail/exhaustive_map_variants.erl
+%-spec map_variants(map_sum_t()) -> ok.
+%map_variants(T) ->
+%    case T of
+%        #{field_one := _} -> ok
+%    end.

--- a/test/should_fail/exhaustive_user_type.hrl
+++ b/test/should_fail/exhaustive_user_type.hrl
@@ -1,0 +1,2 @@
+-record(variant1, {a}).
+-record(variant2, {b}).

--- a/test/should_fail/string_literal.erl
+++ b/test/should_fail/string_literal.erl
@@ -1,4 +1,4 @@
--module(string).
+-module(string_literal).
 
 -export([f/0]).
 

--- a/test/test.erl
+++ b/test/test.erl
@@ -33,7 +33,9 @@ gen_should_fail() ->
         fun() ->
             %% user_types.erl is referenced by opaque_fail.erl.
             %% It is not in the sourcemap of the DB so let's import it manually
-            gradualizer_db:import_erl_files(["test/should_pass/user_types.erl"])
+            gradualizer_db:import_erl_files(["test/should_pass/user_types.erl"]),
+            %% exhaustive_user_type.erl is referenced by exhaustive_remote_user_type.erl
+            gradualizer_db:import_erl_files(["test/should_fail/exhaustive_user_type.erl"])
         end,
         map_erl_files(
             fun(File) ->
@@ -41,7 +43,7 @@ gen_should_fail() ->
                     Errors = gradualizer:type_check_file(File, [return_errors]),
                     %% Test that error formatting doesn't crash
                     Opts = [{fmt_location, brief},
-                        {fmt_expr_fun, fun erl_prettypr:format/1}],
+                            {fmt_expr_fun, fun erl_prettypr:format/1}],
                     lists:foreach(fun({_, Error}) -> gradualizer_fmt:handle_type_error(Error, Opts) end, Errors),
                     {ok, Forms} = gradualizer_file_utils:get_forms_from_erl(File, []),
                     ExpectedErrors = typechecker:number_of_exported_functions(Forms),


### PR DESCRIPTION
I tried exercising sum type exhaustiveness checking on some practical examples and realised that these checks only worked on simple sum types whose variants were builtin types - e.g. an alternative of atoms:

```erlang
-type allergen() :: eggs
                  | chocolate
                  | pollen
                  | cats.
```

I hoped I could rely on these checks when defining functions over a type with many variants, each carrying extra data. For example:

```erlang
-type term_() :: {true, info()}
               | {false, info()}
               | {'if', info(), term_(), term_(), term_()}
               | {zero, info()}
               | {succ, info(), term_()}
               | {pred, info(), term_()}
               | {is_zero, info(), term_()}.
```

The first approach was to enable `typechecker:refinable()` and `gradualizer_lib:pick_value()` to handle `{user_type, _, _, _}` types. However, this first implementation was prone to falling into an infinite loop on recursive variants. This lead me to add the `Trace` parameter to `refinable` - in other words, I optimistically assume that a type T is refinable as soon as recursion on T's variants reaches T again. This assumes that the other non-recursive variants of T will ultimately determine its refinability. Thanks to storing a trace of already seen types instead of a binary `seen | not-seen` flag mutually recursive types are also handled gracefully.

Then it turned out that if the sum type is defined in another module, the check doesn't work. Obviously, data types like this might be handled in multiple modules of a project, so this was not acceptable. The fix I applied is too look up user types in `gradualizer_db` first and only if not found there try the available `TEnv`. [I tried the reverse order](https://github.com/erszcz/Gradualizer/tree/exhaustive-user-type-normalize-remote-type) (`TEnv` first, then `gradualizer_db`), but it seems to lead to more convoluted code since `#tenv{}` is not available in a header, therefore not shareable with `gradualizer_lib` - nothing impossible to handle, but the former fix was already good enough.

Ultimately, this allows to rely on exhaustiveness warnings when working with (mutually recursive) non-trivial variant types from external modules, which IMO is a significant ergonomics improvement. For a larger example, please see https://github.com/erszcz/tapl-erlang/commit/300d1ed100ab1c820dc2fd54d290345f3449a231 and try:

```
$ rebar3 compile
$ gradualizer -pa _build/default/lib/arith/ebin -- src/arith_core.erl
src/arith_core.erl: Nonexhaustive patterns on line 34 at column 9
Example values which are not covered:
	{false, 0}
```

Gradualizer correctly detects the missing clauses:

```erlang
-type term_() :: arith_syntax:term_().

-spec eval1(term_()) -> term_().
eval1(T) ->
    case T of
        %{false, _} ->
        %    erlang:throw(constant);
        %{true, _} ->
        %    erlang:throw(constant);
        %{zero, _} ->
        %    erlang:throw(constant);
        %{'if', _, {true, _}, T2, _} ->
        %    T2;
        %{'if', _, {false, _}, _, T3} ->
        %    T3;
        %{'if', Info, T1, T2, T3} ->
        %    T1_ = eval1(T1),
        %    {'if', Info, T1_, T2, T3};
        {succ, Info, T1} ->
            T1_ = eval1(T1),
            {succ, Info, T1_};
        {pred, _, {zero, _}} ->
            {zero, 0};
        {pred, _, {succ, _, T1}} ->
            T1;
        {pred, Info, T1} ->
            T1_ = eval1(T1),
            {pred, Info, T1_};
        {is_zero, _, {zero, _}} ->
            {true, 0};
        {is_zero, _, {succ, _, _}} ->
            {false, 0};
        {is_zero, Info, T1} ->
            T1_ = eval1(T1),
            {is_zero, Info, T1_}
    end.
```