### PR TITLE
Another batch of type error fixes

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4756,7 +4756,8 @@ type_of_bin_element({bin_element, _P, Expr, _Size, Specifiers}, OccursAs) ->
 
 %%% Helper functions
 
--spec type(atom(), [any()]) -> type().
+-spec type(map | tuple, any) -> type();
+          (atom(), [any()]) -> type().
 type(Name, Args) ->
     {type, erl_anno:new(0), Name, Args}.
 

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4955,7 +4955,8 @@ type_check_forms(Forms, Opts) ->
 %% To avoid the user experience problem, it's better to opportunistically try performing the check,
 %% but in the light of it taking too long, just forcibly break the infinite loop and report
 %% a Gradualizer (NOT the checked program!) error.
--spec type_check_form_with_timeout(expr(), [any()], boolean(), env(), [any()]) -> [any()].
+-spec type_check_form_with_timeout(expr(), [any()], boolean(), env(), [any()]) -> R when
+      R :: badarg | any | [any()].
 type_check_form_with_timeout(Function, Errors, StopOnFirstError, Env, Opts) ->
     %% TODO: make FormCheckTimeOut configurable
     FormCheckTimeOut = ?form_check_timeout_ms,

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -172,8 +172,11 @@ get_module_from_annotation(Anno) ->
 -spec substitute_type_vars(type(),
                            #{atom() => type()}) -> type().
 substitute_type_vars({type, L, 'fun', [Any = {type, _, any}, RetTy]}, TVars) ->
-    %% special case for `fun((...) -> R)`,
-    %% the only place where `{type, _, any}` can occur
+    %% Special case for `fun((...) -> R)',
+    %% the only place where `{type, _, any}' can occur.
+    %% We match on `{type, _, any}' in the head explicitly, so `RetTy' cannot contain it - the
+    %% assertion is safe.
+    RetTy = ?assert_type(RetTy, type()),
     {type, L, 'fun', [Any, substitute_type_vars(RetTy, TVars)]};
 substitute_type_vars({Tag, L, T, Params}, TVars) when Tag == type orelse
                                                       Tag == user_type,

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -142,21 +142,26 @@ anno_keep_only_filename(Anno) ->
 %% Annotate user-defined types and record types with a file name.
 -spec annotate_user_types(module() | file:filename(), type()) -> type().
 annotate_user_types(Module, Type) when is_atom(Module) ->
-    annotate_user_types(atom_to_list(Module) ++ ".erl", Type);
-annotate_user_types(Filename, {user_type, Anno, Name, Params}) ->
-    %% Annotate local user-defined type
+    annotate_user_types_(atom_to_list(Module) ++ ".erl", Type);
+annotate_user_types(Filename, Type) ->
+    Filename = ?assert_type(Filename, file:filename()),
+    annotate_user_types_(Filename, Type).
+
+-spec annotate_user_types_(file:filename(), type()) -> type().
+annotate_user_types_(Filename, {user_type, Anno, Name, Params}) ->
+    %% Annotate local user-defined type.
     {user_type, erl_anno:set_file(Filename, Anno), Name,
      [annotate_user_types(Filename, Param) || Param <- Params]};
-annotate_user_types(Filename, {type, Anno, record, RecName = [_]}) ->
+annotate_user_types_(Filename, {type, Anno, record, RecName = [_]}) ->
     %% Annotate local record type
     {type, erl_anno:set_file(Filename, Anno), record, RecName};
-annotate_user_types(Filename, {type, Anno, T, Params}) when is_list(Params) ->
+annotate_user_types_(Filename, {type, Anno, T, Params}) when is_list(Params) ->
     {type, Anno, T, [annotate_user_types(Filename, Param) || Param <- Params]};
-annotate_user_types(Filename, {ann_type, Anno, [Var, Type]}) ->
+annotate_user_types_(Filename, {ann_type, Anno, [Var, Type]}) ->
     {ann_type, Anno, [Var, annotate_user_types(Filename, Type)]};
-annotate_user_types(Filename, Types) when is_list(Types) ->
+annotate_user_types_(Filename, Types) when is_list(Types) ->
     [annotate_user_types(Filename, Type) || Type <- Types];
-annotate_user_types(_Filename, Type) ->
+annotate_user_types_(_Filename, Type) ->
     Type.
 
 -spec get_module_from_annotation(erl_anno:anno()) -> {ok, module()} | none.


### PR DESCRIPTION
Before:

```
$ make gradualize  | wc -l
make: *** [gradualize] Error 1
     307
```

After:

```
$ make gradualize  | wc -l
make: *** [gradualize] Error 1
     253
```