### PR TITLE
typechecker: check exhaustiveness against refined args

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3490,7 +3490,7 @@ disable_exhaustiveness_check(#env{} = Env) ->
 %% @end
 check_arg_exhaustiveness(Env, ArgsTy, Clauses, RefinedArgsTy) ->
     case exhaustiveness_checking(Env) andalso
-         all_refinable(ArgsTy, Env) andalso
+         all_refinable(RefinedArgsTy, Env) andalso
          no_clause_has_guards(Clauses) andalso
          some_type_not_none(RefinedArgsTy)
     of


### PR DESCRIPTION
This PR changes the logic in the exhaustiveness check to check for refinability of the refined args instead of the non-refined args.

This was suggested in a different issue here: https://github.com/josefs/Gradualizer/issues/339#issuecomment-895786061
The change resolves an issue I encounter where the type checked for exhaustiveness is accepted but the refined type fails with a `badargs` in `pick_value`.

As far as I understand, the `refinable3/` function also acts as a gatekeeper for `pick_value/2`.

edit: Fixes #414
