### PR TITLE
Improve self gradualization

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,3 +23,6 @@ jobs:
         run: "make"
       - name: "Run tests"
         run: "make tests"
+      - name: "Self-gradualize"
+        run: "make gradualize"
+        continue-on-error: true

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -44,6 +44,8 @@
 %% This type is the top of the subtyping lattice.
 -opaque top() :: any().
 
+-include("gradualizer.hrl").
+
 %% API functions
 
 %% @doc Type check a source or beam file
@@ -98,7 +100,8 @@ type_check_dir(Dir) ->
 type_check_dir(Dir, Opts) ->
     case filelib:is_dir(Dir) of
         true ->
-            type_check_files(filelib:wildcard(filename:join(Dir, "*.{erl,beam}")), Opts);
+            Pattern = ?assert_type(filename:join(Dir, "*.{erl,beam}"), file:filename()),
+            type_check_files(filelib:wildcard(Pattern), Opts);
         false ->
             throw({dir_not_found, Dir})
     end.

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -192,7 +192,7 @@ add_source_file_and_forms_to_opts(File, Forms, Opts) ->
     end.
 
 %% Extract -gradualizer(Options) from AST
--spec options_from_forms([erl_parse:abstract_form()]) -> options().
+-spec options_from_forms(gradualizer_file_utils:abstract_forms()) -> options().
 options_from_forms([{attribute, _L, gradualizer, Opts} | Fs]) when is_list(Opts) ->
     Opts ++ options_from_forms(Fs);
 options_from_forms([{attribute, _L, gradualizer, Opt} | Fs]) ->

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -166,8 +166,9 @@ type_check_forms(Forms, Opts) ->
     type_check_forms(File, Forms, Opts).
 
 %% Helper
--spec type_check_forms(file:filename(), [erl_parse:abstract_form()], options()) ->
-                            ok | nok | [{file:filename(), any()}].
+-spec type_check_forms(file:filename(), Forms, options()) -> R when
+      Forms :: gradualizer_file_utils:abstract_forms(),
+      R :: ok | nok | [{file:filename(), any()}].
 type_check_forms(File, Forms, Opts) ->
     ReturnErrors = proplists:get_bool(return_errors, Opts),
     OptsForModule = options_from_forms(Forms) ++ Opts,

--- a/src/gradualizer_app.erl
+++ b/src/gradualizer_app.erl
@@ -16,7 +16,15 @@
 
 start(_StartType, _StartArgs) ->
     Opts = application:get_env(gradualizer, options, []),
+    set_union_size_limit(Opts),
     gradualizer_sup:start_link(Opts).
 
 stop(_State) ->
     ok.
+
+set_union_size_limit(Opts) ->
+    case lists:keyfind(union_size_limit, 1, Opts) of
+        false -> ok;
+        {union_size_limit, L} ->
+            persistent_term:put(gradualizer_union_size_limit, L)
+    end.

--- a/src/gradualizer_bin.erl
+++ b/src/gradualizer_bin.erl
@@ -118,5 +118,5 @@ gcd1(A, 0) -> A;
 gcd1(A, B) ->
   case A rem B of
     0 -> B;
-    X -> gcd1(B, X)
+    X when X > 0 -> gcd1(B, X)
   end.

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -92,7 +92,7 @@ print_usage() ->
     io:format("       --fancy                   - Use fancy error messages when possible (on by default)~n"),
     io:format("       --no_fancy                - Don't use fancy error messages.~n"),
     io:format("       --union_size_limit        - Performance hack: Unions larger than this value~n"),
-    io:format("                                   are replaced by any() in normalization.").
+    io:format("                                   are replaced by any() in normalization (default: 30)~n").
 
 -spec parse_opts([string()], gradualizer:options()) -> {[string()], gradualizer:options()}.
 parse_opts([], Opts) ->

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -90,7 +90,9 @@ print_usage() ->
     io:format("                                   detection of a TTY doesn't work when running as an escript.~n"),
     io:format("       --no_color                - Alias for `--color never'~n"),
     io:format("       --fancy                   - Use fancy error messages when possible (on by default)~n"),
