### PR TITLE
Stop infinite recursion in glb

### DIFF
--- a/src/gradualizer_app.erl
+++ b/src/gradualizer_app.erl
@@ -16,15 +16,7 @@
 
 start(_StartType, _StartArgs) ->
     Opts = application:get_env(gradualizer, options, []),
-    set_union_size_limit(Opts),
     gradualizer_sup:start_link(Opts).
 
 stop(_State) ->
     ok.
-
-set_union_size_limit(Opts) ->
-    case lists:keyfind(union_size_limit, 1, Opts) of
-        false -> ok;
-        {union_size_limit, L} ->
-            persistent_term:put(gradualizer_union_size_limit, L)
-    end.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -537,10 +537,10 @@ glb_ty(Ty1, Var = {var, _, _}, _A, _Env) ->
 
 %% Union types: glb distributes over unions
 glb_ty({type, Ann, union, Ty1s}, Ty2, A, Env) ->
-    {Tys, Css} = lists:unzip([ glb_ty(Ty1, Ty2, A, Env) || Ty1 <- Ty1s ]),
+    {Tys, Css} = lists:unzip([ glb(Ty1, Ty2, A, Env) || Ty1 <- Ty1s ]),
     {{type, Ann, union, Tys}, constraints:combine(Css)};
 glb_ty(Ty1, {type, Ann, union, Ty2s}, A, Env) ->
-    {Tys, Css} = lists:unzip([glb_ty(Ty1, Ty2, A, Env) || Ty2 <- Ty2s ]),
+    {Tys, Css} = lists:unzip([glb(Ty1, Ty2, A, Env) || Ty2 <- Ty2s ]),
     {{type, Ann, union, Tys}, constraints:combine(Css)};
 
 %% Atom types
