### PR TITLE
Detect undefined remote types in a separate pass

### DIFF
--- a/priv/test/undefined_errors_helper.erl
+++ b/priv/test/undefined_errors_helper.erl
@@ -3,15 +3,17 @@
 -export_type([j/0,
               expands_to_undefined_remote/0,
               expands_to_struct_with_undefined_remote/0,
-              expands_to_struct_with_undefined_local/0]).
+              expands_to_struct_with_undefined_local/0,
+              expands_to_struct_with_undefined_record/0]).
 
 -type j() :: undefined_type1().
 -type not_exported() :: ok.
 -type expands_to_undefined_remote() :: undefined_errors:undefined_type2().
 -type expands_to_struct_with_undefined_remote() :: {struct, undefined_errors:undefined_type3()}.
 -type expands_to_struct_with_undefined_local() :: {struct, undefined_type4()}.
+-type expands_to_struct_with_undefined_record() :: {struct, #undefined_record1{}}.
 
--spec und_rec() -> #undefined_record{}.
+-spec und_rec() -> #undefined_record2{}.
 und_rec() -> ok.
 
 -spec und_ty() -> undefined_errors:undefined_type5().

--- a/priv/test/undefined_errors_helper.erl
+++ b/priv/test/undefined_errors_helper.erl
@@ -4,15 +4,15 @@
               expands_to_undefined_remote/0,
               expands_to_struct_with_undefined_remote/0]).
 
--type j() :: undefined_type().
+-type j() :: undefined_type1().
 -type not_exported() :: ok.
--type expands_to_undefined_remote() :: undefined_errors:undefined_type().
--type expands_to_struct_with_undefined_remote() :: {struct, undefined_errors:undefined_type()}.
+-type expands_to_undefined_remote() :: undefined_errors:undefined_type2().
+-type expands_to_struct_with_undefined_remote() :: {struct, undefined_errors:undefined_type3()}.
 
 -spec und_rec() -> #undefined_record{}.
 und_rec() -> ok.
 
--spec und_ty() -> undefined_errors:undefined_type().
+-spec und_ty() -> undefined_errors:undefined_type4().
 und_ty() -> ok.
 
 -spec not_exp_ty() -> not_exported().

--- a/priv/test/undefined_errors_helper.erl
+++ b/priv/test/undefined_errors_helper.erl
@@ -1,10 +1,13 @@
 -module(undefined_errors_helper).
 -export([und_rec/0, und_ty/0, not_exp_ty/0]).
--export_type([j/0, expands_to_undefined_remote/0]).
+-export_type([j/0,
+              expands_to_undefined_remote/0,
+              expands_to_struct_with_undefined_remote/0]).
 
 -type j() :: undefined_type().
 -type not_exported() :: ok.
 -type expands_to_undefined_remote() :: undefined_errors:undefined_type().
+-type expands_to_struct_with_undefined_remote() :: {struct, undefined_errors:undefined_type()}.
 
 -spec und_rec() -> #undefined_record{}.
 und_rec() -> ok.

--- a/priv/test/undefined_errors_helper.erl
+++ b/priv/test/undefined_errors_helper.erl
@@ -2,17 +2,19 @@
 -export([und_rec/0, und_ty/0, not_exp_ty/0]).
 -export_type([j/0,
               expands_to_undefined_remote/0,
-              expands_to_struct_with_undefined_remote/0]).
+              expands_to_struct_with_undefined_remote/0,
+              expands_to_struct_with_undefined_local/0]).
 
 -type j() :: undefined_type1().
 -type not_exported() :: ok.
 -type expands_to_undefined_remote() :: undefined_errors:undefined_type2().
 -type expands_to_struct_with_undefined_remote() :: {struct, undefined_errors:undefined_type3()}.
+-type expands_to_struct_with_undefined_local() :: {struct, undefined_type4()}.
 
 -spec und_rec() -> #undefined_record{}.
 und_rec() -> ok.
 
--spec und_ty() -> undefined_errors:undefined_type4().
+-spec und_ty() -> undefined_errors:undefined_type5().
 und_ty() -> ok.
 
 -spec not_exp_ty() -> not_exported().

