### PR TITLE
Use erl_lint to detect compile errors

### DIFF
--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -66,13 +66,6 @@ format_type_error({nonexhaustive, Anno, Example}, Opts) ->
            verbose ->
                io_lib:format("\nExample values which are not covered:~n\t~s~n", [FormattedExample])
        end]);
-format_type_error({call_undef, Anno, Func, Arity}, Opts) ->
-    io_lib:format(
-      "~sCall to undefined function ~p/~p~s~n",
-      [format_location(Anno, brief, Opts),
-       Func,
-       Arity,
-       format_location(Anno, verbose, Opts)]);
 format_type_error({call_undef, Anno, Module, Func, Arity}, Opts) ->
     io_lib:format(
       "~sCall to undefined function ~p:~p/~p~s~n",
@@ -85,11 +78,6 @@ format_type_error({undef, record, Anno, {Module, RecName}}, Opts) ->
     io_lib:format("~sUndefined record ~p:~p~s~n",
 		  [format_location(Anno, brief, Opts),
 		   Module,
-		   RecName,
-		   format_location(Anno, verbose, Opts)]);
-format_type_error({undef, record, Anno, RecName}, Opts) ->
-    io_lib:format("~sUndefined record ~p~s~n",
-		  [format_location(Anno, brief, Opts),
 		   RecName,
 		   format_location(Anno, verbose, Opts)]);
 format_type_error({undef, record_field, FieldName}, Opts) ->
@@ -124,29 +112,12 @@ format_type_error({not_exported, remote_type, Anno, {Module, Name, Arity}}, Opts
        Name,
        Arity,
        format_location(Anno, verbose, Opts)]);
-format_type_error({illegal_pattern, Pat}, Opts) ->
-    io_lib:format("~sIllegal pattern ~s~s~n",
-		  [format_location(Pat, brief, Opts),
-		   pp_expr(Pat, Opts),
-		   format_location(Pat, verbose, Opts)]);
-format_type_error({illegal_record_info, Expr}, Opts) ->
-    io_lib:format(
-      "~sIllegal record info ~s~s~n",
-      [format_location(Expr, brief, Opts),
-       pp_expr(Expr, Opts),
-       format_location(Expr, verbose, Opts)]);
 format_type_error({illegal_map_type, Type}, Opts) ->
     io_lib:format(
       "~sIllegal map type ~s~s~n",
       [format_location(Type, brief, Opts),
        pp_type(Type, Opts),
        format_location(Type, verbose, Opts)]);
-format_type_error({illegal_binary_segment, Expr}, Opts) ->
-    io_lib:format(
-      "~sIllegal binary segment expression ~s~s~n",
-      [format_location(Expr, brief, Opts),
-       pp_expr(Expr, Opts),
-       format_location(Expr, verbose, Opts)]);
 format_type_error({type_error, list, _Anno, Ty1, Ty}, Opts) ->
     io_lib:format(
       "~sThe type ~s cannot be an element of a list of type ~s~n",
@@ -322,12 +293,6 @@ format_type_error({type_error, pattern, Anno, Pat, Ty}, Opts) ->
        pp_expr(Pat, Opts),
        format_location(Anno, verbose, Opts),
        pp_type(Ty, Opts)]);
-format_type_error({unknown_variable, Anno, Var}, Opts) ->
-    io_lib:format(
-      "~sUnknown variable ~p~s.~n",
-      [format_location(Anno, brief, Opts),
-       Var,
-       format_location(Anno, verbose, Opts)]);
 format_type_error({type_error, check_clauses}, _Opts) ->
     %% TODO: Improve quality of type error
     io_lib:format("Type error in clauses", []);

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -377,6 +377,19 @@ format_type_error({bad_type_annotation, TypeLit}, Opts) ->
       [format_location(TypeLit, brief, Opts),
        pp_expr(TypeLit, Opts),
        format_location(TypeLit, verbose, Opts)]);
