### PR TITLE
Temporary measure: break cycles by timing out

### DIFF
--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -342,6 +342,20 @@ format_type_error({bad_type_annotation, TypeLit}, Opts) ->
       [format_location(TypeLit, brief, Opts),
        pp_expr(TypeLit, Opts),
        format_location(TypeLit, verbose, Opts)]);
+format_type_error({internal_error, form_check_timeout, Form}, Opts) ->
+    io_lib:format(
+      "~sTimeout checking form~s~n",
+      [format_location(Form, brief, Opts),
+       case proplists:get_value(fmt_location, Opts, ?FMT_LOCATION_DEFAULT) of
+           brief ->
+               "";
+           verbose ->
+               io_lib:format("~s~n~p~n"
+                             "This is most likely a bug in Gradualizer.~n"
+                             "Please report it at https://github.com/josefs/Gradualizer/issues",
+                             [format_location(Form, verbose, Opts),
+                              Form])
+       end]);
 format_type_error({Location, Module, ErrorDescription}, Opts)
   when is_integer(Location) orelse is_tuple(Location),
        is_atom(Module) ->

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -344,17 +344,17 @@ format_type_error({bad_type_annotation, TypeLit}, Opts) ->
        format_location(TypeLit, verbose, Opts)]);
 format_type_error({internal_error, form_check_timeout, Form}, Opts) ->
     io_lib:format(
-      "~sTimeout checking form~s~n",
+      "~sTimeout checking ~s~n",
       [format_location(Form, brief, Opts),
        case proplists:get_value(fmt_location, Opts, ?FMT_LOCATION_DEFAULT) of
            brief ->
-               "";
+               "form";
            verbose ->
-               io_lib:format("~s~n~p~n"
+               io_lib:format("~s~s~n"
                              "This is most likely a bug in Gradualizer.~n"
                              "Please report it at https://github.com/josefs/Gradualizer/issues",
-                             [format_location(Form, verbose, Opts),
-                              Form])
+                             [form_info(Form),
+                              format_location(Form, verbose, Opts)])
        end]);
 format_type_error({Location, Module, ErrorDescription}, Opts)
   when is_integer(Location) orelse is_tuple(Location),
@@ -371,6 +371,9 @@ format_type_error({none, Module, ErrorDescription}, _Opts)
     io_lib:format("~s~n", [Module:format_error(ErrorDescription)]);
 format_type_error(type_error, _) ->
     io_lib:format("TYPE ERROR~n", []).
+
+form_info({function, _, Name, Arity, _}) ->
+    io_lib:format("function ~s/~p", [Name, Arity]).
 
 -spec format_expr_type_error(gradualizer_type:abstract_expr(),
 			typelib:extended_type(),

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -1,5 +1,9 @@
 -module(gradualizer_fmt).
--export([format_location/2, format_type_error/2, print_errors/2, handle_type_error/2]).
+-export([format_location/2,
+         format_type_error/2,
+         print_errors/2,
+         handle_type_error/2,
+         form_info/1]).
 
 -include("typelib.hrl").
 

--- a/src/gradualizer_task.erl
+++ b/src/gradualizer_task.erl
@@ -144,13 +144,13 @@ do_apply(TaskOwnerInfo, {Mod, Fun, Args} = MFA) ->
     try
         erlang:apply(Mod, Fun, Args)
     catch
-        error: Value ->
+        error:Value:Stacktrace ->
             task_exit(TaskOwnerInfo, MFA,
-                      {Value, erlang:get_stacktrace()});
-        throw: Value ->
+                      {Value, Stacktrace});
+        throw:Value:Stacktrace ->
             task_exit(TaskOwnerInfo, MFA,
-                      {{nocatch, Value}, erlang:get_stacktrace()});
-        exit: Value ->
+                      {{nocatch, Value}, Stacktrace});
+        exit:Value ->
             task_exit(TaskOwnerInfo, MFA, Value)
     end.
 

