### PR TITLE
Make binary() aka String.t() in Elixir refinable

### DIFF
--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -608,7 +608,9 @@ get_beam_map() ->
                 {match, [Mod]} ->
                     {true, {list_to_atom(Mod), Filename}};
                 nomatch ->
-                    false
+                    false;
+                _ ->
+                    erlang:error({unreachable, "check re:run/3 opts above - this should not happen"})
             end
         end,
         BeamFiles),

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -193,8 +193,8 @@ pick_value(?type(nonempty_list, Ty), Env) ->
     {cons, erl_anno:new(0), H, {nil, erl_anno:new(0)}};
 pick_value(?type(nil), _Env) ->
     {nil, erl_anno:new(0)};
-pick_value(?type(binary, _), _Env) ->
-    {bin, erl_anno:new(0), []};
+pick_value(?type(binary, _) = B, Env) ->
+    pick_binary_value(B, Env);
 %% The ?type(range) is a different case because the type range
 %% ..information is not encoded as an abstract_type()
 %% i.e. {type, Anno, range, [{integer, Anno2, Low}, {integer, Anno3, High}]}
@@ -222,6 +222,22 @@ pick_value(Type, Env)
             throw({undef, Kind, Anno, {Name, length(Args)}})
     end.
 
+pick_binary_value(?type(binary, []), _Env) ->
+    {bin, erl_anno:new(0), []};
+pick_binary_value(?type(binary, [{integer, _, 0}, {integer, _, _}]), _Env) ->
+    {bin, erl_anno:new(0), []};
+pick_binary_value(?type(binary, [{integer, _, M}, {integer, _, _}]), _Env) ->
+    Elements = case M rem 8 of
+                   0 ->
+                       S = [ $a || _ <- lists:seq(1, M div 8) ],
+                       [{bin_element, 0, {string, 0, S}, default, default}];
+                   _ ->
+                       Eights = [ {bin_element, 0, {integer, 0, 0}, default, default}
+                                  || _ <- lists:seq(1, M div 8) ],
+                       Tail = {bin_element, 0, {integer, 0, 0}, {integer, 0, M rem 8}, default},
+                       Eights ++ [Tail]
+               end,
+    {bin, erl_anno:new(0), Elements}.
 
 %% ------------------------------------------------
 %% Functions for working with abstract syntax trees

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -193,6 +193,8 @@ pick_value(?type(nonempty_list, Ty), Env) ->
     {cons, erl_anno:new(0), H, {nil, erl_anno:new(0)}};
 pick_value(?type(nil), _Env) ->
     {nil, erl_anno:new(0)};
+pick_value(?type(binary, _), _Env) ->
+    {bin, erl_anno:new(0), []};
 %% The ?type(range) is a different case because the type range
 %% ..information is not encoded as an abstract_type()
 %% i.e. {type, Anno, range, [{integer, Anno2, Low}, {integer, Anno3, High}]}

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -226,16 +226,13 @@ pick_binary_value(?type(binary, []), _Env) ->
     {bin, erl_anno:new(0), []};
 pick_binary_value(?type(binary, [{integer, _, 0}, {integer, _, _}]), _Env) ->
     {bin, erl_anno:new(0), []};
-pick_binary_value(?type(binary, [{integer, _, M}, {integer, _, _}]), _Env) ->
+pick_binary_value(?type(binary, [{integer, _, M}, {integer, _, _}]), _Env) when M > 0 ->
     Elements = case M rem 8 of
                    0 ->
                        S = [ $a || _ <- lists:seq(1, M div 8) ],
                        [{bin_element, 0, {string, 0, S}, default, default}];
                    _ ->
-                       Eights = [ {bin_element, 0, {integer, 0, 0}, default, default}
-                                  || _ <- lists:seq(1, M div 8) ],
-                       Tail = {bin_element, 0, {integer, 0, 0}, {integer, 0, M rem 8}, default},
-                       Eights ++ [Tail]
+                       [{bin_element, 0, {integer, 0, 0}, {integer, 0, M}, default}]
                end,
     {bin, erl_anno:new(0), Elements}.
 