+format_type_error({Location, Module, ErrorDescription}, Opts)
+  when is_integer(Location) orelse is_tuple(Location),
+       is_atom(Module) ->
+    %% OTP compiler style error descriptor
+    io_lib:format(
+      "~s~s~s~n",
+      [format_location(Location, brief, Opts),
+       Module:format_error(ErrorDescription),
+       format_location(Location, verbose, Opts)]);
+format_type_error({none, Module, ErrorDescription}, _Opts)
+  when is_atom(Module) ->
+    %% OTP compiler style error descriptor, without location
+    io_lib:format("~s~n", [Module:format_error(ErrorDescription)]);
 format_type_error(type_error, _) ->
     io_lib:format("TYPE ERROR~n", []).
 

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3283,11 +3283,10 @@ get_bounded_fun_type_list(Name, Arity, Env, P) ->
                     {ok, Types} = gradualizer_db:get_spec(erlang, Name, Arity),
                     lists:map(fun typelib:remove_pos/1, Types);
                 false ->
+                    %% If it's not imported, the file doesn't compile.
                     case get_imported_bounded_fun_type_list(Name, Arity, Env, P) of
                         {ok, Types} ->
-                            Types;
-                        error ->
-                            throw({call_undef, P, Name, Arity})
+                            Types
                     end
             end
     end.

