### PR TITLE
Remove .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,0 @@
-## This is a https://direnv.net/ .envrc file
-
-## Set ERL_LIBS, so that ErlangLS can find Gradualizer.
-## ErlangLS specific config is present in erlang_ls.config.
-export ERL_LIBS=${ERL_LIBS:-$(expand_path ..)}


### PR DESCRIPTION
A Gradualizer diagnostic is now part of ErlangLS, so there's no need to have .envrc bundled in the repo.
If a user/developer still wants to have one, it's up to them.