### PR TITLE
Fix refinable record fields

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -5,7 +5,7 @@
 
 %% Export all for easier testing and debugging while the project is
 %% still in an early stage
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -include("typelib.hrl").
 

--- a/test/known_problems/should_fail/exhaustive_record.erl
+++ b/test/known_problems/should_fail/exhaustive_record.erl
@@ -1,0 +1,34 @@
+-module(exhaustive_record).
+
+-compile([export_all, nowarn_export_all]).
+
+
+%% This file copies the structure from test/should_fail/record_exhaustive.erl
+
+-record(inner, {
+    field :: integer()
+}).
+
+-record(record_one_field, {
+    inner_rec :: #inner{} | undefined
+}).
+
+-record(record_two_fields, {
+    a :: #record_one_field{},
+    b :: integer() | undefined
+}).
+
+%% expected error message in the console:
+%%     Example values which are not covered:
+%%     #record_two_fields{
+%%       a = #record_one_field{
+%%         inner_rec = undefined
+%%       },
+%%     }
+-spec two_fields_inner(#record_two_fields{} | undefined) -> integer().
+two_fields_inner(#record_two_fields{a = #record_one_field{inner_rec = InnerRec = #inner{}}}) -> InnerRec#inner.field;
+%% unhandled
+% two_fields_inner(#record_two_fields{a = #record_one_field{inner_rec = undefined}}) -> 2;
+two_fields_inner(#record_two_fields{b = undefined}) -> 0;
+two_fields_inner(#record_two_fields{b = B}) -> B;
+two_fields_inner(undefined) -> 0.

--- a/test/should_fail/record_exhaustive.erl
+++ b/test/should_fail/record_exhaustive.erl
@@ -26,44 +26,21 @@ one_field(#record_one_field{inner_rec = InnerRec = #inner{}}) -> InnerRec#inner.
 %%one_field(#record_one_field{field = undefined}) -> -1;
 one_field(undefined) -> 0.
 
-%% expected error message in the console:
-%%     Example values which are not covered:
-%%     #record_two_fields{
-%%       a = #record_one_field{
-%%         inner_rec = undefined
-%%       },
-%%       b = 0
-%%     }
--spec two_fields(#record_two_fields{} | undefined) -> integer().
-two_fields(#record_two_fields{a = #record_one_field{inner_rec = InnerRec = #inner{}}}) -> InnerRec#inner.field;
-%% unhandled
-%%two_fields(#record_two_fields{a = #record_one_field{inner_rec = undefined}}) -> 2;
-two_fields(#record_two_fields{b = undefined}) -> 0;
-%% unhandled
-%%two_fields(#record_two_fields{b = B}) -> B;
-two_fields(undefined) -> 0.
 
-
-
-%% expected error message in the console:
-%%     Example values which are not covered:
-%%     #union_rec{
-%%       foo = c
-%%       bar = -1
-%%     }
--record(union_rec, {
-    foo :: a | b | c,
-    bar :: float()       %% non-refinable field
-}).
--spec union_rec(#union_rec{}) -> integer().
-union_rec(#union_rec{foo = a}) -> 0;
-union_rec(#union_rec{foo = b}) -> 1.
+-spec two_fields_b(#record_two_fields{} | undefined) -> integer().
+two_fields_b(#record_two_fields{a = #record_one_field{inner_rec = InnerRec = #inner{}}}) -> InnerRec#inner.field;
+two_fields_b(#record_two_fields{a = #record_one_field{inner_rec = undefined}}) -> 2;
+% two_fields_b(#record_two_fields{b = undefined}) -> 0;
 %% unhandled
-%%union_rec(#union_rec{foo = c}) -> 2.
+two_fields_b(#record_two_fields{b = B}) -> B;
+two_fields_b(undefined) -> 0.
+
 
 %% expected error message:
 %%     Example values which are not covered:
 %%     #empty_rec{}
 -record(empty_rec, {}).
 -spec empty_rec(#empty_rec{} | undefined) -> integer().
+%% unhandled
+% empty_rec(#empty_rec{}) -> 0;
 empty_rec(undefined) -> 1.


### PR DESCRIPTION
Previously, every record would be refined because the record
that was passed to `refinable/3` always had no fields.

Gradualizer would then crash on `pick_value` for types it cannot
pick an example value.

Now, the record is looked up in the REnv and every typed field of
the record is checked for "refinability".

Do I also need to lookup the records in gradualizer_db at that point (e.g. when checking for the refinement of a remote type)?