--- a/src/gradualizer_lib.erl
+++ b/src/gradualizer_lib.erl
@@ -193,8 +193,10 @@ pick_value(?type(nonempty_list, Ty), Env) ->
     {cons, erl_anno:new(0), H, {nil, erl_anno:new(0)}};
 pick_value(?type(nil), _Env) ->
     {nil, erl_anno:new(0)};
-pick_value(?type(binary, _) = B, Env) ->
-    pick_binary_value(B, Env);
+pick_value(?type(binary, [{integer, _, M}, {integer, _, _}]), _Env) when M > 0 ->
+    {bin, erl_anno:new(0), [{bin_element, 0, {integer, 0, 0}, {integer, 0, M}, default}]};
+pick_value(?type(binary, _), _Env) ->
+    {bin, erl_anno:new(0), []};
 %% The ?type(range) is a different case because the type range
 %% ..information is not encoded as an abstract_type()
 %% i.e. {type, Anno, range, [{integer, Anno2, Low}, {integer, Anno3, High}]}
@@ -221,20 +223,6 @@ pick_value(Type, Env)
         not_found ->
             throw({undef, Kind, Anno, {Name, length(Args)}})
     end.
-
-pick_binary_value(?type(binary, []), _Env) ->
-    {bin, erl_anno:new(0), []};
-pick_binary_value(?type(binary, [{integer, _, 0}, {integer, _, _}]), _Env) ->
-    {bin, erl_anno:new(0), []};
-pick_binary_value(?type(binary, [{integer, _, M}, {integer, _, _}]), _Env) when M > 0 ->
-    Elements = case M rem 8 of
-                   0 ->
-                       S = [ $a || _ <- lists:seq(1, M div 8) ],
-                       [{bin_element, 0, {string, 0, S}, default, default}];
-                   _ ->
-                       [{bin_element, 0, {integer, 0, 0}, {integer, 0, M}, default}]
-               end,
-    {bin, erl_anno:new(0), Elements}.
 
 %% ------------------------------------------------
 %% Functions for working with abstract syntax trees

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3725,6 +3725,10 @@ refine_ty(?type(binary, [{integer, _, 0}, {integer, _, 8}]),
           ?type(binary, [{integer, _, 0}, {integer, _, 0}]), _, _Env) ->
     %% binary() \ <<>> => nonempty_binary()
     type(binary, [{integer, 0, 8}, {integer, 0, 8}]);
+refine_ty(?type(binary, [{integer, _, 0}, {integer, _, 8}]),
+          ?type(binary, [{integer, _, 8}, {integer, _, 8}]), _, _Env) ->
+    %% binary() \ nonempty_binary() => <<>>
+    type(binary, [{integer, 0, 0}, {integer, 0, 0}]);
 refine_ty(?type(binary, [_,_]),
           ?type(binary, [{integer, _, 0}, {integer, _, 1}]), _, _Env) ->
     %% B \ bitstring() => none()

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3721,12 +3721,12 @@ refine_ty(?type(nonempty_list, [Ty1]), ?type(nonempty_list, [Ty2]), Trace, Env) 
         RefTy ->
             type(nonempty_list, [RefTy])
     end;
-refine_ty(?type(binary, [{integer, _, 0}, {integer, _, 8}]),
-          ?type(binary, [{integer, _, 0}, {integer, _, 0}]), _, _Env) ->
+refine_ty(?type(binary, [{integer, _, 0}, {integer, _, N}]),
+          ?type(binary, [{integer, _, 0}, {integer, _, 0}]), _, _Env) when N > 0 ->
     %% binary() \ <<>> => nonempty_binary()