-    io:format("       --no_fancy                - Don't use fancy error messages.~n").
+    io:format("       --no_fancy                - Don't use fancy error messages.~n"),
+    io:format("       --union_size_limit        - Performance hack: Unions larger than this value~n"),
+    io:format("                                   are replaced by any() in normalization.").
 
 -spec parse_opts([string()], gradualizer:options()) -> {[string()], gradualizer:options()}.
 parse_opts([], Opts) ->
@@ -117,6 +119,7 @@ parse_opts([A | Args], Opts) ->
         "--no_color"               -> parse_opts(Args, [{color, never} | Opts]);
         "--fancy"                  -> parse_opts(Args, [fancy | Opts]);
         "--no_fancy"               -> parse_opts(Args, [{fancy, false} | Opts]);
+        "--union_size_limit"       -> handle_union_size_limit(A, Args, Opts);
         "--"                       -> {Args, Opts};
         "-" ++ _                   -> erlang:error(string:join(["Unknown parameter:", A], " "));
         _                          -> {[A | Args], Opts}
@@ -163,6 +166,12 @@ handle_color(["always"|Args], Opts) -> parse_opts(Args, [{color, always} | Opts]
 handle_color(["never" |Args], Opts) -> parse_opts(Args, [{color, never}  | Opts]);
 handle_color(["auto"  |Args], Opts) -> parse_opts(Args, [{color, auto}   | Opts]);
 handle_color(Args,            Opts) -> parse_opts(Args, [{color, always} | Opts]).
+
+handle_union_size_limit(_, [LimitS | Args], Opts) ->
+    Limit = list_to_integer(LimitS),
+    parse_opts(Args, [{union_size_limit, Limit}]);
+handle_union_size_limit(A, [], _Opts) ->
+    erlang:error(string:join(["Missing argument for", A], " ")).
 
 no_start_dash("-" ++ _) ->
     false;

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -298,7 +298,7 @@ import_prelude(State = #state{loaded = Loaded}) ->
     %% are loaded on demand
     State1#state{loaded = Loaded}.
 
--spec import_extra_specs(filelib:filename(), state()) -> state().
+-spec import_extra_specs(file:name(), state()) -> state().
 import_extra_specs(Dir, State = #state{loaded = Loaded}) ->
     FormsByModule = gradualizer_prelude_parse_trans:get_module_forms_tuples(Dir),
     %% Import forms each of the modules to override

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -246,10 +246,16 @@ handle_call({import_beam_files, Files}, _From, State) ->
         Error = {_, _} -> {reply, Error, State}
     end;
 handle_call({import_app, App}, _From, State) ->
-    Pattern = code:lib_dir(App) ++ "/src/*.erl",
-    Files = filelib:wildcard(Pattern),
-    State1 = import_erl_files(Files, [], State),
-    {reply, ok, State1};
+    case code:lib_dir(App) of
+        {error, bad_name} ->
+            error_logger:warning_msg("Unknown app: ~p", [App]),
+            {reply, ok, State};
+        LibDir ->
+            Pattern = LibDir ++ "/src/*.erl",
+            Files = filelib:wildcard(Pattern),
+            State1 = import_erl_files(Files, [], State),
+            {reply, ok, State1}
+    end;
 handle_call(import_otp, _From, State) ->
     Pattern = code:lib_dir() ++ "/*/src/*.erl",
     Files = filelib:wildcard(Pattern),

--- a/src/gradualizer_file_utils.erl
+++ b/src/gradualizer_file_utils.erl
@@ -9,9 +9,10 @@
 
 -type abstract_forms() :: [erl_parse:abstract_form() | erl_parse:form_info()].
 
--type parsed_file_error() :: {file_not_found, file:filename()} |
-                             {file_open_error, {file:posix() | badarg | system_limit, file:filename()}} |
-                             {forms_not_found, file:filename()} |
+-type parsed_file_error() :: {file_not_found, file:filename_all()} |
+                             {file_open_error, {file:posix() | badarg | system_limit,
+                                                file:filename_all()}} |
+                             {forms_not_found, file:filename_all()} |
                              {forms_error, Reason :: any()}.
 
 -type parsed_file() :: {ok, abstract_forms()} |
@@ -71,7 +72,7 @@ epp_open(File, Fd, StartLocation, Includes) ->
     end.
 
 %% Accepts a filename or the beam code as a binary
--spec get_forms_from_beam(file:filename() | binary()) -> parsed_file() | parsed_file_error().
+-spec get_forms_from_beam(file:filename_all()) -> parsed_file() | parsed_file_error().
 get_forms_from_beam(File) ->
     case beam_lib:chunks(File, [abstract_code]) of
         {ok, {_Module, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->

--- a/src/gradualizer_highlight.erl
+++ b/src/gradualizer_highlight.erl
@@ -177,7 +177,7 @@ highlight_line(Line, N, {L1, _C1}, {L2, C2}, Color) when L1 < N, N == L2 ->
     color_and_mark_line(Line, step_spaces(Line, 1), C2, Color);
 highlight_line(Line, N, {L1, _}, {L2, __}, Color) when L1 < N, N < L2 ->
     %% Internal line
-    color_and_mark_line(Line, step_spaces(Line, 1), length(Line) + 1, Color).
+    color_and_mark_line(Line, step_spaces(Line, 1), ?assert_type(length(Line) + 1, pos_integer()), Color).
 
 -spec step_spaces(string(), erl_anno:column()) -> erl_anno:column().
 step_spaces([$\t | Str], Col) -> step_spaces(Str, Col + 1);
@@ -190,18 +190,22 @@ blank("")          -> "".
 
 %% Color the string from column C1 to (not including) C2. Returns
 %% a list containing the colored line and a line with ^^^^ markers.
--spec color_and_mark_line(Line :: string(), StartCol :: erl_anno:column(),
-                          EndCol :: erl_anno:column(), Color :: boolean()) -> [string()].
-color_and_mark_line(Line, C1, C2, Color) ->
+-spec color_and_mark_line(Line, StartCol, EndCol, Color) -> [string()] when
+      Line :: string(),
+      StartCol :: erl_anno:column(),
+      EndCol :: erl_anno:column(),
+      Color :: boolean().
+color_and_mark_line(Line, C1, C2, Color) when C2 >= C1 ->
     {Pre, Rest} = lists:split(C1 - 1, Line),
-    {Mid, Post} = lists:split(C2 - C1, Rest),
+    HighlightLen = ?assert_type(C2 - C1, non_neg_integer()),
+    {Mid, Post} = lists:split(HighlightLen, Rest),
     {ColorText, ColorMarker, ColorEnd} =
         case Color of
             true  -> {?color_text, ?color_marker, ?color_end};
             false -> {"", "", ""}
         end,
     [Pre ++ ColorText ++ Mid ++ ColorEnd ++ Post,
-     blank(Pre) ++ ColorMarker ++ lists:duplicate(C2 - C1, ?marker_char) ++ ColorEnd].
+     blank(Pre) ++ ColorMarker ++ lists:duplicate(HighlightLen, ?marker_char) ++ ColorEnd].
 
 %% Finds a node in an AST and return its corresponding node in another AST.
 %% The AST is searched in depth first order.

--- a/src/gradualizer_highlight.erl
+++ b/src/gradualizer_highlight.erl
@@ -171,7 +171,7 @@ highlight_line(Line, N, {N, C1}, {N, C2}, Color) ->
     color_and_mark_line(Line, C1, C2, Color);
 highlight_line(Line, N, {L1, C1}, {L2, _C2}, Color) when L1 == N, N < L2 ->
     %% First line
-    color_and_mark_line(Line, C1, length(Line) + 1, Color);
+    color_and_mark_line(Line, C1, ?assert_type(length(Line) + 1, pos_integer()), Color);
 highlight_line(Line, N, {L1, _C1}, {L2, C2}, Color) when L1 < N, N == L2 ->
     %% Last line
     color_and_mark_line(Line, step_spaces(Line, 1), C2, Color);

--- a/src/gradualizer_prelude_parse_trans.erl
+++ b/src/gradualizer_prelude_parse_trans.erl
@@ -7,6 +7,8 @@
 
 -type forms() :: [erl_parse:abstract_form() | {error, _} | {eof, _}].
 
+-include("gradualizer.hrl").
+
 parse_transform(Forms, _Options) ->
     replace_get_modules_and_forms(Forms).
 
@@ -19,9 +21,10 @@ replace_get_modules_and_forms([{function, Anno, get_modules_and_forms, 0, _OldBo
 replace_get_modules_and_forms([Form | RestForms]) ->
     [Form | replace_get_modules_and_forms(RestForms)].
 
--spec get_module_forms_tuples(filelib:filename()) -> [{module(), forms()}].
+-spec get_module_forms_tuples(file:name_all()) -> [{module(), forms()}].
 get_module_forms_tuples(Dir) ->
-    Files = filelib:wildcard(filename:join([Dir, "*.specs.erl"])),
+    Pattern = ?assert_type(filename:join([Dir, "*.specs.erl"]), file:filename()),
+    Files = filelib:wildcard(Pattern),
     lists:map(fun get_module_and_forms/1, Files).
 
 %% Parses and returns the forms of a file along with the module given in the -module attribute

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1051,7 +1051,7 @@ expect_list_union([], AccTy, AccCs, _NoAny, _N, _TEnv) ->
 infer_literal_string("") ->
     type(nil);
 infer_literal_string(Str) ->
-    SortedChars = ?assert_type(lists:usort(Str), [A, ...]),
+    SortedChars = ?assert_type(lists:usort(Str), [char(), ...]),
     if length(SortedChars) =< 10 ->
             %% heuristics: if there are not more than 10 different characters
             %% list them explicitely as singleton types

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3561,7 +3561,7 @@ refine_ty(Ty1, Ty2, TEnv) ->
         _NotDisjoint -> throw(no_refinement) %% imprecision
     end.
 
--spec refine_map_field_ty({_, _}) -> gradualizer_type:abstract_type().
+-spec refine_map_field_ty({_, _}) -> [gradualizer_type:abstract_type()].
 %% For the same key K in both M1 and M2 the diff over its field (ignoring other keys) is:
 %%
 %% M1 \ M2    | #{K := V} | #{K => V}

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1050,7 +1050,7 @@ expect_list_union([], AccTy, AccCs, _NoAny, _N, _TEnv) ->
 infer_literal_string("") ->
     type(nil);
 infer_literal_string(Str) ->
-    SortedChars = lists:usort(Str),
+    SortedChars = ?assert_type(lists:usort(Str), [A, ...]),
     if length(SortedChars) =< 10 ->
             %% heuristics: if there are not more than 10 different characters
             %% list them explicitely as singleton types


### PR DESCRIPTION
This fixes the low-hanging fruit in self-gradualization. If applied together with #340 all map related errors are gone, too. This is done on OTP 24, I've not tested on other versions.

The remaining errors present even with this PR applied are due to:
- missing Rebar .beam files (typechecking the Rebar plugin)
- map typing issues (fixed if this one is used together with #340)
- actual limitations in Gradualizer, as far as I can tell mostly type refinement in guards

I think that with improved refinement some of the type assertions I added could also go away, but they're necessary as of now.