@@ -705,10 +705,10 @@ glb_ty({type, _, 'fun', [{type, _, any} = Any, Res1]},
 
 glb_ty({type, _, 'fun', [{type, _, any}, Res1]},
        {type, _, 'fun', [{type, _, product, _} = TArgs2, _]} = T2, A, Env) ->
-    glb_ty(type('fun', [TArgs2, Res1]), T2, A, Env);
+    glb(type('fun', [TArgs2, Res1]), T2, A, Env);
 glb_ty({type, _, 'fun', [{type, _, product, _} = TArgs1, _]} = T1,
        {type, _, 'fun', [{type, _, any}, Res2]}, A, Env) ->
-    glb_ty(T1, type('fun', [TArgs1, Res2]), A, Env);
+    glb(T1, type('fun', [TArgs1, Res2]), A, Env);
 
 %% normalize and remove_pos only does the top layer
 glb_ty({type, _, Name, Args1}, {type, _, Name, Args2}, A, Env)

--- a/src/typechecker.hrl
+++ b/src/typechecker.hrl
@@ -1,13 +1,15 @@
 -ifndef(__TYPECHECKER_HRL__).
 -define(__TYPECHECKER_HRL__, true).
 
--record(env, {fenv     = #{},
-              imported = #{}   :: #{{atom(), arity()} => module()},
-              venv     = #{},
-              tenv             :: gradualizer_lib:tenv(),
-              infer    = false :: boolean(),
-              verbose  = false :: boolean(),
-              exhaust  = true  :: boolean()
+-record(env, {fenv              = #{},
+              imported          = #{}   :: #{{atom(), arity()} => module()},
+              venv              = #{},
+              tenv                      :: gradualizer_lib:tenv(),
+              infer             = false :: boolean(),
+              verbose           = false :: boolean(),
+              exhaust           = true  :: boolean(),
+              %% Performance hack: Unions larger than this limit are replaced by any() in normalization.
+              union_size_limit          :: non_neg_integer()
              }).
 
 -endif. %% __TYPECHECKER_HRL__

--- a/test/gradualizer_cli_tests.erl
+++ b/test/gradualizer_cli_tests.erl
@@ -112,3 +112,9 @@ fancy_test() ->
     ?assertEqual(true, proplists:get_value(fancy, Opts1)),
     {ok, _Files, Opts2} = gradualizer_cli:handle_args(["--no_fancy", "file.erl"]),
     ?assertEqual(false, proplists:get_value(fancy, Opts2)).
+
+union_size_limit_test() ->
+    {ok, _Files, Opts1} = gradualizer_cli:handle_args(["--union_size_limit", "60", "file.erl"]),
+    ?assertEqual(60, proplists:get_value(union_size_limit, Opts1)),
+    {ok, _Files, Opts2} = gradualizer_cli:handle_args(["--union_size_limit", "10", "file.erl"]),
+    ?assertEqual(10, proplists:get_value(union_size_limit, Opts2)).

--- a/test/should_pass/glb_infinite_loop1.erl
+++ b/test/should_pass/glb_infinite_loop1.erl
@@ -1,5 +1,10 @@
 -module(glb_infinite_loop1).
 
+%% This module is a minimised version of src/gradualizer_fmt.erl.
+%% Self-gradualising the above triggered an infinite loop in typechecker:glb/4.
+%% This is a regression test against that.
+%% See https://github.com/josefs/Gradualizer/pull/356.
+
 %% The default is too low to trigger the problem,
 %% exactly to avoid the problem in everyday use.
 -gradualizer([{union_size_limit, 1000}]).

--- a/test/should_pass/glb_infinite_loop1.erl
+++ b/test/should_pass/glb_infinite_loop1.erl
@@ -1,0 +1,347 @@
+-module(glb_infinite_loop1).
+
+%% The default is too low to trigger the problem,
+%% exactly to avoid the problem in everyday use.
+-gradualizer([{union_size_limit, 1000}]).
+
+-export([describe_expr/1]).
+
+%% Start of Abstract Format
+
+-type anno() :: erl_anno:anno().
+
+-type abstract_expr() :: af_literal()
+                       | af_match(abstract_expr())
+                       | af_variable()
+                       | af_tuple(abstract_expr())
+                       | af_nil()
+                       | af_cons(abstract_expr())
+                       | af_bin(abstract_expr())
+                       | af_binary_op(abstract_expr())
+                       | af_unary_op(abstract_expr())
+                       | af_record_creation(abstract_expr())
+                       | af_record_update(abstract_expr())
+                       | af_record_index()
+                       | af_record_field_access(abstract_expr())
+                       | af_map_creation(abstract_expr())
+                       | af_map_update(abstract_expr())
+                       | af_catch()
+                       | af_local_call()
+                       | af_remote_call()
+                       | af_list_comprehension()
+                       | af_binary_comprehension()
+                       | af_block()
+                       | af_if()
+                       | af_case()
+                       | af_try()
+                       | af_receive()
+                       | af_local_fun()
+                       | af_remote_fun()
+                       | af_fun()
+                       | af_named_fun()
+                       | af_just_a_test().
+
+-type af_just_a_test() :: {z, a}.
+
+-type af_record_update(T) :: {'record',
+                              anno(),
+                              abstract_expr(),
+                              record_name(),
+                              [af_record_field(T)]}.
+
+-type af_catch() :: {'catch', anno(), abstract_expr()}.
+
+-type af_local_call() :: {'call', anno(), af_local_function(), af_args()}.
+
+-type af_remote_call() :: {'call', anno(), af_remote_function(), af_args()}.
+
+-type af_args() :: [abstract_expr()].
+
+-type af_local_function() :: abstract_expr().
+
+-type af_remote_function() ::
+        {'remote', anno(), abstract_expr(), abstract_expr()}.
+
+-type af_list_comprehension() ::
+        {'lc', anno(), af_template(), af_qualifier_seq()}.
+
+-type af_binary_comprehension() ::
+        {'bc', anno(), af_template(), af_qualifier_seq()}.
+
+-type af_template() :: abstract_expr().
+
+-type af_qualifier_seq() :: [af_qualifier()].
+
+-type af_qualifier() :: af_generator() | af_filter().
+
+-type af_generator() :: {'generate', anno(), af_pattern(), abstract_expr()}
+                      | {'b_generate', anno(), af_pattern(), abstract_expr()}.
+
+-type af_filter() :: abstract_expr().
+
+-type af_block() :: {'block', anno(), af_body()}.
+
+-type af_if() :: {'if', anno(), af_clause_seq()}.
+
+-type af_case() :: {'case', anno(), abstract_expr(), af_clause_seq()}.
+
+-type af_try() :: {'try',
+                   anno(),
+                   af_body() | [],
+                   af_clause_seq() | [],
+                   af_clause_seq() | [],
+                   af_body() | []}.
+
+-type af_clause_seq() :: [af_clause(), ...].
+
+-type af_receive() ::
+        {'receive', anno(), af_clause_seq()}
+      | {'receive', anno(), af_clause_seq(), abstract_expr(), af_body()}.
+
+-type af_local_fun() ::
+        {'fun', anno(), {'function', function_name(), arity()}}.
+
+-type af_remote_fun() ::
+        {'fun', anno(), {'function', module(), function_name(), arity()}}
+      | {'fun', anno(), {'function', af_atom(), af_atom(), af_integer()}}.
+
+-type af_fun() :: {'fun', anno(), {'clauses', af_clause_seq()}}.
+
+-type af_named_fun() :: {'named_fun', anno(), fun_name(), af_clause_seq()}.
+
+-type fun_name() :: atom().
+
+-type af_clause() ::
+        {'clause', anno(), [af_pattern()], af_guard_seq(), af_body()}.
+
+-type af_body() :: [abstract_expr(), ...].
+
+-type af_guard_seq() :: [af_guard()].
+
+-type af_guard() :: [af_guard_test(), ...].
+
+-type af_guard_test() :: af_literal()
+                       | af_variable()
+                       | af_tuple(af_guard_test())
+                       | af_nil()
+                       | af_cons(af_guard_test())
+                       | af_bin(af_guard_test())
+                       | af_binary_op(af_guard_test())
+                       | af_unary_op(af_guard_test())
+                       | af_record_creation(af_guard_test())
+                       | af_record_index()
+                       | af_record_field_access(af_guard_test())
+                       | af_map_creation(abstract_expr())
+                       | af_map_update(abstract_expr())
+                       | af_guard_call()
+                       | af_remote_guard_call().
+
+-type af_record_field_access(T) ::
+        {'record_field', anno(), T, record_name(), af_field_name()}.
+
+-type af_map_creation(T) :: {'map', anno(), [af_assoc(T)]}.
+
+-type af_map_update(T) :: {'map', anno(), T, [af_assoc(T)]}.
+
+-type af_assoc(T) :: {'map_field_assoc', anno(), T, T}
+                   | af_assoc_exact(T).
+
+-type af_assoc_exact(T) :: {'map_field_exact', anno(), T, T}.
+
+-type af_guard_call() :: {'call', anno(), function_name(), [af_guard_test()]}.
+
+-type af_remote_guard_call() ::
+        {'call', anno(),
+         {'remote', anno(), af_lit_atom('erlang'), af_atom()},
+         [af_guard_test()]}.
+
+-type af_pattern() :: af_literal()
+                    | af_match(af_pattern())
+                    | af_variable()
+                    | af_tuple(af_pattern())
+                    | af_nil()
+                    | af_cons(af_pattern())
+                    | af_bin(af_pattern())
+                    | af_binary_op(af_pattern())
+                    | af_unary_op(af_pattern())
+                    | af_record_creation(af_pattern())
+                    | af_record_index()
+                    | af_map_pattern().
+
+-type af_record_index() ::
+        {'record_index', anno(), record_name(), af_field_name()}.
+
+-type af_record_creation(T) ::
+        {'record', anno(), record_name(), [af_record_field(T)]}.
+
+-type af_record_field(T) :: {'record_field', anno(), af_field_name(), T}.
+
+-type af_map_pattern() ::
+        {'map', anno(), [af_assoc_exact(abstract_expr())]}.
+
+-type abstract_type() :: af_annotated_type()
+                       | af_atom()
+                       | af_bitstring_type()
+                       | af_empty_list_type()
+                       | af_fun_type()
+                       | af_integer_range_type()
+                       | af_map_type()
+                       | af_predefined_type()
+                       | af_record_type()
+                       | af_remote_type()
+                       | af_singleton_integer_type()
+                       | af_tuple_type()
+                       | af_type_union()
+                       | af_type_variable()
+                       | af_user_defined_type().
+
+-type af_annotated_type() ::
+        {'ann_type', anno(), [af_anno() | abstract_type()]}. % [Var, Type]
+
+-type af_anno() :: af_variable().
+
+-type af_bitstring_type() ::
+        {'type', anno(), 'binary', [af_singleton_integer_type()]}.
+
+-type af_empty_list_type() :: {'type', anno(), 'nil', []}.
+
+-type af_fun_type() :: {'type', anno(), 'fun', []}
+                     | {'type', anno(), 'fun', [{'type', anno(), 'any'} |
+                                                abstract_type()]}
+                     | af_function_type().
+
+-type af_integer_range_type() ::
+        {'type', anno(), 'range', [af_range_integer_type()]}.
+
+-type af_map_type() :: {'type', anno(), 'map', 'any'}
+                     | {'type', anno(), 'map', [af_assoc_type()]}.
+
+-type af_assoc_type() ::
+        {'type', anno(), 'map_field_assoc', [abstract_type()]}
+      | {'type', anno(), 'map_field_exact', [abstract_type()]}.
+
+-type af_predefined_type() ::
+        {'type', anno(), type_name(),  [abstract_type()]}.
+
+-type af_record_type() ::
+        {'type', anno(), 'record', [(Name :: af_atom()) % [Name, T1, ... Tk]
+                                    | af_record_field_type()]}.
+
+-type af_record_field_type() ::
+        {'type', anno(), 'field_type', [(Name :: af_atom()) |
+                                        abstract_type()]}. % [Name, Type]
+
+-type af_remote_type() ::
+        {'remote_type', anno(), [(Module :: af_atom()) |
+                                 (TypeName :: af_atom()) |
+                                 [abstract_type()]]}. % [Module, Name, [T]]
+
+-type af_tuple_type() :: {'type', anno(), 'tuple', 'any'}
+                       | {'type', anno(), 'tuple', [abstract_type()]}.
+
+-type af_type_union() :: {'type', anno(), 'union', [abstract_type()]}.
+
+-type af_type_variable() :: {'var', anno(), atom()}. % except '_'
+
+-type af_user_defined_type() ::
+        {'user_type', anno(), type_name(),  [abstract_type()]}.
+
+-type af_function_type() ::
+        {'type', anno(), 'fun',
+         [{'type', anno(), 'product', [abstract_type()]} | abstract_type()]}.
+
+-type af_range_integer_type() :: 'pos_inf' | 'neg_inf'
+                               | af_singleton_integer_type().
+
+-type af_singleton_integer_type() :: af_integer()
+                                   | af_character()
+                                   | af_unary_op(af_singleton_integer_type())
+                                   | af_binary_op(af_singleton_integer_type()).
+
+-type af_literal() :: af_atom()
+                    | af_character()
+                    | af_float()
+                    | af_integer()
+                    | af_string().
+
+-type af_atom() :: af_lit_atom(atom()).
+
+-type af_lit_atom(A) :: {'atom', anno(), A}.
+
+-type af_character() :: {'char', anno(), char()}.
+
+-type af_float() :: {'float', anno(), float()}.
+
+-type af_integer() :: {'integer', anno(), non_neg_integer()}.
+
+-type af_string() :: {'string', anno(), string()}.
+
+-type af_match(T) :: {'match', anno(), af_pattern(), T}.
+
+-type af_variable() :: {'var', anno(), atom()}. % | af_anon_variable()
+
+%-type af_anon_variable() :: {'var', anno(), '_'}.
+
+-type af_tuple(T) :: {'tuple', anno(), [T]}.
+
+-type af_nil() :: {'nil', anno()}.
+
+-type af_cons(T) :: {'cons', anno(), T, T}.
+
+-type af_bin(T) :: {'bin', anno(), [af_binelement(T)]}.
+
+-type af_binelement(T) :: {'bin_element',
+                           anno(),
+                           T,
+                           af_binelement_size(),
+                           type_specifier_list()}.
+
+-type af_binelement_size() :: 'default' | abstract_expr().
+
+-type af_binary_op(T) :: {'op', anno(), binary_op(), T, T}.
+
+-type binary_op() :: '/' | '*' | 'div' | 'rem' | 'band' | 'and' | '+' | '-'
+                   | 'bor' | 'bxor' | 'bsl' | 'bsr' | 'or' | 'xor' | '++'
+                   | '--' | '==' | '/=' | '=<' | '<'  | '>=' | '>' | '=:='
+                   | '=/='.
+
+-type af_unary_op(T) :: {'op', anno(), unary_op(), T}.
+
+-type unary_op() :: '+' | '-' | 'bnot' | 'not'.
+
+%% See also lib/stdlib/{src/erl_bits.erl,include/erl_bits.hrl}.
+-type type_specifier_list() :: 'default' | [type_specifier(), ...].
+
+-type type_specifier() :: type()
+                        | signedness()
+                        | endianness()
+                        | unit().
+
+-type type() :: 'integer'
+              | 'float'
+              | 'binary'
+              | 'bytes'
+              | 'bitstring'
+              | 'bits'
+              | 'utf8'
+              | 'utf16'
+              | 'utf32'.
+
+-type signedness() :: 'signed' | 'unsigned'.
+
+-type endianness() :: 'big' | 'little' | 'native'.
+
+-type unit() :: {'unit', 1..256}.
+
+-type record_name() :: atom().
+
+-type af_field_name() :: af_atom().
+
+-type function_name() :: atom().
+
+-type type_name() :: atom().
+
+%% End of Abstract Format
+
+-spec describe_expr(abstract_expr()) -> ok.
+describe_expr({call, _, _, _}) -> ok.

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -271,25 +271,21 @@ normalize_test_() ->
     [
      {"Merge intervals",
       ?_assertEqual(?t( 1..6 ),
-                    typechecker:normalize(?t( 1..3|4..6 ),
-                                          gradualizer_lib:create_tenv(?MODULE, [], [])))},
+                    typechecker:normalize(?t( 1..3|4..6 ), test_lib:create_env([])))},
      {"Remove singleton atoms if atom() is present",
       ?_assertEqual(?t( atom() ),
-                    typechecker:normalize(?t( a | atom() | b ),
-                                          gradualizer_lib:create_tenv(?MODULE, [], [])))},
+                    typechecker:normalize(?t( a | atom() | b ), test_lib:create_env([])))},
      {"Evaluate numeric operators in types",
       %% ?t(-8) is parsed as {op,0,'-',{integer,0,8}}
       ?_assertEqual({integer, 0 , -8},
                     typechecker:normalize(?t( (bnot 3) *
                                               (( + 7 ) rem ( 5 div - 2 ) ) bxor
-                                              (1 bsl 6 bsr 4) ),
-                                          gradualizer_lib:create_tenv(?MODULE, [], [])))},
+                                              (1 bsl 6 bsr 4) ), test_lib:create_env([])))},
      {"normalize(boolean()) == normalize(normalize(boolean))",
-      ?_assertEqual(typechecker:normalize(?t( boolean() ),
-                                          gradualizer_lib:empty_tenv()),
+      ?_assertEqual(typechecker:normalize(?t( boolean() ), test_lib:create_env([])),
                     typechecker:normalize(typechecker:normalize(?t( boolean() ),
-                                                                gradualizer_lib:empty_tenv()),
-                                          gradualizer_lib:empty_tenv()))
+                                                                test_lib:create_env([])),
+                                          test_lib:create_env([])))
      }
     ].
 
