### PR TITLE
Check exhaustiveness argument-wise

### DIFF
--- a/test/should_fail/exhaustive_argumentwise.erl
+++ b/test/should_fail/exhaustive_argumentwise.erl
@@ -1,0 +1,8 @@
+-module(exhaustive_argumentwise).
+
+-export([f/2]).
+
+-type t() :: ala | ola.
+
+-spec f(t(), any()) -> ok.
+f(ala, _) -> ok.


### PR DESCRIPTION
This enables checking exhaustiveness of functions of arity > 1 when some of the arguments cannot be
checked for exhaustiveness.

Consider the following example (Elixir syntax, but the problem is NOT Elixir specfic):

```elixir
  @spec handle(message(), any, any) :: state()
  ## Try breaking the pattern match, e.g. by changing 'echo_req'
  def handle({:echo_req, payload}, from, state) do
    GenServer.reply(from, {:echo_res, payload})
    state
  end

  ## Try commenting out the following clause
  def handle({:hello, name}, from, state) do
    IO.puts("Hello, #{name}!")
    GenServer.reply(from, :ok)
    state
  end
```

Without this PR this function cannot be checked for exhaustiveness because arguments of type `any` are not refinable. However, the 2nd and 3rd arguments are not used for control flow and are not pattern matched on, so it's not useful to check if the function clauses exhaust them.

With this PR the exhaustiveness check is more flexible - it's up to the programmer to specify only some of the arguments to a level precise enough for exhaustiveness checking. Other, underspecified args, won't prevent the check from running on the well-specified ones.