### PR TITLE
Add examples of list comprehension generators being none()

### DIFF
--- a/test/known_problems/should_pass/lc_cannot_glb_different_variants.erl
+++ b/test/known_problems/should_pass/lc_cannot_glb_different_variants.erl
@@ -1,0 +1,14 @@
+-module(lc_cannot_glb_different_variants).
+
+-export([g/2]).
+
+-type t() :: {a, d}
+           | {a, [t()]}.
+
+-spec g(integer(), t()) -> [t()].
+g(1, {a, d} = T) ->
+    [T];
+g(_, {a, Ts}) ->
+    [ T || T <- Ts ];
+g(_, _) ->
+    [].

--- a/test/known_problems/should_pass/lc_cannot_glb_different_variants.erl
+++ b/test/known_problems/should_pass/lc_cannot_glb_different_variants.erl
@@ -13,6 +13,10 @@
 g(1, {a, d} = T) ->
     [T];
 g(_, {a, Ts}) ->
+    %% `typechecker:add_type_pat({a, Ts}, {a, d} | {a, [t()]}, Env)' at `typechecker.erl:4310'
+    %% calls `glb(d, [t()])' to find the type of `Ts'.
+    %% The call determines that `Ts :: none()', as `d' and `[t()]' are incompatible.
+    %% This leads to a warning being reported for the following line.
     [ T || T <- Ts ];
 g(_, _) ->
     [].

--- a/test/known_problems/should_pass/lc_cannot_glb_different_variants.erl
+++ b/test/known_problems/should_pass/lc_cannot_glb_different_variants.erl
@@ -1,5 +1,9 @@
 -module(lc_cannot_glb_different_variants).
 
+%% Compare with:
+%% - test/should_fail/lc_generator_should_fail.erl
+%% - test/should_pass/lc_generator_not_none.erl
+
 -export([g/2]).
 
 -type t() :: {a, d}

--- a/test/should_fail/lc_generator_should_fail.erl
+++ b/test/should_fail/lc_generator_should_fail.erl
@@ -1,0 +1,12 @@
+-module(lc_generator_should_fail).
+
+-export([g/1]).
+
+-type t() :: {a, d}
+           | {a, [t()]}.
+
+-spec g(t()) -> [t()].
+g({a, d} = T) ->
+    [T];
+g({a, Ts}) ->
+    [ T || T <- Ts ].

--- a/test/should_fail/lc_generator_should_fail.erl
+++ b/test/should_fail/lc_generator_should_fail.erl
@@ -1,12 +1,20 @@
 -module(lc_generator_should_fail).
 
+%% Compare with:
+%% - test/known_problems/should_pass/lc_cannot_glb_different_variants.erl
+%% - test/should_pass/lc_generator_not_none.erl
+
 -export([g/1]).
 
 -type t() :: {a, d}
            | {a, [t()]}.
 
 -spec g(t()) -> [t()].
-g({a, d} = T) ->
-    [T];
 g({a, Ts}) ->
+    %% If we didn't use a list comprehension and just returned an empty list,
+    %% this would rightly fail with a nonexhaustiveness warning.
+    %[].
+    %% If we use a comprehension, glb(d, [t()]) determines that Ts :: none().
+    %% This glb() call is done from typechecker:add_type_pat({a, Ts}, {a, d} | {a, [t()]}, Env)
+    %% at typechecker.erl:4310
     [ T || T <- Ts ].

--- a/test/should_pass/lc_generator_not_none.erl
+++ b/test/should_pass/lc_generator_not_none.erl
@@ -1,0 +1,12 @@
+-module(lc_generator_not_none).
+
+-export([g/1]).
+
+-type t() :: {a, d}
+           | {a, [t()]}.
+
+-spec g(t()) -> [t()].
+g({a, d} = T) ->
+    [T];
+g({a, Ts}) ->
+    [ T || T <- Ts ].

--- a/test/should_pass/lc_generator_not_none.erl
+++ b/test/should_pass/lc_generator_not_none.erl
@@ -1,5 +1,9 @@
 -module(lc_generator_not_none).
 
+%% Compare with:
+%% - test/known_problems/should_pass/lc_cannot_glb_different_variants.erl
+%% - test/should_fail/lc_generator_should_fail.erl
+
 -export([g/1]).
 
 -type t() :: {a, d}


### PR DESCRIPTION
This is a set of examples for #433 found based on the error message for `typechecker:has_overlapping_keys/2` and tracing execution.