--- a/test/misc/lint_errors.erl
+++ b/test/misc/lint_errors.erl
@@ -1,0 +1,43 @@
+%% This module doesn't even compile. The errors here are caught by erl_lint.
+-module(lint_errors).
+-export([local_type/0,
+         local_call/0,
+         one_more_for_the_record/0,
+         local_record/1,
+         record_field/1,
+         illegal_binary_segment/1,
+         invalid_record_info/0,
+         illegal_pattern/1]).
+
+-spec local_type() -> undefined_type().
+local_type() -> ok.
+
+-spec local_call() -> ok.
+local_call() -> undefined_call().
+
+-record(r, {a :: #s{}}).
+
+%% The number of expected errors are the number of exported functions,
+%% so we create a function without errors, to account for the error in
+%% the record definition above.
+one_more_for_the_record() -> ok.
+
+-spec local_record(#r{}) -> boolean().
+local_record(R) -> if
+    (R#r.a)#s.a == c -> true;
+    true -> false
+   end.
+
+-spec record_field(#r{}) -> boolean().
+record_field(R) -> if
+    R#r.b == c -> true;
+    true -> false
+   end.
+
+illegal_binary_segment(X) ->
+    <<X:42/utf8>>. %% Size not allowed with utf8/16/32
+
+invalid_record_info() -> record_info(foo, bar).
+
+-spec illegal_pattern(gradualizer:top()) -> gradualizer:top().
+illegal_pattern(1 + A) -> ok.

--- a/test/misc/undefined_errors.erl
+++ b/test/misc/undefined_errors.erl
@@ -1,40 +1,19 @@
 -module(undefined_errors).
--export([local_type/0, remote_type/0,
-         local_call/0, remote_call/0,
-         local_record/1, remote_record/0,
-         record_field/1,
+-export([remote_type/0,
+         remote_call/0,
+         remote_record/0,
          normalize_remote_type/0,
          not_exported/0]).
-
--spec local_type() -> undefined_type().
-local_type() -> ok.
 
 -spec remote_type() -> undefined_errors_helper:j().
 remote_type() -> ok.
 
--spec local_call() -> ok.
-local_call() -> undefined_call().
-
 -spec remote_call() -> ok.
 remote_call() -> undefined_errors_helper:undefined_call().
-
--record(r, {a :: #s{}}).
-
--spec local_record(#r{}) -> boolean().
-local_record(R) -> if
-    (R#r.a)#s.a == c -> true;
-    true -> false
-   end.
 
 -record(defined_record, {a, b, c}).
 -spec remote_record() -> #defined_record{}.
 remote_record() -> undefined_errors_helper:und_rec().
-
--spec record_field(#r{}) -> boolean().
-record_field(R) -> if
-    R#r.b == c -> true;
-    true -> false
-   end.
 
 -spec normalize_remote_type() -> ok.
 normalize_remote_type() -> undefined_errors_helper:und_ty().

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -426,13 +426,14 @@ type_check_in_test_() ->
      ?_assertNot(type_check_forms(["-spec f(foo) -> ok.",
                                    "g() -> f(3.14)."])),
      %% Although there is no spec for f/1 - inferred type is `fun((any()) -> any())'
-     ?_assert(type_check_forms(["f(_) -> ok.",
+     ?_assert(type_check_forms(["f(_) -> 42.",
                                 "-spec g() -> fun((integer()) -> integer()).",
                                 "g() -> fun f/1."],
                                [infer])),
      %% Although there is not spec for f/1 - inferred arity does not match
      ?_assertNot(type_check_forms(["-spec g() -> fun(() -> integer()).",
-                                   "g() -> fun f/1."],
+                                   "g() -> fun f/1.",
+                                   "f(_) -> ok."],
                                   [infer]))
     ].
 
@@ -586,24 +587,6 @@ add_type_pat_test_() ->
      {"Pattern matching record against any()",
       ?_assert(type_check_forms(["-record(r, {f}).",
                                  "f(#r{f = F}) -> F."]))}
-    ].
-
-%% it is the responsibility of the compiler to catch semantically
-%% invalid programs (such as one with undefined records)
-%% but to improve code coverage we test them quickly.
-%% Gradualizer should not crash but return error nicely
-illegal_forms_test_() ->
-    [%% undefined records
-     ?_assertNot(type_check_forms(["-spec f() -> gradualizer:top().",
-                                   "f() -> #r{f = 1}."])),
-     ?_assertNot(type_check_forms(["-record(r, {f1}).",
-                                   "-spec f() -> gradualizer:top().",
-                                   "f() -> #r{f2 = 1}."])),
-     %% invalid record_info
-     ?_assertNot(type_check_forms(["f() -> record_info(foo, bar)."])),
-     %% illegal pattern
-     ?_assertNot(type_check_forms(["-spec f(gradualizer:top()) -> gradualizer:top().",
-                                   "f(1 + A) -> ok."]))
     ].
 
 %%

--- a/test/undefined_errors_test.erl
+++ b/test/undefined_errors_test.erl
@@ -14,14 +14,15 @@ undefined_errors_test_() ->
          [ok = application:stop(App) || App <- Apps],
          ok
      end,
-     ?_test(begin
-        File = "test/misc/undefined_errors.erl",
-        Errors = gradualizer:type_check_file(File, [return_errors]),
-        %% Test that error formatting doesn't crash
-        Opts = [{fmt_location, brief},
-                {fmt_expr_fun, fun erl_prettypr:format/1}],
-        lists:foreach(fun({_, Error}) -> gradualizer_fmt:handle_type_error(Error, Opts) end, Errors),
-        {ok, Forms} = gradualizer_file_utils:get_forms_from_erl(File, []),
-        ExpectedErrors = typechecker:number_of_exported_functions(Forms),
-        ?assertEqual(ExpectedErrors, length(Errors))
-    end)}.
+     [?_test(check_file("test/misc/undefined_errors.erl")),
+      ?_test(check_file("test/misc/lint_errors.erl"))]}.
+
+check_file(File) ->
+    Errors = gradualizer:type_check_file(File, [return_errors]),
+    %% Test that error formatting doesn't crash
+    Opts = [{fmt_location, brief},
+            {fmt_expr_fun, fun erl_prettypr:format/1}],
+    lists:foreach(fun({_, Error}) -> gradualizer_fmt:handle_type_error(Error, Opts) end, Errors),
+    {ok, Forms} = gradualizer_file_utils:get_forms_from_erl(File, []),
+    ExpectedErrors = typechecker:number_of_exported_functions(Forms),
+    ?assertEqual(ExpectedErrors, length(Errors)).


### PR DESCRIPTION
When checking `.erl` files, use `erl_lint` to detect compile errors. This is basically what the `basic_validation` compiler pass does.

It detects use of undefined variables, undefined functions, undefined records, missing include files and some things you could expect the parser to detect such as `foo() -> ok; bar() ->ok.` (Note the semicolon.) and `f(X + 1) -> X.`.

This pass is not used when checking beam files, since we already know that this abstract form compiles.

Fixes #291. Fixes #288. Fixes #371.