### PR TITLE
Add a GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,9 +18,6 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
-      - name: "Run tests"
-        run: "make && make tests"
-        continue-on-error: true
       - name: "Print gradualizer_db state"
         run: erl -eval 'application:ensure_all_started(gradualizer), io:format("~p\n", [ sys:get_state(gradualizer_db) ]), halt().' -pa ebin -noinput -noshell
         continue-on-error: true
@@ -33,3 +30,5 @@ jobs:
       - name: "Print code paths"
         run: erl -pa ebin -noinput -noshell -eval 'io:format("~p\n", [code:get_path()]), halt().'
         continue-on-error: true
+      - name: "Run tests"
+        run: "make && make tests"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Erlang ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ['24.1']
+        otp: ['22.3.4.20', '23.3.4.7', '24.1']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Erlang ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ['22.3.4.20', '23.3.4.7', '24.1']
+        otp: ['24.1']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,4 +18,18 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
-      - run: 'make && make tests'
+      - name: "Run tests"
+        run: "make && make tests"
+        continue-on-error: true
+      - name: "Print gradualizer_db state"
+        run: erl -eval 'application:ensure_all_started(gradualizer), io:format("~p\n", [ sys:get_state(gradualizer_db) ]), halt().' -pa ebin -noinput -noshell
+        continue-on-error: true
+      - name: "Print lists:deep_list() definition"
+        run: erl -eval 'application:ensure_all_started(gradualizer), io:format("~p\n", [gradualizer_lib:get_type_definition(typelib:remove_pos(typelib:parse_type("lists:deep_list()")), gradualizer_lib:empty_tenv(), [])]), halt().' -pa ebin -noinput -noshell
+        continue-on-error: true
+      - name: "Print prelude"
+        run: erl -pa ebin -noinput -noshell -eval 'io:format("~p\n", [gradualizer_prelude:get_modules_and_forms()]), halt().'
+        continue-on-error: true
+      - name: "Print code paths"
+        run: erl -pa ebin -noinput -noshell -eval 'io:format("~p\n", [code:get_path()]), halt().'
+        continue-on-error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,21 @@
+name: Build and test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: []
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Erlang ${{matrix.otp}}
+    strategy:
+      matrix:
+        otp: ['22.3.4.20', '23.3.4.7', '24.1']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+      - run: 'make && make tests'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,17 +18,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
-      - name: "Print gradualizer_db state"
-        run: erl -eval 'application:ensure_all_started(gradualizer), io:format("~p\n", [ sys:get_state(gradualizer_db) ]), halt().' -pa ebin -noinput -noshell
-        continue-on-error: true
-      - name: "Print lists:deep_list() definition"
-        run: erl -eval 'application:ensure_all_started(gradualizer), io:format("~p\n", [gradualizer_lib:get_type_definition(typelib:remove_pos(typelib:parse_type("lists:deep_list()")), gradualizer_lib:empty_tenv(), [])]), halt().' -pa ebin -noinput -noshell
-        continue-on-error: true
-      - name: "Print prelude"
-        run: erl -pa ebin -noinput -noshell -eval 'io:format("~p\n", [gradualizer_prelude:get_modules_and_forms()]), halt().'
-        continue-on-error: true
-      - name: "Print code paths"
-        run: erl -pa ebin -noinput -noshell -eval 'io:format("~p\n", [code:get_path()]), halt().'
-        continue-on-error: true
+      - name: "Build"
+        run: "make"
       - name: "Run tests"
-        run: "make && make tests"
+        run: "make tests"

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -167,10 +167,7 @@ type_check_forms(Forms, Opts) ->
                             ok | nok | [{file:filename(), any()}].
 type_check_forms(File, Forms, Opts) ->
     ReturnErrors = proplists:get_bool(return_errors, Opts),
-    OptsForModule =
-	options_from_forms(Forms) ++
-	Opts ++
-	[prelude], % using prelude is the default if nothing else is specified
+    OptsForModule = options_from_forms(Forms) ++ Opts,
     Errors = typechecker:type_check_forms(Forms, OptsForModule),
     case {ReturnErrors, Errors} of
         {true, _ } ->

--- a/src/gradualizer_app.erl
+++ b/src/gradualizer_app.erl
@@ -15,34 +15,6 @@
 %%%===================================================================
 
 start(_StartType, _StartArgs) ->
