### PR TITLE
Override filename specs

### DIFF
--- a/priv/prelude/filename.specs.erl
+++ b/priv/prelude/filename.specs.erl
@@ -5,6 +5,9 @@
 -spec basename(binary()) -> binary();
               (string() | atom() | deep_list()) -> string().
 
+-spec dirname(binary()) -> binary();
+             (string() | atom() | deep_list()) -> string().
+
 -spec rootname(binary()) -> binary();
               (string() | atom() | deep_list()) -> string().
 

--- a/priv/prelude/filename.specs.erl
+++ b/priv/prelude/filename.specs.erl
@@ -1,0 +1,6 @@
+-module(filename).
+
+-type deep_list() :: lists:deep_list(char() | atom()).
+
+-spec rootname(binary()) -> binary();
+              (string() | atom() | deep_list()) -> string().

--- a/priv/prelude/filename.specs.erl
+++ b/priv/prelude/filename.specs.erl
@@ -7,3 +7,6 @@
 
 -spec rootname(binary()) -> binary();
               (string() | atom() | deep_list()) -> string().
+
+-spec join([string() | atom() | deep_list()]) -> string();
+          ([string() | atom() | deep_list() | binary()]) -> binary().

--- a/priv/prelude/filename.specs.erl
+++ b/priv/prelude/filename.specs.erl
@@ -2,5 +2,8 @@
 
 -type deep_list() :: lists:deep_list(char() | atom()).
 
+-spec basename(binary()) -> binary();
+              (string() | atom() | deep_list()) -> string().
+
 -spec rootname(binary()) -> binary();
               (string() | atom() | deep_list()) -> string().

--- a/priv/prelude/filename.specs.erl
+++ b/priv/prelude/filename.specs.erl
@@ -11,5 +11,13 @@
 -spec rootname(binary()) -> binary();
               (string() | atom() | deep_list()) -> string().
 
--spec join([string() | atom() | deep_list()]) -> string();
-          ([string() | atom() | deep_list() | binary()]) -> binary().
+-type name() :: string() | atom() | deep_list().
+-type bname() :: string() | atom() | deep_list() | binary().
+
+-spec join([name()]) -> string();
+          ([bname()]) -> binary().
+
+-spec join(name(),  name())  -> string();
+          (bname(), name())  -> binary();
+          (name(),  bname()) -> binary();
+          (bname(), bname()) -> binary().

--- a/priv/prelude/lists.specs.erl
+++ b/priv/prelude/lists.specs.erl
@@ -3,6 +3,8 @@
 %% This module contains specs to replace incorrect or inexact specs in OTP. The
 %% commented-out specs are the original specs given in OTP 21 (stdlib-3.7.1)
 
+-export_type([deep_list/1]).
+
 -type deep_list(A) :: [A | deep_list(A)].
 
 %% flatten/1,2 are defined using recursive constraints, which is something we

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -238,7 +238,7 @@ type_check_dir(Dir) ->
 type_check_dir(Dir, Opts) ->
     case filelib:is_dir(Dir) of
         true ->
-            Pattern = ?assert_type(filename:join(Dir, "*.{erl,beam}"), file:filename()),
+            Pattern = filename:join(Dir, "*.{erl,beam}"),
             type_check_files(filelib:wildcard(Pattern), Opts);
         false ->
             throw({dir_not_found, Dir})

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -431,6 +431,7 @@ import_absform(Module, Forms1, State) ->
 %% Include dirs for OTP apps are given in makefiles. We can never
 %% guarantee to get them right without extracting the types during
 %% compilation.
+-spec guess_include_dirs(file:filename()) -> list().
 guess_include_dirs(File) ->
     Dir = filename:dirname(File),
     case filename:basename(Dir) of

--- a/src/gradualizer_db.erl
+++ b/src/gradualizer_db.erl
@@ -144,7 +144,7 @@ import_module(Module) ->
 
 -type opts() :: #{autoimport := boolean(),
                   prelude := boolean(),
-                  specs_override := [file:name()]}.
+                  specs_override := [file:filename()]}.
 -define(default_opts, #{autoimport => true,
                         prelude => true,
                         specs_override => []}).
@@ -307,7 +307,7 @@ import_prelude(State = #state{loaded = Loaded}) ->
     %% are loaded on demand
     State1#state{loaded = Loaded}.
 
--spec import_extra_specs(file:name(), state()) -> state().
+-spec import_extra_specs(file:filename(), state()) -> state().
 import_extra_specs(Dir, State = #state{loaded = Loaded}) ->
     FormsByModule = gradualizer_prelude_parse_trans:get_module_forms_tuples(Dir),
     %% Import forms each of the modules to override

--- a/src/gradualizer_prelude_parse_trans.erl
+++ b/src/gradualizer_prelude_parse_trans.erl
@@ -23,9 +23,9 @@ replace_get_modules_and_forms([{function, Anno, get_modules_and_forms, 0, _OldBo
 replace_get_modules_and_forms([Form | RestForms]) ->
     [Form | replace_get_modules_and_forms(RestForms)].
 
--spec get_module_forms_tuples(file:name_all()) -> [{module(), forms()}].
+-spec get_module_forms_tuples(file:filename()) -> [{module(), forms()}].
 get_module_forms_tuples(Dir) ->
-    Pattern = ?assert_type(filename:join([Dir, "*.specs.erl"]), file:filename()),
+    Pattern = filename:join([Dir, "*.specs.erl"]),
     Files = filelib:wildcard(Pattern),
     lists:map(fun get_module_and_forms/1, Files).
 


### PR DESCRIPTION
This uses function intersection type support to define better specs for some functions from the `filename` module. It therefore reduces the number of self-check errors and also allows to drop some assertions.

The type names in `file` and `filename` are quite hard to memorise: `file:name()` vs `file:filename()` vs `file:filename_all()` vs `file:name_all()`. I'm not using them in the new prelude file and strive for using the builtin type names instead.