### PR TITLE
Make atom() refinable

### DIFF
--- a/src/gradualizer_app.erl
+++ b/src/gradualizer_app.erl
@@ -15,6 +15,15 @@
 %%%===================================================================
 
 start(_StartType, _StartArgs) ->
+
+    F = fun
+            (Trace, ok) ->
+                io:format("~p\n", [Trace])
+        end,
+    dbg:tracer(process, {F, ok}),
+    dbg:p(all, call),
+    dbg:tpl(typechecker, refine_ty, x),
+
     Opts = application:get_env(gradualizer, options, []),
     gradualizer_sup:start_link(Opts).
 

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4941,6 +4941,7 @@ type_check_forms(Forms, Opts) ->
     AllErrors = lists:foldr(fun (Function, Errors) ->
                                     type_check_form_with_timeout(Function, Errors, StopOnFirstError, Env, Opts)
                             end, [], ParseData#parsedata.functions),
+    timer:sleep(200),
     lists:reverse(AllErrors).
 
 

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3841,6 +3841,8 @@ refinable(?type(neg_integer), _Env, _Trace) ->
     true;
 refinable({atom, _, _}, _Env, _Trace) ->
     true;
+refinable(?type(atom), _Env, _Trace) ->
+    true;
 refinable(?type(nil), _Env, _Trace) ->
     true;
 refinable(?type(Name, Tys) = Ty0, Env, Trace)

--- a/test/should_pass/exhaustive_maps.erl
+++ b/test/should_pass/exhaustive_maps.erl
@@ -1,14 +1,21 @@
 -module(exhaustive_maps).
 
--export([map_union_empty_pat_is_first/1,
-         map_union_empty_pat_is_last/1]).
+-compile(export_all).
+
+%-export([map_union_empty_pat_is_first/1,
+%         map_union_empty_pat_is_last/1]).
 
 -spec map_union_empty_pat_is_first(#{a => atom()} | #{b := boolean()}) -> atom().
 map_union_empty_pat_is_first(#{}) -> empty;
 map_union_empty_pat_is_first(#{a := A}) -> A;
 map_union_empty_pat_is_first(#{b := B}) -> B.
 
--spec map_union_empty_pat_is_last(#{a => atom()} | #{b := boolean()}) -> atom().
-map_union_empty_pat_is_last(#{a := A}) -> A;
-map_union_empty_pat_is_last(#{b := B}) -> B;
-map_union_empty_pat_is_last(#{}) -> empty.
+%-spec map_union_empty_pat_is_last(#{a => atom()} | #{b := boolean()}) -> atom().
+%map_union_empty_pat_is_last(#{a := A}) -> A;
+%map_union_empty_pat_is_last(#{b := B}) -> B;
+%map_union_empty_pat_is_last(#{}) -> empty.
+
+%-spec map_union_empty_pat_is_last2(#{a => atom()} | #{b := boolean()}) -> atom().
+%map_union_empty_pat_is_last2(#{a := A}) -> A;
+%map_union_empty_pat_is_last2(#{}) -> empty;
+%map_union_empty_pat_is_last2(#{b := B}) -> B.

--- a/test/should_pass/exhaustive_maps.erl
+++ b/test/should_pass/exhaustive_maps.erl
@@ -1,0 +1,14 @@
+-module(exhaustive_maps).
+
+-export([map_union_empty_pat_is_first/1,
+         map_union_empty_pat_is_last/1]).
+
+-spec map_union_empty_pat_is_first(#{a => atom()} | #{b := boolean()}) -> atom().
+map_union_empty_pat_is_first(#{}) -> empty;
+map_union_empty_pat_is_first(#{a := A}) -> A;
+map_union_empty_pat_is_first(#{b := B}) -> B.
+
+-spec map_union_empty_pat_is_last(#{a => atom()} | #{b := boolean()}) -> atom().
+map_union_empty_pat_is_last(#{a := A}) -> A;
+map_union_empty_pat_is_last(#{b := B}) -> B;
+map_union_empty_pat_is_last(#{}) -> empty.

--- a/test/should_pass/map_pattern.erl
+++ b/test/should_pass/map_pattern.erl
@@ -14,11 +14,11 @@
 f(#{bepa := Bepa}) ->
     Bepa.
 
--spec key_subtype(#{atom() => integer()}) -> integer().
+-spec key_subtype(#{banana := integer()}) -> integer().
 key_subtype(#{banana := N}) ->
     N.
 
--spec map_union(#{a => atom()} | #{b := boolean()}) -> atom().
+-spec map_union(#{a := atom()} | #{b := boolean()}) -> atom().
 map_union(#{a := A}) -> A;
 map_union(#{b := B}) -> B.
 


### PR DESCRIPTION
This explores, apparently non-trivial, consequences of making `atom()` refinable. This addresses #422.