### PR TITLE
fix GitHub reference in rebar3 example README

### DIFF
--- a/examples/rebar3/README.md
+++ b/examples/rebar3/README.md
@@ -3,7 +3,7 @@
 To run Gradualizer from rebar3, add it as a plugin in your `rebar.config`:
 ```Erlang
 {plugins, [
-  {gradualizer, {git, "git://github.com/josefs/Gradualizer.git", {branch, "master"}}}
+  {gradualizer, {git, "git@github.com:josefs/Gradualizer.git", {branch, "master"}}}
 ]}.
 ```
 


### PR DESCRIPTION
The git:// protocol is no longer supported, see:
https://github.blog/2021-09-01-improving-git-protocol-security-github/