### PR TITLE
Call remove_pos only where a type comes into the system

### DIFF
--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -105,12 +105,12 @@ reverse_graph(G) ->
       Opts :: [annotate_user_types],
       Ty :: gradualizer_type:abstract_type().
 get_type_definition({remote_type, _Anno, [{atom, _, Module}, {atom, _, Name}, Args]}, _Env, _Opts) ->
-    remove_pos(gradualizer_db:get_type(Module, Name, Args));
+    gradualizer_db:get_type(Module, Name, Args);
 get_type_definition({user_type, Anno, Name, Args}, Env, Opts) ->
     %% Let's check if the type is a known remote type.
     case typelib:get_module_from_annotation(Anno) of
         {ok, Module} ->
-            remove_pos(gradualizer_db:get_type(Module, Name, Args));
+            gradualizer_db:get_type(Module, Name, Args);
         none ->
             %% Let's check if the type is defined in the context of this module.
             case maps:get({Name, length(Args)}, maps:get(types, Env#env.tenv), not_found) of
@@ -129,11 +129,6 @@ get_type_definition({user_type, Anno, Name, Args}, Env, Opts) ->
                     not_found
             end
     end.
-
-remove_pos({ok, T}) ->
-    {ok, typelib:remove_pos(T)};
-remove_pos(Error) ->
-    Error.
 
 %% Given a type `Ty', pick a value of that type.
 %% Used in exhaustiveness checking to show an example value

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -4,7 +4,8 @@
 
 -export([merge_with/3, top_sort/1, get_type_definition/3,
          pick_value/2, fold_ast/3, get_ast_children/1,
-         empty_tenv/0, create_tenv/3]).
+         empty_tenv/0, create_tenv/3,
+         remove_pos_typed_record_field/1]).
 -export_type([graph/1, tenv/0]).
 
 %% Type environment, passed around while comparing compatible subtypes.
@@ -104,12 +105,12 @@ reverse_graph(G) ->
       Opts :: [annotate_user_types],
       Ty :: gradualizer_type:abstract_type().
 get_type_definition({remote_type, _Anno, [{atom, _, Module}, {atom, _, Name}, Args]}, _Env, _Opts) ->
-    gradualizer_db:get_type(Module, Name, Args);
+    remove_pos(gradualizer_db:get_type(Module, Name, Args));
 get_type_definition({user_type, Anno, Name, Args}, Env, Opts) ->
     %% Let's check if the type is a known remote type.
     case typelib:get_module_from_annotation(Anno) of
         {ok, Module} ->
-            gradualizer_db:get_type(Module, Name, Args);
+            remove_pos(gradualizer_db:get_type(Module, Name, Args));
         none ->
             %% Let's check if the type is defined in the context of this module.
             case maps:get({Name, length(Args)}, maps:get(types, Env#env.tenv), not_found) of
@@ -129,6 +130,10 @@ get_type_definition({user_type, Anno, Name, Args}, Env, Opts) ->
             end
     end.
 
+remove_pos({ok, T}) ->
+    {ok, typelib:remove_pos(T)};
+remove_pos(Error) ->
+    Error.
 
 %% Given a type `Ty', pick a value of that type.
 %% Used in exhaustiveness checking to show an example value
@@ -270,11 +275,21 @@ create_tenv(Module, TypeDefs, RecordDefs) when is_atom(Module) ->
                             {Id, {Params, typelib:remove_pos(Body)}}
                         end || {Name, Body, Vars} <- TypeDefs]),
     RecordMap =
