### PR TITLE
Propagate var binds across list comprehension filters

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3129,8 +3129,8 @@ type_check_comprehension_in(Env, ResTy, OrigExpr, Compr, Expr, P, [Pred | Quals]
     %% TODO: As a non-boolean predicates don't give runtime errors, we could
     %% possibly add a configuration parameter to toggle this check.
     {VB1, Cs1} = type_check_expr_in(Env, {type, erl_anno:new(0), 'boolean', []}, Pred),
-    {VB2, Cs2} = type_check_comprehension_in(Env, ResTy, OrigExpr, Compr, Expr, P, Quals),
-    {union_var_binds(VB1, VB2, Env), constraints:combine(Cs1, Cs2)}.
+    {VB2, Cs2} = type_check_comprehension_in(union_var_binds([VB1], Env), ResTy, OrigExpr, Compr, Expr, P, Quals),
+    {union_var_binds([VB2], Env), constraints:combine(Cs1, Cs2)}.
 
 -spec type_check_assocs(env(), _) -> {[type()], env(), constraints:constraints()}.
 type_check_assocs(Env, [{Assoc, _P, Key, Val}| Assocs])

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3129,8 +3129,9 @@ type_check_comprehension_in(Env, ResTy, OrigExpr, Compr, Expr, P, [Pred | Quals]
     %% TODO: As a non-boolean predicates don't give runtime errors, we could
     %% possibly add a configuration parameter to toggle this check.
     {VB1, Cs1} = type_check_expr_in(Env, {type, erl_anno:new(0), 'boolean', []}, Pred),
-    {VB2, Cs2} = type_check_comprehension_in(union_var_binds([VB1], Env), ResTy, OrigExpr, Compr, Expr, P, Quals),
-    {union_var_binds([VB2], Env), constraints:combine(Cs1, Cs2)}.
+    Env1 = union_var_binds([VB1], Env),
+    {VB2, Cs2} = type_check_comprehension_in(Env1, ResTy, OrigExpr, Compr, Expr, P, Quals),
+    {union_var_binds([VB2], Env1), constraints:combine(Cs1, Cs2)}.
 
 -spec type_check_assocs(env(), _) -> {[type()], env(), constraints:constraints()}.
 type_check_assocs(Env, [{Assoc, _P, Key, Val}| Assocs])

--- a/test/should_pass/lc_var_binds_in_filters.erl
+++ b/test/should_pass/lc_var_binds_in_filters.erl
@@ -1,0 +1,12 @@
+-module(lc_var_binds_in_filters).
+
+-export([f/0]).
+
+-spec f() -> [ok].
+f() ->
+    [ ok
+      || begin
+             Id = 1,
+             true
+         end,
+         Id * 2 > 0 ].


### PR DESCRIPTION
This fixes #442.