-    %dbg:tracer(process, {fun
-    %                         ({trace, Pid, call, {M, handle_call, [Msg, From, _State]}}, ok) ->
-    %                             Trace = {trace, Pid, call, {M, handle_call, [Msg, From, '#state{}']}},
-    %                             io:format("~p\n\n", [Trace]);
-    %                         ({trace, Pid, call, {M, Fun, [Msg, _State]}}, ok) when
-    %                               Fun =:= handle_cast;
-    %                               Fun =:= handle_info ->
-    %                             Trace = {trace, Pid, call, {M, Fun, [Msg, '#state{}']}},
-    %                             io:format("~p\n\n", [Trace]);
-    %                         ({trace, Pid, return_from, {M, Fun, Arity}, {ok, Type}}, ok) ->
-    %                             TypeS = typelib:pp_type(Type),
-    %                             Trace = {trace, Pid, return_from, {M, Fun, Arity}, 'Type'},
-    %                             io:format("~p\nType = ~ts\n\n", [Trace, TypeS]);
-    %                         (Trace, ok) ->
-    %                             io:format("~p\n\n", [Trace])
-    %                     end, ok}),
-    %%dbg:p(all, [call, arity]),
-    %dbg:p(all, [call]),
-    %dbg:tpl(gradualizer_db, start_link, []),
-    %dbg:tpl(gradualizer_db, init, []),
-    %dbg:tpl(gradualizer_db, import_prelude, []),
-    %dbg:tpl(gradualizer_db, import_extra_specs, []),
-    %dbg:tpl(gradualizer_db, handle_call, []),
-    %dbg:tpl(gradualizer_db, handle_cast, []),
-    %dbg:tpl(gradualizer_db, handle_info, []),
-    %dbg:tpl(gradualizer_db, get_spec, x),
-    %dbg:tpl(gradualizer_db, get_type, x),
-
     Opts = application:get_env(gradualizer, cli_options, []),
     gradualizer_sup:start_link(Opts).
 

--- a/src/gradualizer_app.erl
+++ b/src/gradualizer_app.erl
@@ -15,7 +15,7 @@
 %%%===================================================================
 
 start(_StartType, _StartArgs) ->
-    Opts = application:get_env(gradualizer, cli_options, []),
+    Opts = application:get_env(gradualizer, options, []),
     gradualizer_sup:start_link(Opts).
 
 stop(_State) ->

--- a/src/gradualizer_app.erl
+++ b/src/gradualizer_app.erl
@@ -15,33 +15,33 @@
 %%%===================================================================
 
 start(_StartType, _StartArgs) ->
-    dbg:tracer(process, {fun
-                             ({trace, Pid, call, {M, handle_call, [Msg, From, _State]}}, ok) ->
-                                 Trace = {trace, Pid, call, {M, handle_call, [Msg, From, '#state{}']}},
-                                 io:format("~p\n\n", [Trace]);
-                             ({trace, Pid, call, {M, Fun, [Msg, _State]}}, ok) when
-                                   Fun =:= handle_cast;
-                                   Fun =:= handle_info ->
-                                 Trace = {trace, Pid, call, {M, Fun, [Msg, '#state{}']}},
-                                 io:format("~p\n\n", [Trace]);
-                             ({trace, Pid, return_from, {M, Fun, Arity}, {ok, Type}}, ok) ->
-                                 TypeS = typelib:pp_type(Type),
-                                 Trace = {trace, Pid, return_from, {M, Fun, Arity}, 'Type'},
-                                 io:format("~p\nType = ~ts\n\n", [Trace, TypeS]);
-                             (Trace, ok) ->
-                                 io:format("~p\n\n", [Trace])
-                         end, ok}),
-    %dbg:p(all, [call, arity]),
-    dbg:p(all, [call]),
-    dbg:tpl(gradualizer_db, start_link, []),
-    dbg:tpl(gradualizer_db, init, []),
-    dbg:tpl(gradualizer_db, import_prelude, []),
-    dbg:tpl(gradualizer_db, import_extra_specs, []),
-    dbg:tpl(gradualizer_db, handle_call, []),
-    dbg:tpl(gradualizer_db, handle_cast, []),
-    dbg:tpl(gradualizer_db, handle_info, []),
-    dbg:tpl(gradualizer_db, get_spec, x),
-    dbg:tpl(gradualizer_db, get_type, x),
+    %dbg:tracer(process, {fun
+    %                         ({trace, Pid, call, {M, handle_call, [Msg, From, _State]}}, ok) ->
+    %                             Trace = {trace, Pid, call, {M, handle_call, [Msg, From, '#state{}']}},
+    %                             io:format("~p\n\n", [Trace]);
+    %                         ({trace, Pid, call, {M, Fun, [Msg, _State]}}, ok) when
+    %                               Fun =:= handle_cast;
+    %                               Fun =:= handle_info ->
+    %                             Trace = {trace, Pid, call, {M, Fun, [Msg, '#state{}']}},
+    %                             io:format("~p\n\n", [Trace]);
+    %                         ({trace, Pid, return_from, {M, Fun, Arity}, {ok, Type}}, ok) ->
+    %                             TypeS = typelib:pp_type(Type),
+    %                             Trace = {trace, Pid, return_from, {M, Fun, Arity}, 'Type'},
+    %                             io:format("~p\nType = ~ts\n\n", [Trace, TypeS]);
+    %                         (Trace, ok) ->
+    %                             io:format("~p\n\n", [Trace])
+    %                     end, ok}),
+    %%dbg:p(all, [call, arity]),
+    %dbg:p(all, [call]),
+    %dbg:tpl(gradualizer_db, start_link, []),
+    %dbg:tpl(gradualizer_db, init, []),
+    %dbg:tpl(gradualizer_db, import_prelude, []),
+    %dbg:tpl(gradualizer_db, import_extra_specs, []),
+    %dbg:tpl(gradualizer_db, handle_call, []),
+    %dbg:tpl(gradualizer_db, handle_cast, []),
+    %dbg:tpl(gradualizer_db, handle_info, []),
+    %dbg:tpl(gradualizer_db, get_spec, x),
+    %dbg:tpl(gradualizer_db, get_type, x),
 
     Opts = application:get_env(gradualizer, cli_options, []),
     gradualizer_sup:start_link(Opts).