-        maps:from_list([{Name, [{typed_record_field, Field, typelib:remove_pos(Type)}
-                                || {typed_record_field, Field, Type}
-                                       <- lists:map(fun absform:normalize_record_field/1,
-                                                    Fields)]}
+        maps:from_list([{Name, [remove_pos_typed_record_field(
+                                  absform:normalize_record_field(Field))
+                                || Field <- Fields]}
                          || {Name, Fields} <- RecordDefs]),
     #{module => Module,
       types => TypeMap,
       records => RecordMap}.
+
+%% Removes the position annotation from a list of record fields normalized using
+%% absform:normalize_record_field/1.
+%%
+%% Note: The field name (atom) is sometimes used as a type.
+remove_pos_typed_record_field({typed_record_field,
+                               {record_field, _, Name, Default},
+                               Type}) ->
+    {typed_record_field,
+     {record_field, 0, typelib:remove_pos(Name), Default},
+     typelib:remove_pos(Type)}.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -769,7 +769,7 @@ normalize_rec({user_type, P, Name, Args} = Type, Env, Unfolded) ->
             UnfoldedNew = maps:put(mta(Type, Env), {type, Type}, Unfolded),
             case gradualizer_lib:get_type_definition(Type, Env, []) of
                 {ok, T} ->
-                    normalize_rec(typelib:remove_pos(T), Env, UnfoldedNew);
+                    normalize_rec(T, Env, UnfoldedNew);
                 opaque ->
                     Type;
                 not_found ->
@@ -3056,8 +3056,7 @@ update_map_type(?type(map, Assocs), AssocTys) ->
     %% `AssocTys' come from a map creation or map update expr - after the expr is evaluated the map
     %% will contain the associations. Therefore in the resulting map type they
     %% cannot be optional - we rewrite optional assocs to non-optional ones.
-    UpdatedAssocs = update_assocs(AssocTys,
-                                  lists:map(fun typelib:remove_pos/1, Assocs)),
+    UpdatedAssocs = update_assocs(AssocTys, Assocs),
     type(map, UpdatedAssocs);
 update_map_type({var, _, _Var}, _AssocTys) ->
     type(any);
@@ -3071,7 +3070,7 @@ update_map_type(Type, _AssocTys) ->
 update_assocs([{type, _, _Assoc, [Key, ValueType]} | AssocTys],
 	      Assocs) ->
     [type(map_field_exact, [Key, ValueType]) |
-     case take_assoc(typelib:remove_pos(Key), Assocs, []) of
+     case take_assoc(Key, Assocs, []) of
          {value, _, RestAssocs} ->
              update_assocs(AssocTys, RestAssocs);
          false ->

--- a/test/absform_tests.erl
+++ b/test/absform_tests.erl
@@ -7,14 +7,15 @@ function_type_list_to_fun_types_test() ->
     {attribute, _, spec, {_, FunTypeList}} =
         merl:quote("-spec f(T)-> boolean() when T :: tuple();"
                    "       (atom()) -> any()."),
-    BoundedFunTypeList = absform:normalize_function_type_list(FunTypeList),
+    FunTypeListNoPos = lists:map(fun typelib:remove_pos/1, FunTypeList),
+    BoundedFunTypeList = absform:normalize_function_type_list(FunTypeListNoPos),
     Ty = typechecker:bounded_type_list_to_type(
            #env{tenv = gradualizer_lib:create_tenv(?MODULE, [], [])}, BoundedFunTypeList),
     ?assertMatch({type, 0, union,
-                  [{type,1,'fun',
-                    [{type,1,product,[{type,0,tuple,any}]},
-                     {type,1,boolean,[]}]},
-                   {type,1,'fun',
-                    [{type,1,product,[{type,1,atom,[]}]},
-                     {type,1,any,[]}]}]}, Ty),
+                  [{type,0,'fun',
+                    [{type,0,product,[{type,0,tuple,any}]},
+                     {type,0,boolean,[]}]},
+                   {type,0,'fun',
+                    [{type,0,product,[{type,0,atom,[]}]},
+                     {type,0,any,[]}]}]}, Ty),
     ok.


### PR DESCRIPTION
Remove_pos normalizes the syntactical representation of a type, by recursively removing the location annotation (line and column). This is to be able to compare types using equality and pattern matching in the type checker.

This should only be done once on each type and only when the type comes into the type checker, i.e. when types are extracted from a parse tree.

This PR sorts out the mess, makes sure it's done where it should and removes it where it shouldn't be done.

Note that gradualizer_db doesn't use this, so we call remove_pos on the types returned by gradualizer_db.