--- a/src/gradualizer_task.erl
+++ b/src/gradualizer_task.erl
@@ -1,0 +1,184 @@
+%% @doc Task is a helper for running asynchronous operations.
+%%
+%% This is a port of the Elixir Task module borrowed from https://github.com/redink/task.
+%% Original Elixir Task documentation can be found at https://hexdocs.pm/elixir/Task.html.
+%% @end
+-module(gradualizer_task).
+
+-export([async/3,
+         async/4,
+         async/1,
+         async/2,
+         await/1,
+         await/2]).
+
+-export([async_opt/4,
+         async_opt/5,
+         async_opt/2,
+         async_opt/3]).
+
+-export([safe_await/2,
+         safe_await/3]).
+
+-export([async_do/3]).
+
+-spec async(function()) -> {pid(), reference()}.
+async(Fun) when erlang:is_function(Fun) ->
+    async(erlang, apply, [Fun, []]).
+
+-spec async(atom(), function()) -> {pid(), reference()}.
+async(Node, Fun) when erlang:is_function(Fun) ->
+    async(Node, erlang, apply, [Fun, []]).
+
+-spec async(atom(), atom(), [term()]) -> {pid(), reference()}.
+async(Mod, Fun, Args) ->
+    Me  = erlang:self(),
+    Pid = proc_lib:spawn_link(?MODULE, async_do,
+                              [Me, get_info(Me), {Mod, Fun, Args}]),
+    Ref = erlang:monitor(process, Pid),
+    erlang:send(Pid, {Me, Ref}),
+    {Pid, Ref}.
+
+-spec async(atom(), atom(), atom(), [term()]) -> {pid(), reference()}.
+async(Node, Mod, Fun, Args) ->
+    Me  = erlang:self(),
+    Pid = proc_lib:spawn_link(Node, ?MODULE, async_do,
+                              [Me, get_info(Me), {Mod, Fun, Args}]),
+    Ref = erlang:monitor(process, Pid),
+    erlang:send(Pid, {Me, Ref}),
+    {Pid, Ref}.
+
+-spec async_opt(function(), [term()]) -> {pid(), reference()}.
+async_opt(Fun, Opts) when erlang:is_function(Fun) ->
+    async_opt(erlang, apply, [Fun, []], Opts).
+
+-spec async_opt(atom(), function(), [term()]) -> {pid(), reference()}.
+async_opt(Node, Fun, Opts) when erlang:is_function(Fun) ->
+    async_opt(Node, erlang, apply, [Fun, []], Opts).
+
+-spec async_opt(atom(), atom(),
+                [term()], [term()]) -> {pid(), reference()}.
+async_opt(Mod, Fun, Args, Opts) ->
+    Me  = erlang:self(),
+    Pid = proc_lib:spawn_opt(?MODULE, async_do,
+                             [Me, get_info(Me), {Mod, Fun, Args}],
+                             [link | Opts]),
+    Ref = erlang:monitor(process, Pid),
+    erlang:send(Pid, {Me, Ref}),
+    {Pid, Ref}.
+
+-spec async_opt(atom(), atom(), atom(),
+                [term()], [term()]) -> {pid(), reference()}.
+async_opt(Node, Mod, Fun, Args, Opts) ->
+    Me  = erlang:self(),
+    Pid = proc_lib:spawn_opt(Node, ?MODULE, async_do,
+                             [Me, get_info(Me), {Mod, Fun, Args}],
+                             [link | Opts]),
+    Ref = erlang:monitor(process, Pid),
+    erlang:send(Pid, {Me, Ref}),
+    {Pid, Ref}.
+
+-spec await({pid(), reference()}) -> any() | no_return().
+await({Pid, Ref}) ->
+    await({Pid, Ref}, 5000).
+
+-spec await({pid(), reference()},
+            non_neg_integer()) -> any() | no_return().
+await({Pid, Ref}, TimeOut) ->
+    receive
+        {Ref, Reply} ->
+            erlang:demonitor(Ref, [flush]),
+            Reply;
+        {'DOWN', Ref, _, _, noconnection} ->
+            erlang:exit({nodedown, erlang:node(Pid),
+                         {?MODULE, await, [{Pid, Ref}, TimeOut]}});
+        {'DOWN', Ref, _, _, Reason} ->
+            erlang:exit({Reason,
+                         {?MODULE, await, [{Pid, Ref}, TimeOut]}})
+    after TimeOut ->
+              erlang:demonitor(Ref, [flush]),
+              erlang:exit({timeout,
+                           {?MODULE, await, [{Pid, Ref}, TimeOut]}})
+    end.
+
+-spec safe_await({pid(), reference()}, term()) -> any().
+safe_await(TaskRef, DefaultResult) ->
+    safe_await(TaskRef, DefaultResult, 5000).
+
+-spec safe_await({pid(), reference()},
+                 term(), non_neg_integer()) -> any().
+safe_await(TaskRef, DefaultResult, TimeOut) ->
+    case catch await(TaskRef, TimeOut) of
+        {'EXIT', _} ->
+            DefaultResult;
+        Any ->
+            Any
+    end.
+
+-spec async_do(pid(), {node(), pid() | atom()},
+               {atom(), atom(), [term()]}) -> term().
+async_do(TaskOwner, TaskOwnerInfo, MFA) ->
+    initial_call(MFA),
+    Ref = receive
+              {TaskOwner, Ref1} ->
+                  Ref1
+          end,
+    erlang:send(TaskOwner, {Ref, do_apply(TaskOwnerInfo, MFA)}).
+
+get_info(Pid) ->
+    Name = case erlang:process_info(Pid, [registered_name]) of
+               [{registered_name, []}] ->
+                   Pid;
+               [{registered_name, RegisteredName}] ->
+                   RegisteredName
+           end,
+    {erlang:node(Pid), Name}.
+
+initial_call(MFA) ->
+    erlang:put('$initial_call', get_initial_call(MFA)).
+
+get_initial_call({Mod, Fun, Args}) ->
+    {Mod, Fun, erlang:length(Args)}.
+
+do_apply(TaskOwnerInfo, {Mod, Fun, Args} = MFA) ->
+    try
+        erlang:apply(Mod, Fun, Args)
+    catch
+        error: Value ->
+            task_exit(TaskOwnerInfo, MFA,
+                      {Value, erlang:get_stacktrace()});
+        throw: Value ->
+            task_exit(TaskOwnerInfo, MFA,
+                      {{nocatch, Value}, erlang:get_stacktrace()});
+        exit: Value ->
+            task_exit(TaskOwnerInfo, MFA, Value)
+    end.
+
+task_exit(_, _, normal) ->
+    erlang:exit(normal);
+task_exit(_, _, shutdown) ->
+    erlang:exit(shutdown);
+task_exit(_, _, Reason)
+  when erlang:tuple_size(Reason) =:= 2
+       andalso
+       erlang:element(2, Reason) =:= shutdown ->
+    erlang:exit(Reason);
+task_exit(TaskOwnerInfo, MFA, Reason) ->
+    {Fun, Args} = get_running(MFA),
+
+    error_logger:format("** Task ~p terminating~n" ++
+                        "** Started from ~p~n" ++
+                        "** When function == ~p~n" ++
+                        "**      arguments == ~p~n" ++
+                        "** Reason for termination == ~n" ++
+                        "** ~p~n",
+                        [erlang:self(), get_from(TaskOwnerInfo), Fun, Args, Reason]),
+    erlang:exit(Reason).
+
+get_from({Node, PidOrName}) when Node =:= erlang:node() ->
+    PidOrName;
+get_from(Other) ->
+    Other.
+
+get_running({Mod, Fun, Args}) ->
+    {erlang:make_fun(Mod, Fun, erlang:length(Args)), Args}.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -44,7 +44,7 @@
         end).
 
 %% This is the maximum time that typechecking a single form may take.