--- a/src/gradualizer_app.erl
+++ b/src/gradualizer_app.erl
@@ -15,7 +15,36 @@
 %%%===================================================================
 
 start(_StartType, _StartArgs) ->
-    gradualizer_sup:start_link().
+    dbg:tracer(process, {fun
+                             ({trace, Pid, call, {M, handle_call, [Msg, From, _State]}}, ok) ->
+                                 Trace = {trace, Pid, call, {M, handle_call, [Msg, From, '#state{}']}},
+                                 io:format("~p\n\n", [Trace]);
+                             ({trace, Pid, call, {M, Fun, [Msg, _State]}}, ok) when
+                                   Fun =:= handle_cast;
+                                   Fun =:= handle_info ->
+                                 Trace = {trace, Pid, call, {M, Fun, [Msg, '#state{}']}},
+                                 io:format("~p\n\n", [Trace]);
+                             ({trace, Pid, return_from, {M, Fun, Arity}, {ok, Type}}, ok) ->
+                                 TypeS = typelib:pp_type(Type),
+                                 Trace = {trace, Pid, return_from, {M, Fun, Arity}, 'Type'},
+                                 io:format("~p\nType = ~ts\n\n", [Trace, TypeS]);
+                             (Trace, ok) ->
+                                 io:format("~p\n\n", [Trace])
+                         end, ok}),
+    %dbg:p(all, [call, arity]),
+    dbg:p(all, [call]),
+    dbg:tpl(gradualizer_db, start_link, []),
+    dbg:tpl(gradualizer_db, init, []),
+    dbg:tpl(gradualizer_db, import_prelude, []),
+    dbg:tpl(gradualizer_db, import_extra_specs, []),
+    dbg:tpl(gradualizer_db, handle_call, []),
+    dbg:tpl(gradualizer_db, handle_cast, []),
+    dbg:tpl(gradualizer_db, handle_info, []),
+    dbg:tpl(gradualizer_db, get_spec, x),
+    dbg:tpl(gradualizer_db, get_type, x),
+
+    Opts = application:get_env(gradualizer, cli_options, []),
+    gradualizer_sup:start_link(Opts).
 
 stop(_State) ->
     ok.

--- a/src/gradualizer_cache.erl
+++ b/src/gradualizer_cache.erl
@@ -9,7 +9,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0,
+-export([start_link/1,
          get_glb/3,
          store_glb/4
         ]).
@@ -30,11 +30,13 @@
 %% API
 %%===================================================================
 
--spec start_link() -> {ok, Pid :: pid()} |
-                      {error, Error :: {already_started, pid()}} |
-                      {error, Error :: any()}.
-start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+-spec start_link(Opts) -> R when
+      Opts :: list(),
+      R :: {ok, Pid :: pid()}
+         | {error, Error :: {already_started, pid()}}
+         | {error, Error :: any()}.
+start_link(Opts) ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [Opts], []).
 
 %%
 %% GLB Cache
