### PR TITLE
Publish to hex.pm automatically when this repo is tagged.

### DIFF
--- a/.github/workflows/publish-to-hex.yml
+++ b/.github/workflows/publish-to-hex.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out
+        uses: actions/checkout@v2
+
+      - name: Publish to Hex.pm
+        uses: erlangpack/github-action@v1
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/src/gradualizer.app.src
+++ b/src/gradualizer.app.src
@@ -1,11 +1,12 @@
 {application, gradualizer,
  [{description, "A type checker for Erlang"},
-  {vsn, "0.1.0"},
+  {vsn, "git"},
   {registered, []},
   {applications,
    [kernel,
     stdlib
    ]},
+  {licenses, ["MIT License"]},
   {mod, {gradualizer_app, []}},
   {env,[
       {providers, [rebar_prv_gradualizer]}


### PR DESCRIPTION
In this PR, I use GitHub Actions [erlangpack/github-action@v1](https://github.com/erlangpack/github-action) and [actions/checkout@v2](https://github.com/actions/checkout) to automate hex package publishing.

@josefs You have to generate Hex API key via this [link](https://hex.pm/dashboard/keys) and place it in Repository secrets.

<img width="1367" alt="image" src="https://user-images.githubusercontent.com/20479699/119797886-3b948000-bf0d-11eb-8ff3-1fc851da4c06.png">


I have added @zuiderkwast as owner of this package. I need your username @josefs .

close #331 