### PR TITLE
Recover position information for undef/not_exported type errors

### DIFF
--- a/priv/test/undefined_errors_helper.erl
+++ b/priv/test/undefined_errors_helper.erl
@@ -1,14 +1,22 @@
 -module(undefined_errors_helper).
 -export([und_rec/0, und_ty/0, not_exp_ty/0]).
--export_type([j/0]).
+-export_type([j/0,
+              expands_to_undefined_remote/0,
+              expands_to_struct_with_undefined_remote/0,
+              expands_to_struct_with_undefined_local/0,
+              expands_to_struct_with_undefined_record/0]).
 
--type j() :: undefined_type().
+-type j() :: undefined_type1().
 -type not_exported() :: ok.
+-type expands_to_undefined_remote() :: undefined_errors:undefined_type2().
+-type expands_to_struct_with_undefined_remote() :: {struct, undefined_errors:undefined_type3()}.
+-type expands_to_struct_with_undefined_local() :: {struct, undefined_type4()}.
+-type expands_to_struct_with_undefined_record() :: {struct, #undefined_record1{}}.
 
--spec und_rec() -> #undefined_record{}.
+-spec und_rec() -> #undefined_record2{}.
 und_rec() -> ok.
 
--spec und_ty() -> undefined_errors:undefined_type().
+-spec und_ty() -> undefined_errors:undefined_type5().
 und_ty() -> ok.
 
 -spec not_exp_ty() -> not_exported().

--- a/src/typechecker.hrl
+++ b/src/typechecker.hrl
@@ -9,7 +9,8 @@
               verbose           = false :: boolean(),
               exhaust           = true  :: boolean(),
               %% Performance hack: Unions larger than this limit are replaced by any() in normalization.
-              union_size_limit          :: non_neg_integer()
+              union_size_limit          :: non_neg_integer(),
+              current_spec      = none  :: erl_parse:abstract_form() | none
              }).
 
 -endif. %% __TYPECHECKER_HRL__

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -86,7 +86,9 @@ parse_type(Src) ->
 %% kept for user-defined types and record types. Filename is used to
 %% disambiguate between types with the same name from different modules.
 %% Annotated types as in Name :: Type are also removed.
--spec remove_pos(type()) -> type().
+-spec remove_pos(type() | [type()]) -> type().
+remove_pos(Types) when is_list(Types) ->
+    [ remove_pos(Ty) || Ty <- Types ];
 remove_pos({Type, _, Value})
   when Type == atom; Type == integer; Type == char; Type == var ->
     {Type, erl_anno:new(0), Value};

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -86,9 +86,7 @@ parse_type(Src) ->
 %% kept for user-defined types and record types. Filename is used to
 %% disambiguate between types with the same name from different modules.
 %% Annotated types as in Name :: Type are also removed.
--spec remove_pos(type() | [type()]) -> type().
-remove_pos(Types) when is_list(Types) ->
-    [ remove_pos(Ty) || Ty <- Types ];
+-spec remove_pos(type()) -> type().
 remove_pos({Type, _, Value})
   when Type == atom; Type == integer; Type == char; Type == var ->
     {Type, erl_anno:new(0), Value};