@@ -66,7 +68,7 @@ store_glb(Module, T1, T2, TyCs) ->
 %% gen_server callbacks
 %%===================================================================
 
-init([]) ->
+init([_Opts]) ->
     ets:new(?GLB_CACHE, [set, public, named_table]),
     {ok, #state{}}.
 

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -23,7 +23,6 @@ start_application(Opts) ->
     %% A load after set_env overrides anything set with set_env.
     %% If gradualizer is run as an escript this should not be necessary, but better safe than sorry.
     ok = application:load(gradualizer),
-    %io:format("cli_options: ~p\n", [Opts]),
     application:set_env(gradualizer, cli_options, Opts),
     {ok, _} = application:ensure_all_started(gradualizer).
 

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -23,6 +23,7 @@ start_application(Opts) ->
     %% A load after set_env overrides anything set with set_env.
     %% If gradualizer is run as an escript this should not be necessary, but better safe than sorry.
     ok = application:load(gradualizer),
+    io:format("cli_options: ~p\n", [Opts]),
     application:set_env(gradualizer, cli_options, Opts),
     {ok, _} = application:ensure_all_started(gradualizer).
 

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -23,7 +23,7 @@ start_application(Opts) ->
     %% A load after set_env overrides anything set with set_env.
     %% If gradualizer is run as an escript this should not be necessary, but better safe than sorry.
     ok = application:load(gradualizer),
-    application:set_env(gradualizer, cli_options, Opts),
+    application:set_env(gradualizer, options, Opts),
     {ok, _} = application:ensure_all_started(gradualizer).
 
 -spec handle_args([string()]) -> help | version | {error, string()} |

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -23,7 +23,7 @@ start_application(Opts) ->
     %% A load after set_env overrides anything set with set_env.
     %% If gradualizer is run as an escript this should not be necessary, but better safe than sorry.
     ok = application:load(gradualizer),
-    io:format("cli_options: ~p\n", [Opts]),
+    %io:format("cli_options: ~p\n", [Opts]),
     application:set_env(gradualizer, cli_options, Opts),
     {ok, _} = application:ensure_all_started(gradualizer).
 

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -139,7 +139,7 @@ import_module(Module) ->
                   prelude := boolean(),
                   specs_override := [file:name()]}.
 -define(default_opts, #{autoimport => true,
-                        prelude => false,
+                        prelude => true,
                         specs_override => []}).
 
 -record(state, {specs   = #{} :: #{mfa() => [type()]},

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -155,6 +155,7 @@ import_module(Module) ->
 -spec init(opts()) -> {ok, state()}.
 init(Opts0) ->
     Opts = maps:merge(?default_opts, Opts0),
+    io:format("db opts: ~p\n", [Opts]),
     State1 = #state{opts = Opts},
     State2 = case Opts of
                  #{autoimport := true} ->

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -155,7 +155,7 @@ import_module(Module) ->
 -spec init(opts()) -> {ok, state()}.
 init(Opts0) ->
     Opts = maps:merge(?default_opts, Opts0),
-    io:format("db opts: ~p\n", [Opts]),
+    %io:format("db opts: ~p\n", [Opts]),
     State1 = #state{opts = Opts},
     State2 = case Opts of
                  #{autoimport := true} ->

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -5,7 +5,7 @@
 -module(gradualizer_db).
 
 %% API functions
--export([start_link/0,
+-export([start_link/1,
          get_spec/3,
          get_type/3, get_exported_type/3, get_opaque_type/3,
          get_record_type/2,
@@ -42,8 +42,10 @@
 
 %% Public API functions
 
-start_link() ->
-    gen_server:start_link({local, ?name}, ?MODULE, #{}, []).
+start_link(Opts) ->
+    OptsMap1 = proplists:to_map(Opts),
+    OptsMap2 = OptsMap1#{specs_override => proplists:get_all_values(specs_override, Opts)},
+    gen_server:start_link({local, ?name}, ?MODULE, OptsMap2, []).
 
 %% @doc Fetches the types of the clauses of an exported function. User-defined
 %%      types and record types are annotated with filename on the form
@@ -133,8 +135,12 @@ import_module(Module) ->
 
 %% Gen_server
 
--type opts() :: #{autoimport => boolean()}.
--define(default_opts, #{autoimport => true}).
+-type opts() :: #{autoimport := boolean(),
+                  prelude := boolean(),
+                  specs_override := [file:name()]}.
+-define(default_opts, #{autoimport => true,
+                        prelude => false,
+                        specs_override => []}).
 
 -record(state, {specs   = #{} :: #{mfa() => [type()]},
                 types   = #{} :: #{mfa() => #typeinfo{}},
@@ -156,6 +162,9 @@ init(Opts0) ->
                  _ ->
                     State1
              end,
+    Self = self(),
+    maps:get(prelude, Opts) andalso (Self ! import_prelude),
+    Self ! {import_extra_specs, maps:get(specs_override, Opts)},
     {ok, State2}.
 
 -spec handle_call(any(), {pid(), term()}, state()) -> {reply, term(), state()}.
@@ -252,6 +261,12 @@ handle_call({import_extra_specs, Dirs}, _From, State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
+handle_info(import_prelude, State) ->
+    State2 = import_prelude(State),
+    {noreply, State2};
+handle_info({import_extra_specs, Dirs}, State) ->
+    State2 = lists:foldl(fun import_extra_specs/2, State, Dirs),
+    {noreply, State2};
 handle_info(_Msg, State) ->
     {noreply, State}.
 

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -43,7 +43,7 @@
 %% Public API functions
 
 start_link(Opts) ->
-    OptsMap1 = proplists:to_map(Opts),
+    OptsMap1 = maps:from_list(proplists:unfold(Opts)),
     OptsMap2 = OptsMap1#{specs_override => proplists:get_all_values(specs_override, Opts)},
     gen_server:start_link({local, ?name}, ?MODULE, OptsMap2, []).
 

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -155,7 +155,6 @@ import_module(Module) ->
 -spec init(opts()) -> {ok, state()}.
 init(Opts0) ->
     Opts = maps:merge(?default_opts, Opts0),
-    %io:format("db opts: ~p\n", [Opts]),
     State1 = #state{opts = Opts},
     State2 = case Opts of
                  #{autoimport := true} ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4364,7 +4364,32 @@ type_check_forms(Forms, Opts) ->
     CrashOnError = proplists:get_bool(crash_on_error, Opts),
 
     {ok, _} = application:ensure_all_started(gradualizer),
-    proplists:get_bool(prelude, Opts) andalso gradualizer_db:import_prelude(),
+    io:format("before prelude:\n~ts\n\n", [typelib:pp_type(element(2, gradualizer_db:get_spec(lists, flatten, 2)))]),
+    %io:format("gradualizer_db state before prelude:\n~p\n\n", [sys:get_state(gradualizer_db)]),
+    %io:format("gradualizer_db state before prelude:\n~ts\n\n",
+              %[
+               %typelib:pp_type(hd(maps:get({lists,flatten,1},
+                                           %element(2, sys:get_state(gradualizer_db)))))
+              %]),
+    proplists:get_bool(prelude, Opts)
+    andalso begin
+                io:format("importing prelude\n", []),
+                gradualizer_db:import_prelude()
+            end,
+    %timer:sleep(3000),
+    %io:format("gradualizer_db state after prelude:\n~p\n\n", [sys:get_state(gradualizer_db)]),
+    %io:format("gradualizer_db state after prelude:\n~ts\n\n",
+    %          [
+    %           typelib:pp_type(hd(maps:get({lists,flatten,1},
+    %                                       element(2, sys:get_state(gradualizer_db)))))
+    %          ]),
+    %io:format("gradualizer_db state after post-prelude lookup:\n~p\n\n", [sys:get_state(gradualizer_db)]),
+    %io:format("after prelude:\n~ts\n\n", [typelib:pp_type(element(2, gradualizer_db:get_spec(lists, flatten, 2)))]),
+    %io:format("gradualizer_db state after post-prelude lookup:\n~ts\n\n",
+    %          [
+    %           typelib:pp_type(hd(maps:get({lists,flatten,1},
+    %                                       element(2, sys:get_state(gradualizer_db)))))
+    %          ]),
     gradualizer_db:import_extra_specs(proplists:get_all_values(specs_override, Opts)),
 
     ParseData =

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4363,35 +4363,6 @@ type_check_forms(Forms, Opts) ->
     StopOnFirstError = proplists:get_bool(stop_on_first_error, Opts),
     CrashOnError = proplists:get_bool(crash_on_error, Opts),
 
-    {ok, _} = application:ensure_all_started(gradualizer),
-    io:format("before prelude:\n~ts\n\n", [typelib:pp_type(element(2, gradualizer_db:get_spec(lists, flatten, 2)))]),
-    %io:format("gradualizer_db state before prelude:\n~p\n\n", [sys:get_state(gradualizer_db)]),
-    %io:format("gradualizer_db state before prelude:\n~ts\n\n",
-              %[
-               %typelib:pp_type(hd(maps:get({lists,flatten,1},
-                                           %element(2, sys:get_state(gradualizer_db)))))
-              %]),
-    proplists:get_bool(prelude, Opts)
-    andalso begin
-                io:format("importing prelude\n", []),
-                gradualizer_db:import_prelude()
-            end,
-    %timer:sleep(3000),
-    %io:format("gradualizer_db state after prelude:\n~p\n\n", [sys:get_state(gradualizer_db)]),
-    %io:format("gradualizer_db state after prelude:\n~ts\n\n",
-    %          [
-    %           typelib:pp_type(hd(maps:get({lists,flatten,1},
-    %                                       element(2, sys:get_state(gradualizer_db)))))
-    %          ]),
-    %io:format("gradualizer_db state after post-prelude lookup:\n~p\n\n", [sys:get_state(gradualizer_db)]),
-    %io:format("after prelude:\n~ts\n\n", [typelib:pp_type(element(2, gradualizer_db:get_spec(lists, flatten, 2)))]),
-    %io:format("gradualizer_db state after post-prelude lookup:\n~ts\n\n",
-    %          [
-    %           typelib:pp_type(hd(maps:get({lists,flatten,1},
-    %                                       element(2, sys:get_state(gradualizer_db)))))
-    %          ]),
-    gradualizer_db:import_extra_specs(proplists:get_all_values(specs_override, Opts)),
-
     ParseData =
         collect_specs_types_opaques_and_functions(Forms),
     Env = create_env(ParseData, Opts),

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -470,7 +470,7 @@ type_check_call_test_() ->
                                    "f() -> g().",
                                    "-spec g() -> number()."])),
      %% Passing an incompatible type to a spec'ed function
-     ?_assertNot(type_check_forms(["-spec int_top() -> gradualier:top().",
+     ?_assertNot(type_check_forms(["-spec int_top() -> gradualizer:top().",
                                    "int_top() -> 5.",
                                    "-spec int_arg(integer()) -> integer().",
                                    "int_arg(I) -> I + 1.",

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -539,12 +539,20 @@ type_check_clause_test_() ->
                                    "    try 1",
                                    "    catch _ -> error",
                                    "    end."])),
-     %% The return type of the after clause is ignored
-     ?_assert(type_check_forms(["-spec f(gradualizer:top()) -> integer().",
-                                "f(X) ->",
-                                "    try throw(error)",
-                                "    after error",
-                                "    end."])),
+
+     %% erlang:throw/1 needs gradualizer_db to be started
+     {setup,
+      fun setup_app/0,
+      fun cleanup_app/1,
+      [
+       %% The return type of the after clause is ignored
+       ?_assert(type_check_forms(["-spec f(gradualizer:top()) -> integer().",
+                                  "f(X) ->",
+                                  "    try throw(error)",
+                                  "    after error",
+                                  "    end."]))
+      ]},
+
      %% Correct try without an after block
      ?_assert(type_check_forms(["-spec f(gradualizer:top()) -> atom().",
                                 "f(X) ->",


### PR DESCRIPTION
I've noticed that PRs stopped being checked by Travis and realised it might be time to switch to GH Actions. To my surprise, though, the tests didn't pass from the get go in the GH Actions worker environment.

It seems that prelude was not loaded in a deterministic fashion, since on my machine the tests passed just fine, whereas they didn't "here". I imagine there must've been some race condition or a `gradualizer_db` restart in tests happening, since some tests failed as though prelude had not been loaded at all. This made me check when it's loaded and, indeed, it was not tied to `gradualizer_db` lifetime, but to an explicit call from `typechecker:type_check_forms()`. This meant that if `gradualizer_db` died and was restarted by the supervisor after the `import_prelude` call in `typechecker:type_check_forms()`, but before the typechecking finished, inconsistent information would be brought in from the DB, and some of it would use prelude, but some wouldn't.

Loading prelude from `graudalizer_db:init()` solved the problem and also uncovered that two other tests depended on the module as they started failing.

https://github.com/erszcz/Gradualizer/pull/1 contains the whole history. I'm fine with a squash merge.