### PR TITLE
fix: pp_type 'var' always assume the var is a string

### DIFF
--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -303,7 +303,7 @@ format_type_error({type_error, check_clauses}, _Opts) ->
 format_type_error({type_error, record_pattern, Anno, Record, Ty}, Opts) ->
     io_lib:format(
       "~sThe record pattern for record #~p~s is expected to have"
-      " type ~s.~n",
+      " type ~s~n",
       [format_location(Anno, brief, Opts),
        Record,
        format_location(Anno, verbose, Opts),

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -47,8 +47,11 @@ pp_type(Type = {type, _, bounded_fun, _}) ->
                           [{capture, all_but_first, list}, dotall]),
     "fun(" ++ S ++ ")";
 pp_type({var, _, TyVar}) ->
-    %% TODO: In type(), TyVar should be an atom but we use a string.
-    TyVar;
+    %% See gradualizer_type:af_type_variable/0 and typechecker:new_type_var/0
+    if
+        is_atom(TyVar) -> atom_to_list(TyVar);
+        is_list(TyVar) -> TyVar
+    end;
 pp_type(Type) ->
     %% erl_pp can handle type definitions, so wrap Type in a type definition
     %% and then take the type from that.


### PR DESCRIPTION
A 'var' type variable's name is not always a string as opposed to what the comment indicate in `pp_type`.

This commit fixes the logic to handle both cases in `pp_type`.

This commit also removes the final period in one error message because most error messages don't have a
final period.

---

The odd thing about this bug is that I hit this case through `format_type_error({type_error, record_pattern, ...`:
> /app/src/censored: The record pattern for record #censored on line 707 at column 19 is expected to have type A

where `A` is typed as a `var` because it stems from a `lists:map()`.

The error message should be improved for generics if it's possible.