--- a/priv/test/undefined_errors_helper.erl
+++ b/priv/test/undefined_errors_helper.erl
@@ -1,9 +1,10 @@
 -module(undefined_errors_helper).
 -export([und_rec/0, und_ty/0, not_exp_ty/0]).
--export_type([j/0]).
+-export_type([j/0, expands_to_undefined_remote/0]).
 
 -type j() :: undefined_type().
 -type not_exported() :: ok.
+-type expands_to_undefined_remote() :: undefined_errors:undefined_type().
 
 -spec und_rec() -> #undefined_record{}.
 und_rec() -> ok.

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -102,15 +102,16 @@ reverse_graph(G) ->
 -spec get_type_definition(UserTy, Env, Opts) -> {ok, Ty} | opaque | not_found when
       UserTy :: gradualizer_type:abstract_type(),
       Env :: typechecker:env(),
-      Opts :: [annotate_user_types],
+      Opts :: [Opt],
+      Opt :: annotate_user_types | remove_pos,
       Ty :: gradualizer_type:abstract_type().
-get_type_definition({remote_type, _Anno, [{atom, _, Module}, {atom, _, Name}, Args]}, _Env, _Opts) ->
-    gradualizer_db:get_type(Module, Name, Args);
+get_type_definition({remote_type, _Anno, [{atom, _, Module}, {atom, _, Name}, Args]}, _Env, Opts) ->
+    gradualizer_db:get_type(Module, Name, Args, Opts);
 get_type_definition({user_type, Anno, Name, Args}, Env, Opts) ->
     %% Let's check if the type is a known remote type.
     case typelib:get_module_from_annotation(Anno) of
         {ok, Module} ->
