### PR TITLE
add xref ignores to header file defining ::/:::

### DIFF
--- a/include/gradualizer.hrl
+++ b/include/gradualizer.hrl
@@ -27,6 +27,7 @@
 %%
 -compile({inline, ['::'/2, ':::'/2]}).
 -compile({nowarn_unused_function, ['::'/2, ':::'/2]}).
+-ignore_xref(['::'/2, ':::'/2]).
 
 '::'(Expr, _Type) -> Expr.
 ':::'(Expr, _Type) -> Expr.


### PR DESCRIPTION
This is needed or xref will complain about unused function since the `nowarn_unused_function` only applies to compilation.

Support for `ignore_xref` is in rebar3, not Erlang itself, but is just ignored if using another tool to build.