### PR TITLE
Add install-asdf rule to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,3 +230,14 @@ check: tests dialyze gradualize
 
 .PHONY: travischeck
 travischeck: cover/coverage.xml dialyze nocrashongradualize
+
+.PHONY: install-asdf
+install-asdf: bin/gradualizer
+	@if asdf current erlang 2>/dev/null >/dev/null; then \
+		ASDF_ERLANG_BIN=$$(dirname $$(asdf which erl)); \
+		cp bin/gradualizer $$ASDF_ERLANG_BIN/; \
+		asdf reshim; \
+		echo "Installed gradualizer to $$ASDF_ERLANG_BIN"; \
+	else \
+		echo "Couldn't find Erlang managed by asdf"; \
+	fi


### PR DESCRIPTION
This makes it possible to easily install Gradualizer globally if we use [asdf](https://asdf-vm.com/) to manage Erlang installations. Pretty convenient and not a lot of code added.