--- a/test/misc/undefined_errors.erl
+++ b/test/misc/undefined_errors.erl
@@ -1,5 +1,9 @@
 -module(undefined_errors).
 -export([remote_type/0,
+         remote_remote_type/0,
+         remote_struct_with_remote_type/0,
+         remote_struct_with_local_type/0,
+         remote_struct_with_record/0,
          remote_call/0,
          remote_record/0,
          normalize_remote_type/0,
@@ -7,6 +11,18 @@
 
 -spec remote_type() -> undefined_errors_helper:j().
 remote_type() -> ok.
+
+-spec remote_remote_type() -> undefined_errors_helper:expands_to_undefined_remote().
+remote_remote_type() -> ok.
+
+-spec remote_struct_with_remote_type() -> undefined_errors_helper:expands_to_struct_with_undefined_remote().
+remote_struct_with_remote_type() -> {struct, ok}.
+
+-spec remote_struct_with_local_type() -> undefined_errors_helper:expands_to_struct_with_undefined_local().
+remote_struct_with_local_type() -> {struct, ok}.
+
+-spec remote_struct_with_record() -> undefined_errors_helper:expands_to_struct_with_undefined_record().
+remote_struct_with_record() -> {struct, ok}.
 
 -spec remote_call() -> ok.
 remote_call() -> undefined_errors_helper:undefined_call().


### PR DESCRIPTION
This is another take at #379 which supersedes #380. The implementation is significantly simpler. It also covers the `undef, user_type` cases which were still not handled by #380.

Current master:
```
> gradualizer:type_check_file("test/misc/undefined_errors.erl", []).
test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type2/0 on line 0
test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type3/0 on line 0
test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type5/0 on line 0
test/misc/undefined_errors.erl: Undefined remote type undefined_errors_helper:not_exported_type/0 on line 0
test/misc/undefined_errors.erl: Undefined type undefined_type1/0 on line 0
test/misc/undefined_errors.erl: Undefined type undefined_type4/0 on line 0
test/misc/undefined_errors.erl: The atom on line 25 at column 41 is expected to have type #undefined_record1{} but it has type ok

-spec remote_struct_with_record() -> undefined_errors_helper:expands_to_struct_with_undefined_record().
remote_struct_with_record() -> {struct, ok}.
                                        ^^

test/misc/undefined_errors.erl: Call to undefined function undefined_errors_helper:undefined_call/0 on line 28 at column 41
test/misc/undefined_errors.erl: The function call on line 32 at column 20 is expected to have type #defined_record{} but it has type #undefined_record2{}

-record(defined_record, {a, b, c}).
-spec remote_record() -> #defined_record{}.
remote_record() -> undefined_errors_helper:und_rec().
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

nok
>
> gradualizer:type_check_file("priv/test/undefined_errors_helper.erl", []).
priv/test/undefined_errors_helper.erl: record undefined_record1 undefined on line 14 at column 61
priv/test/undefined_errors_helper.erl: record undefined_record2 undefined on line 16 at column 20
priv/test/undefined_errors_helper.erl: type undefined_type1() undefined on line 9 at column 14
priv/test/undefined_errors_helper.erl: type undefined_type4() undefined on line 13 at column 60
nok
```

This PR (some lines reordered for a simpler diff):
```
> gradualizer:type_check_file("test/misc/undefined_errors.erl", []).
test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type2/0 on line 15 at column 25
test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type3/0 on line 18 at column 37
test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type5/0 on line 34 at column 28
test/misc/undefined_errors.erl: Undefined remote type undefined_errors_helper:not_exported_type/0 on line 37 at column 19
test/misc/undefined_errors.erl: Undefined type undefined_type1/0 on line 12 at column 18
test/misc/undefined_errors.erl: Undefined type undefined_type4/0 on line 21 at column 36
test/misc/undefined_errors.erl: The atom on line 25 at column 41 is expected to have type #undefined_record1{} but it has type ok

-spec remote_struct_with_record() -> undefined_errors_helper:expands_to_struct_with_undefined_record().
remote_struct_with_record() -> {struct, ok}.
                                        ^^

test/misc/undefined_errors.erl: Call to undefined function undefined_errors_helper:undefined_call/0 on line 28 at column 41
test/misc/undefined_errors.erl: The function call on line 32 at column 20 is expected to have type #defined_record{} but it has type #undefined_record2{}

-record(defined_record, {a, b, c}).
-spec remote_record() -> #defined_record{}.
remote_record() -> undefined_errors_helper:und_rec().
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

nok
>
> gradualizer:type_check_file("priv/test/undefined_errors_helper.erl", []).
priv/test/undefined_errors_helper.erl: record undefined_record1 undefined on line 14 at column 61
priv/test/undefined_errors_helper.erl: record undefined_record2 undefined on line 16 at column 20
priv/test/undefined_errors_helper.erl: type undefined_type1() undefined on line 9 at column 14
priv/test/undefined_errors_helper.erl: type undefined_type4() undefined on line 13 at column 60
nok
```

Diff:
```
--- remote-types.before.log	2022-02-15 14:44:11.000000000 +0100
+++ remote-types.after.3.log	2022-02-15 21:04:15.000000000 +0100
@@ -1,10 +1,10 @@
 > gradualizer:type_check_file("test/misc/undefined_errors.erl", []).
-test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type2/0 on line 0
-test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type3/0 on line 0
-test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type5/0 on line 0
-test/misc/undefined_errors.erl: Undefined remote type undefined_errors_helper:not_exported_type/0 on line 0
-test/misc/undefined_errors.erl: Undefined type undefined_type1/0 on line 0
-test/misc/undefined_errors.erl: Undefined type undefined_type4/0 on line 0
+test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type2/0 on line 15 at column 25
+test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type3/0 on line 18 at column 37
+test/misc/undefined_errors.erl: Undefined remote type undefined_errors:undefined_type5/0 on line 34 at column 28
+test/misc/undefined_errors.erl: Undefined remote type undefined_errors_helper:not_exported_type/0 on line 37 at column 19
+test/misc/undefined_errors.erl: Undefined type undefined_type1/0 on line 12 at column 18
+test/misc/undefined_errors.erl: Undefined type undefined_type4/0 on line 21 at column 36
 test/misc/undefined_errors.erl: The atom on line 25 at column 41 is expected to have type #undefined_record1{} but it has type ok
 
 -spec remote_struct_with_record() -> undefined_errors_helper:expands_to_struct_with_undefined_record().
```