### PR TITLE
Clean up hack in `glb` and `add_any_types_pat`

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -411,7 +411,7 @@ glb(T1, T2, A, TEnv) ->
         %% actual use case.
         true -> {type(none), constraints:empty()};
         false ->
-            Module = maps:get(module, TEnv, '$__improbable__module__name__$'),
+            Module = maps:get(module, TEnv),
             case gradualizer_cache:get_glb(Module, T1, T2) of
                 false ->
                     Ty1 = typelib:remove_pos(normalize(T1, TEnv)),
@@ -4054,13 +4054,7 @@ add_any_types_pat({bin, _, BinElements}, VEnv) ->
 add_any_types_pat({var, _, '_'}, VEnv) ->
     VEnv;
 add_any_types_pat({var, _, A}, VEnv) ->
-    case VEnv of
-        #{A := VarTy} ->
-            {RefinedTy, _Cs} = glb(VarTy, type(any), gradualizer_lib:empty_tenv()),
-            VEnv#{ A := RefinedTy };
-        _ ->
-            VEnv#{ A => type(any) }
-    end;
+    VEnv#{ A => type(any) };
 add_any_types_pat({op, _, '++', _Pat1, Pat2}, VEnv) ->
     %% Pat1 cannot contain any variables so there is no need to traverse it.
     add_any_types_pat(Pat2, VEnv);


### PR DESCRIPTION
In `add_any_types_pat` we called `glb` with one of the arguments
being `any()`. But that always returns `any()`! So we can simplify
that whole call away.
Furthermore, the call to `glb` used an `empty_tenv` which is going
to crash since `glb` needs the module name from the `tenv` but
`empty_tenv` doesn't set the module name.
So now, instead of hacking around the fact that `glb` might not get
a proper module name, we will simply always fail. This will help
us catch bugs like these faster in the future.

This issue was highlighted by @erszcz in #333. Thanks!