### PR TITLE
Fix false nonexhaustive record patterns

### DIFF
--- a/src/gradualizer_app.erl
+++ b/src/gradualizer_app.erl
@@ -15,6 +15,21 @@
 %%%===================================================================
 
 start(_StartType, _StartArgs) ->
+
+    F = fun
+            (Trace, ok) ->
+                io:format("~p\n", [Trace])
+        end,
+    dbg:tracer(process, {F, ok}),
+    %dbg:p(all, call),
+    %dbg:tpl(typechecker, check_arg_exhaustiveness, x),
+    %dbg:tpl(typechecker, exhaustiveness_checking, x),
+    %dbg:tpl(typechecker, all_refinable, x),
+    %dbg:tpl(typechecker, no_clause_has_guards, x),
+    dbg:tpl(typechecker, some_type_not_none, x),
+    dbg:tpl(typechecker, type_diff, x),
+    dbg:tpl(typechecker, refine, x),
+
     Opts = application:get_env(gradualizer, options, []),
     gradualizer_sup:start_link(Opts).
 

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -218,7 +218,7 @@ format_type_error({type_error, op_type_too_precise, Op, Anno, Ty}, Opts) ->
        pp_type(Ty, Opts)]);
 format_type_error({type_error, arith_error, ArithOp, Anno, Ty1, Ty2}, Opts) ->
     io_lib:format(
-      "~sThe operator ~p~s is requires numeric arguments, but "
+      "~sThe operator ~p~s requires numeric arguments, but "
       "has arguments of type ~s and ~s~n",
       [format_location(Anno, brief, Opts),
        ArithOp,
@@ -227,8 +227,8 @@ format_type_error({type_error, arith_error, ArithOp, Anno, Ty1, Ty2}, Opts) ->
        pp_type(Ty2, Opts)]);
 format_type_error({type_error, int_error, ArithOp, Anno, Ty1, Ty2}, Opts) ->
     io_lib:format(
-      "~sThe operator ~p~s is requires integer arguments, but "
-      " has arguments of type ~s and ~s~n",
+      "~sThe operator ~p~s requires integer arguments, but "
+      "has arguments of type ~s and ~s~n",
       [format_location(Anno, brief, Opts),
        ArithOp,
        format_location(Anno, verbose, Opts),

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4916,6 +4916,7 @@ type_check_forms(Forms, Opts) ->
     AllErrors = lists:foldr(fun (Function, Errors) ->
                                     type_check_form_with_timeout(Function, Errors, StopOnFirstError, Env, Opts)
                             end, [], ParseData#parsedata.functions),
+    timer:sleep(200),
     lists:reverse(AllErrors).
 
 

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3432,9 +3432,10 @@ check_clauses(Env, ArgsTy, ResTy, Clauses, Caps) ->
     %% i.e. separately for each argument.
     %% This allows to report non-exhaustiveness warnings even if some arguments are not subject
     %% to exhaustiveness checking, e.g. 'any'.
-    lists:foreach(fun ({ArgTy, RefinedArgTy}) ->
-                          check_arg_exhaustiveness(Env2, [ArgTy], Clauses, [RefinedArgTy])
-                  end, lists:zip(ArgsTy, RefinedArgsTy)),
+    AllRefinable = all_refinable(ArgsTy, Env2),
+    lists:foreach(fun (RefinedArgTy) ->
+                          check_arg_exhaustiveness(Env2, AllRefinable, Clauses, [RefinedArgTy])
+                  end, RefinedArgsTy),
     Env3 = pop_clauses_controls(Env2),
     {union_var_binds(VarBindsList, Env3), constraints:combine(Css)}.
 
@@ -3468,9 +3469,10 @@ disable_exhaustiveness_check(#env{} = Env) ->
 %% Currently, exhaustiveness checking is disabled if a clause has any guards.
 %% TODO: Exhaustiveness checking might be improved in the future to handle (some) guards.
 %% @end
-check_arg_exhaustiveness(Env, ArgsTy, Clauses, RefinedArgsTy) ->
+check_arg_exhaustiveness(Env, AllRefinable, Clauses, RefinedArgsTy) ->
     case exhaustiveness_checking(Env) andalso
-         all_refinable(ArgsTy, Env) andalso
+         %all_refinable(ArgsTy, Env) andalso
+         AllRefinable andalso
          no_clause_has_guards(Clauses) andalso
          some_type_not_none(RefinedArgsTy)
     of

--- a/test/should_pass/nonexhaustive_record_pattern.erl
+++ b/test/should_pass/nonexhaustive_record_pattern.erl
@@ -5,6 +5,6 @@
 -record(env, {}).
 -type env() :: #env{}.
 
--spec g(_, env()) -> ok.
-g([], _Env) -> ok;
-g([_Ty1|_Tys], _Env) -> ok.
+-spec g(integer(), env()) -> ok.
+g(1, _Env) -> ok;
+g(_I, _Env) -> ok.

--- a/test/should_pass/nonexhaustive_record_pattern.erl
+++ b/test/should_pass/nonexhaustive_record_pattern.erl
@@ -1,9 +1,14 @@
 -module(nonexhaustive_record_pattern).
 
--export([g/2]).
+-export([f/2,
+         g/2]).
 
 -record(env, {}).
 -type env() :: #env{}.
+
+-spec f(_, env()) -> ok.
+f([], _Env) -> ok;
+f([_Ty1|_Tys], _Env) -> ok.
 
 -spec g(integer(), env()) -> ok.
 g(1, _Env) -> ok;

--- a/test/should_pass/nonexhaustive_record_pattern.erl
+++ b/test/should_pass/nonexhaustive_record_pattern.erl
@@ -1,0 +1,10 @@
+-module(nonexhaustive_record_pattern).
+
+-export([g/2]).
+
+-record(env, {}).
+-type env() :: #env{}.
+
+-spec g(_, env()) -> ok.
+g([], _Env) -> ok;
+g([_Ty1|_Tys], _Env) -> ok.


### PR DESCRIPTION
I started debugging the next most prominent error found in self-gradualize logs: nonexhaustive pattern warning on records (approx. 20 out of 50+ reported errors).

So far it seems to be an issue cascading from undefinedness of some preceding parameter and the fact that fun params are packed into a tuple before being passed to `refine_ty`.