@@ -305,7 +301,7 @@ unfold_bounded_type_test() ->
         "fun(([{A, B}]) -> {[A], [B]})",
 
     {attribute, _, spec, {{unzip, 1}, [BoundedFun]}} = merl:quote(OrigSpecStr),
-    Env = #env{tenv = gradualizer_lib:create_tenv(?MODULE, [], [])},
+    Env = test_lib:create_env([]),
     UnfoldedType = typechecker:unfold_bounded_type(Env, BoundedFun),
     UnfoldedTypeStr = typelib:pp_type(UnfoldedType),
     ?assertEqual(ExpectedTypeStr, UnfoldedTypeStr).
@@ -623,7 +619,7 @@ cleanup_app(Apps) ->
     ok.
 
 subtype(T1, T2) ->
-    case typechecker:subtype(T1, T2, gradualizer_lib:create_tenv(?MODULE, [], [])) of
+    case typechecker:subtype(T1, T2, test_lib:create_env([])) of
         {true, _} ->
             true;
         false ->
@@ -631,13 +627,13 @@ subtype(T1, T2) ->
     end.
 
 glb(T1, T2) ->
-    glb(T1, T2, #env{tenv = gradualizer_lib:create_tenv(?MODULE, [], [])}).
+    glb(T1, T2, test_lib:create_env([])).
 
 glb(T1, T2, Env) ->
     typechecker:glb(T1, T2, Env).
 
 deep_normalize(T) ->
-    deep_normalize(T, gradualizer_lib:create_tenv(?MODULE, [], [])).
+    deep_normalize(T, test_lib:create_env([])).
 
 deep_normalize(T, TEnv) ->
     case typechecker:normalize(T, TEnv) of


### PR DESCRIPTION
When self-gradualizing with higher `union_size_limit` values, Gradualizer would fall into an infinite loop that I tracked to occur in `gradualizer_fmt.erl` - `test/should_pass/glb_infinite_loop1.erl` is a test module based on that.

~In order to test effectively, I hacked a way to set the limit using the `gradualizer` attribute, but I consider this temporary - I created https://github.com/josefs/Gradualizer/issues/355 to remember this needs a proper solution at some point.~ EDIT: now solved properly.

I think this test only exercises the `union` branches of `glb_ty`, not the `{type, _, 'fun', ...}` branches, but I think all the branches should call `glb` instead of `glb_ty` - otherwise, the `A` map is not updated, so we won't stop recursion as intended.