### PR TITLE
Fix variable bind before a record pattern match in function head

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4236,10 +4236,10 @@ add_type_pat({bin, _P, BinElements} = Bin, Ty, Env, VEnv) ->
 add_type_pat({record, P, Record, Fields}, Ty, Env, VEnv) ->
     case expect_record_type(Ty, Record, Env) of
         any ->
-            {type(none)
-                ,Ty
-                ,union_var_binds([add_any_types_pat(Field, VEnv) || ?record_field_expr(Field) <- Fields], Env)
-                ,constraints:empty()};
+            {type(none), Ty,
+             union_var_binds([VEnv] ++ [ add_any_types_pat(Field, #{})
+                                         || ?record_field_expr(Field) <- Fields ], Env),
+             constraints:empty()};
         {fields_ty, Tys, Cs} ->
             {PatTys, UBounds, VEnv1, Cs1} = add_type_pat_fields(Fields, Tys, Env, VEnv),
             {type_record(Record, PatTys)

--- a/test/should_pass/variable_binding.erl
+++ b/test/should_pass/variable_binding.erl
@@ -1,0 +1,8 @@
+-module(variable_binding).
+
+-export([variable_bind_before_record_pattern_match/2]).
+
+-record(st, {}).
+
+variable_bind_before_record_pattern_match({Pid}, #st{}) ->
+    Pid.


### PR DESCRIPTION
Fix and test for #395. This is one of the issues found thanks to #373.