--define(form_check_timeout_ms, 5000).
+-define(form_check_timeout_ms, 500).
 
 -type tenv() :: gradualizer_lib:tenv().
 -type venv() :: map().

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4760,19 +4760,28 @@ type_check_forms(Forms, Opts) ->
 %% but in the light of it taking too long, just forcibly break the infinite loop and report
 %% a Gradualizer (NOT the checked program!) error.
 type_check_form_with_timeout(Function, Errors, StopOnFirstError, Env, Opts) ->
+    ?verbose(Env, "Spawning async task...~n", []),
     Task = gradualizer_task:async(fun () ->
                                           type_check_form(Function, Errors, StopOnFirstError,
                                                           Env, Opts)
                                   end),
     case gradualizer_task:safe_await(Task, timeout, ?form_check_timeout_ms) of
         timeout ->
+            ?verbose(Env, "Form check timeout on ~s~n",
+                     [gradualizer_fmt:form_info(Function)]),
             [{internal_error, form_check_timeout, Function} | Errors];
         {crash, Crash, St} ->
+            ?verbose(Env, "Task reported crash on ~s~n",
+                     [gradualizer_fmt:form_info(Function)]),
             io:format("Crashing...~n"),
             erlang:raise(throw, Crash, St);
         {error_trace, Error, Trace} ->
+            ?verbose(Env, "Task reported error with trace from ~s~n",
+                     [gradualizer_fmt:form_info(Function)]),
             erlang:raise(error, Error, Trace);
         Other ->
+            ?verbose(Env, "Task returned from ~s with ~p~n",
+                     [gradualizer_fmt:form_info(Function), Other]),
             Other
     end.
 


### PR DESCRIPTION
Current master branch is known to fall into infinite loops on some forms. It's evidenced by the property tests and real-world issues like #360. This PR tries to improve the UX and facilitate dogfooding by a **temporary measure** of forcibly breaking infinite loops after a timeout and therefore turning situations of hogging the CPU or never terminating into warning messages.

When Gradualizer is run interactively from the CLI or as a Rebar plugin, it's easy to conclude that it's stuck on a given file. However, it's still problematic when it gets stuck, as it prevents us from assessing the number of forms in the project which cause it to loop.

When Gradualizer is run as a background integration task, the only means of realising that it's stuck is the lack of diagnostics and the sound of fans cooling down the CPU.

This PR improves the situation in both of the above cases:
- it allows to finish the CLI / Rebar plugin run and assess the number of `Timeout` warnings to understand how many forms causing Gradualizer to fail are present in real-world code,
- it allows to finish a background run and only mark some forms in the editor with the `Timeout` diagnostic, providing valuable feedback on other forms which do not time out and are successfully type checked.