-            gradualizer_db:get_type(Module, Name, Args);
+            gradualizer_db:get_type(Module, Name, Args, Opts);
         none ->
             %% Let's check if the type is defined in the context of this module.
             case maps:get({Name, length(Args)}, maps:get(types, Env#env.tenv), not_found) of

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4834,8 +4834,8 @@ check_remote_type({call, _, {remote, _, {atom, _, Module}, {atom, _, Fun}}, Args
     end;
 check_remote_type({remote_type, P, [{atom, _, M}, {atom, _, N}, Args]}, Acc) ->
     case gradualizer_db:get_exported_type(M, N, Args) of
-        {ok, _} ->
-            Acc;
+        {ok, Type} ->
+            check_undefined_types([Type]) ++ Acc;
         opaque ->
             Acc;
         not_exported ->

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -118,7 +118,7 @@ remove_pos({type, _, Assoc, Tys}) when Assoc == map_field_exact;
     {type, erl_anno:new(0), Assoc, lists:map(fun remove_pos/1, Tys)};
 remove_pos({remote_type, _, [Mod, Name, Params]}) ->
     Params1 = lists:map(fun remove_pos/1, Params),
-    {remote_type, erl_anno:new(0), [Mod, Name, Params1]};
+    {remote_type, erl_anno:new(0), [remove_pos(Mod), remove_pos(Name), Params1]};
 remove_pos({ann_type, _, [_Var, Type]}) ->
     %% Also remove annotated types one the form Name :: Type
     remove_pos(Type);

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -66,7 +66,7 @@ pp_type(Type) ->
 
 %% Looks up and prints the type M:N(P1, ..., Pn).
 debug_type(M, N, P) ->
-    case gradualizer_db:get_type(M, N, P) of
+    case gradualizer_db:get_type(M, N, P, _RemovePosOff = []) of
         {ok, T} ->
             Params = lists:join($,, lists:map(fun pp_type/1, P)),
             io:format("~w:~w(~s) :: ~s.~n",

--- a/test/misc/undefined_errors.erl
+++ b/test/misc/undefined_errors.erl
@@ -3,6 +3,7 @@
          remote_remote_type/0,
          remote_struct_with_remote_type/0,
          remote_struct_with_local_type/0,
+         remote_struct_with_record/0,
          remote_call/0,
          remote_record/0,
          normalize_remote_type/0,
@@ -19,6 +20,9 @@ remote_struct_with_remote_type() -> {struct, ok}.
 
 -spec remote_struct_with_local_type() -> undefined_errors_helper:expands_to_struct_with_undefined_local().
 remote_struct_with_local_type() -> ok.
+
+-spec remote_struct_with_record() -> undefined_errors_helper:expands_to_struct_with_undefined_record().
+remote_struct_with_record() -> ok.
 
 -spec remote_call() -> ok.
 remote_call() -> undefined_errors_helper:undefined_call().

--- a/test/misc/undefined_errors.erl
+++ b/test/misc/undefined_errors.erl
@@ -2,6 +2,7 @@
 -export([remote_type/0,
          remote_remote_type/0,
          remote_struct_with_remote_type/0,
+         remote_struct_with_local_type/0,
          remote_call/0,
          remote_record/0,
          normalize_remote_type/0,
@@ -15,6 +16,9 @@ remote_remote_type() -> ok.
 
 -spec remote_struct_with_remote_type() -> undefined_errors_helper:expands_to_struct_with_undefined_remote().
 remote_struct_with_remote_type() -> {struct, ok}.
+
+-spec remote_struct_with_local_type() -> undefined_errors_helper:expands_to_struct_with_undefined_local().
+remote_struct_with_local_type() -> ok.
 
 -spec remote_call() -> ok.
 remote_call() -> undefined_errors_helper:undefined_call().

--- a/test/misc/undefined_errors.erl
+++ b/test/misc/undefined_errors.erl
@@ -1,5 +1,6 @@
 -module(undefined_errors).
 -export([remote_type/0,
+         remote_remote_type/0,
          remote_call/0,
          remote_record/0,
          normalize_remote_type/0,
@@ -7,6 +8,9 @@
 
 -spec remote_type() -> undefined_errors_helper:j().
 remote_type() -> ok.
+
+-spec remote_remote_type() -> undefined_errors_helper:expands_to_undefined_remote().
+remote_remote_type() -> ok.
 
 -spec remote_call() -> ok.
 remote_call() -> undefined_errors_helper:undefined_call().

--- a/test/misc/undefined_errors.erl
+++ b/test/misc/undefined_errors.erl
@@ -19,10 +19,10 @@ remote_remote_type() -> ok.
 remote_struct_with_remote_type() -> {struct, ok}.
 
 -spec remote_struct_with_local_type() -> undefined_errors_helper:expands_to_struct_with_undefined_local().
-remote_struct_with_local_type() -> ok.
+remote_struct_with_local_type() -> {struct, ok}.
 
 -spec remote_struct_with_record() -> undefined_errors_helper:expands_to_struct_with_undefined_record().
-remote_struct_with_record() -> ok.
+remote_struct_with_record() -> {struct, ok}.
 
 -spec remote_call() -> ok.
 remote_call() -> undefined_errors_helper:undefined_call().

--- a/test/misc/undefined_errors.erl
+++ b/test/misc/undefined_errors.erl
@@ -1,6 +1,7 @@
 -module(undefined_errors).
 -export([remote_type/0,
          remote_remote_type/0,
+         remote_struct_with_remote_type/0,
          remote_call/0,
          remote_record/0,
          normalize_remote_type/0,
@@ -11,6 +12,9 @@ remote_type() -> ok.
 
 -spec remote_remote_type() -> undefined_errors_helper:expands_to_undefined_remote().
 remote_remote_type() -> ok.
+
+-spec remote_struct_with_remote_type() -> undefined_errors_helper:expands_to_struct_with_undefined_remote().
+remote_struct_with_remote_type() -> {struct, ok}.
 
 -spec remote_call() -> ok.
 remote_call() -> undefined_errors_helper:undefined_call().


### PR DESCRIPTION
This tries fixing #379 by introducing a separate pass over the AST.

Remaining tasks:
- [x] fix `typelib:remove_pos` to actually remove pos from all `remote_type` elements
- [x] fix the failing test case