-    type(binary, [{integer, 0, 8}, {integer, 0, 8}]);
-refine_ty(?type(binary, [{integer, _, 0}, {integer, _, 8}]),
-          ?type(binary, [{integer, _, 8}, {integer, _, 8}]), _, _Env) ->
+    type(binary, [{integer, 0, N}, {integer, 0, N}]);
+refine_ty(?type(binary, [{integer, _, 0}, {integer, _, N}]),
+          ?type(binary, [{integer, _, N}, {integer, _, N}]), _, _Env) when N > 0 ->
     %% binary() \ nonempty_binary() => <<>>
     type(binary, [{integer, 0, 0}, {integer, 0, 0}]);
 refine_ty(?type(binary, [_,_]),

--- a/test/known_problems/should_pass/binary_exhaustiveness_checking_should_pass.erl
+++ b/test/known_problems/should_pass/binary_exhaustiveness_checking_should_pass.erl
@@ -1,0 +1,12 @@
+-module(binary_exhaustiveness_checking_should_pass).
+
+-gradualizer([infer]).
+
+-export([f/0]).
+
+-spec f() -> ok.
+f() ->
+    Cond = <<"asd">>,
+    case Cond of
+        <<_/bytes>> -> ok
+    end.

--- a/test/should_pass/binary_exhaustiveness_checking.erl
+++ b/test/should_pass/binary_exhaustiveness_checking.erl
@@ -1,13 +1,17 @@
 -module(binary_exhaustiveness_checking).
 
--export([f/1, g/1, h/1]).
+-export([f/1, g/1, h/1, k/1]).
 
 f(<<>>) -> ok;
 f(<<_:8, _/binary>>) -> ok.
 
 -spec g(binary()) -> ok.
-g(<<>>) -> ok;
-g(<<_:8, _/binary>>) -> ok.
+g(<<_:8, _/binary>>) -> ok;
+g(<<>>) -> ok.
 
 -spec h(binary()) -> ok.
-h(<<_:4, _:4, _/binary>>) -> ok.
+h(<<_:8, _/binary>>) -> ok;
+h(<<>>) -> ok.
+
+-spec k(binary()) -> ok.
+k(<<_:4, _:4, _/binary>>) -> ok.

--- a/test/should_pass/binary_exhaustiveness_checking.erl
+++ b/test/should_pass/binary_exhaustiveness_checking.erl
@@ -1,0 +1,13 @@
+-module(binary_exhaustiveness_checking).
+
+-export([f/1, g/1, h/1]).
+
+f(<<>>) -> ok;
+f(<<_:8, _/binary>>) -> ok.
+
+-spec g(binary()) -> ok.
+g(<<>>) -> ok;
+g(<<_:8, _/binary>>) -> ok.
+
+-spec h(binary()) -> ok.
+h(<<_:4, _:4, _/binary>>) -> ok.

--- a/test/should_pass/binary_exhaustiveness_checking.erl
+++ b/test/should_pass/binary_exhaustiveness_checking.erl
@@ -1,5 +1,7 @@
 -module(binary_exhaustiveness_checking).
 
+-gradualizer([infer]).
+
 -export([f/1, g/1, h/1, k/1]).
 
 f(<<>>) -> ok;
@@ -15,3 +17,16 @@ h(<<>>) -> ok.
 
 -spec k(binary()) -> ok.
 k(<<_:4, _:4, _/binary>>) -> ok.
+
+%% This case should pass, since we should detect that <<V:8, _/binary>> is a complex pattern for
+%% which we cannot guarantee it exhausts the binary() type (see `is_bin_pat_exhaustive')
+%% and therefore not try to do exhaustiveness checking.
+-spec l(binary()) -> ok.
+l(B) ->
+    V = $A,
+    case B of
+        <<>> ->
+            ok;
+        <<V:8, _/binary>> ->
+            ok
+    end.


### PR DESCRIPTION
`String.t()` is the default string type in Elixir just as `string()` is the default in Erlang. However, when Erlang `string()` is a _charlist_, i.e. a list of integers, the Elixir default string type is actually a binary. This makes binaries ubiquitous in Elixir code, much more so than in Erlang. To make exhaustiveness checking useful and relevant in Elixir (for example in cases such as #391), it has to support the binary type.

Alas, this brings in some problems, the most obvious one being a broken test case. Therefore, until this is solved, I'm making this a draft.