### PR TITLE
Add known problem for unsupported maybe expression

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Erlang ${{matrix.otp}}
     strategy:
       matrix:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Erlang ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ['22.3.4.20', '23.3.4.7', '24.3.4.4']
+        otp: ['23.3.4.7', '24.3.4.4', '25.1.2']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/proptests.yml
+++ b/.github/workflows/proptests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Erlang ${{matrix.otp}}
     strategy:
       matrix:

--- a/.github/workflows/publish-to-hex.yml
+++ b/.github/workflows/publish-to-hex.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check Out

--- a/.github/workflows/self-check.yml
+++ b/.github/workflows/self-check.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Erlang ${{matrix.otp}}
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@
 .PHONY: all
 all: app escript
 
+ERL_OPTS = -enable-feature maybe_expr
+
 # Compilation
 
 erls = $(wildcard src/*.erl)
@@ -143,7 +145,7 @@ end
 endef
 
 eunit: compile-tests
-	erl -noinput -pa ebin -pa test -eval \
+	erl $(ERL_OPTS) -noinput -pa ebin -pa test -eval \
 	 '$(erl_run_eunit), halt().'
 
 cli-tests: bin/gradualizer test/arg.beam

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,10 @@
           {deps,
            [
             {proper, {git, "https://github.com/proper-testing/proper.git", {branch, "master"}}}
-           ]}
+           ]},
+          %% see the maybe expression fail;
+          %% the VM also needs to be configured to load the module
+          {erl_opts, [{feature,maybe_expr,enable}]}
          ]}
  ]}.
 

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -362,6 +362,12 @@ format_type_error({form_check_timeout, Form}, Opts) ->
                              [form_info(Form),
                               format_location(Form, verbose, Opts)])
        end]);
+format_type_error({unsupported_expression, Anno, Expr}, Opts) ->
+    io_lib:format(
+      "~sThe ~s expression~s is not supported yet~n",
+      [format_location(Anno, brief, Opts),
+       atom_to_list(element(1, Expr)),
+       format_location(Anno, verbose, Opts)]);
 format_type_error({Location, Module, ErrorDescription}, Opts)
   when is_integer(Location) orelse is_tuple(Location),
        is_atom(Module) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1903,7 +1903,12 @@ do_type_check_expr(Env, {'try', _, Block, CaseCs, CatchCs, AfterBlock}) ->
           end,
     {normalize({type, erl_anno:new(0), union, [Ty, TyC, TyS]}, Env)
     ,VB
-    ,constraints:combine([Cs1,Cs2,Cs3,Cs4])}.
+    ,constraints:combine([Cs1,Cs2,Cs3,Cs4])};
+
+%% Maybe - value-based error handling expression
+%% See https://www.erlang.org/eeps/eep-0049
+do_type_check_expr(Env, {'maybe', Anno, [{maybe_match, _, _LHS, _RHS}]} = MaybeExpr) ->
+    erlang:throw({unsupported_expression, Anno, MaybeExpr}).
 
 %% Helper for type_check_expr for funs
 -spec type_check_fun(env(), _) -> {type(), env(), constraints:constraints()}.

--- a/test/known_problems/should_pass/any_doesnt_have_type_none_should_pass.erl
+++ b/test/known_problems/should_pass/any_doesnt_have_type_none_should_pass.erl
@@ -1,5 +1,7 @@
 -module(any_doesnt_have_type_none_should_pass).
 
+-export([f/2]).
+
 -type type() :: abstract_type().
 
 -type abstract_type() :: af_tuple_type().

--- a/test/known_problems/should_pass/fun_subtyping.erl
+++ b/test/known_problems/should_pass/fun_subtyping.erl
@@ -1,6 +1,6 @@
 -module(fun_subtyping).
 
--compile([export_all, nowarn_export_all]).
+-export([return_fun_intersection/0]).
 
 -spec return_fun_intersection() -> fun((number()) -> number()).
 return_fun_intersection() -> fun number/1.

--- a/test/known_problems/should_pass/list_concat_op_should_pass.erl
+++ b/test/known_problems/should_pass/list_concat_op_should_pass.erl
@@ -2,9 +2,7 @@
 
 -export([nil_concat_op_elem_gives_elem/0,
          nonempty1_concat_op_elem_gives_improper/0,
-         nonempty2_concat_op_elem_gives_improper/0,
-         nil_concat_op_nonempty_gives_proper/0,
-         nonempty_concat_op_nonempty_gives_proper/0]).
+         nonempty2_concat_op_elem_gives_improper/0]).
 
 -spec nil_concat_op_elem_gives_elem() -> b.
 nil_concat_op_elem_gives_elem() ->
@@ -22,14 +20,6 @@ nonempty2_concat_op_elem_gives_improper() ->
 %% -spec improper_concat_op_elem_gives_badarg() -> none().
 %% improper_concat_op_elem_gives_badarg() ->
 %%     [a|b] ++ c.
-
--spec nil_concat_op_nonempty_gives_proper() -> [atom()].
-nil_concat_op_nonempty_gives_proper() ->
-    [] ++ [a].
-
--spec nonempty_concat_op_nonempty_gives_proper() -> [atom()].
-nonempty_concat_op_nonempty_gives_proper() ->
-    [a,b] ++ [c].
 
 %% See list_op_should_fail.
 %% -spec improper_concat_op_nonempty_gives_badarg() -> none().

--- a/test/known_problems/should_pass/maybe_expr.erl
+++ b/test/known_problems/should_pass/maybe_expr.erl
@@ -1,0 +1,7 @@
+-module(maybe_expr).
+-export([syntax/0]).
+
+syntax() ->
+    maybe
+        ok ?= ok
+    end.

--- a/test/known_problems/should_pass/maybe_expr.erl
+++ b/test/known_problems/should_pass/maybe_expr.erl
@@ -2,7 +2,9 @@
 
 -ifdef(OTP_RELEASE).
 -if(?OTP_RELEASE >= 25).
--if(?FEATURE_ENABLED(maybe_expr)).
+-if(?FEATURE_AVAILABLE(maybe_expr)).
+
+-feature(maybe_expr, enable).
 
 -export([syntax/0]).
 
@@ -11,6 +13,6 @@ syntax() ->
         ok ?= ok
     end.
 
--endif. %% FEATURE_ENABLED
+-endif. %% FEATURE_AVAILABLE
 -endif. %% OTP >= 25
 -endif. %% OTP_RELEASE

--- a/test/known_problems/should_pass/maybe_expr.erl
+++ b/test/known_problems/should_pass/maybe_expr.erl
@@ -1,7 +1,16 @@
 -module(maybe_expr).
+
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE >= 25).
+-if(?FEATURE_ENABLED(maybe_expr)).
+
 -export([syntax/0]).
 
 syntax() ->
     maybe
         ok ?= ok
     end.
+
+-endif. %% FEATURE_ENABLED
+-endif. %% OTP >= 25
+-endif. %% OTP_RELEASE

--- a/test/known_problems/should_pass/refine_mismatch_using_guard_bifs.erl
+++ b/test/known_problems/should_pass/refine_mismatch_using_guard_bifs.erl
@@ -1,8 +1,7 @@
 -module(refine_mismatch_using_guard_bifs).
 
 -export([refine_by_guards_1/1,
-         refine_by_guards_2/1,
-         refine_literals_by_guards/1]).
+         refine_by_guards_2/1]).
 
 -spec refine_by_guards_1(atom() | pos_integer() | float() |
                          binary() | tuple() | [any()] |
@@ -24,10 +23,3 @@ refine_by_guards_2(X) when is_boolean(X) -> ok;
 refine_by_guards_2(X) when is_list(X)    -> ok;
 refine_by_guards_2(X) when is_port(X)    -> ok;
 refine_by_guards_2(X)                    -> X.
-
--spec refine_literals_by_guards(banana | 0 | {} | [] | pid()) -> pid().
-refine_literals_by_guards(X) when is_atom(X)    -> self();
-refine_literals_by_guards(X) when is_integer(X) -> self();
-refine_literals_by_guards(X) when is_tuple(X)   -> self();
-refine_literals_by_guards(X) when is_list(X)    -> self();
-refine_literals_by_guards(X)                    -> X.

--- a/test/should_pass/list_concat_op_pass.erl
+++ b/test/should_pass/list_concat_op_pass.erl
@@ -4,7 +4,9 @@
          nonempty1_concat_fun_elem_gives_improper/0,
          nonempty2_concat_fun_elem_gives_improper/0,
          nil_concat_fun_nonempty_gives_proper/0,
+         nil_concat_op_nonempty_gives_proper/0,
          nonempty_concat_fun_nonempty_gives_proper/0,
+         nonempty_concat_op_nonempty_gives_proper/0,
          proper_concat_fun_proper_gives_proper/0]).
 
 -spec nil_concat_fun_elem_gives_elem() -> b.
@@ -23,9 +25,17 @@ nonempty2_concat_fun_elem_gives_improper() ->
 nil_concat_fun_nonempty_gives_proper() ->
     erlang:'++'([], [a]).
 
+-spec nil_concat_op_nonempty_gives_proper() -> [atom()].
+nil_concat_op_nonempty_gives_proper() ->
+    [] ++ [a].
+
 -spec nonempty_concat_fun_nonempty_gives_proper() -> [atom()].
 nonempty_concat_fun_nonempty_gives_proper() ->
     erlang:'++'([a,b], [c]).
+
+-spec nonempty_concat_op_nonempty_gives_proper() -> [atom()].
+nonempty_concat_op_nonempty_gives_proper() ->
+    [a,b] ++ [c].
 
 -spec proper_concat_fun_proper_gives_proper() -> [integer()].
 proper_concat_fun_proper_gives_proper() ->

--- a/test/should_pass/type_refinement_pass.erl
+++ b/test/should_pass/type_refinement_pass.erl
@@ -1,6 +1,17 @@
 -module(type_refinement_pass).
 
--compile([export_all, nowarn_export_all]).
+-export([basic_type_refinement/1,
+         getenv/1,
+         int_literals_1/1, int_literals_2/1, int_literals_3/1,
+         disjoint_stuff_1/1, disjoint_stuff_2/1, disjoint_stuff_3/1, disjoint_stuff_4/1,
+         var_pat/2,
+         nil_elimination/1,
+         tuple_union/1,
+         tuple_union_2/1,
+         beside_match_all/2,
+         beside_singleton/2,
+         refine_bound_var_by_guard_bifs/1,
+         refine_literals_by_guards/1]).
 
 %% Test that Value is not considered to be string() | false.
 -spec basic_type_refinement(string()) -> string().
@@ -81,3 +92,10 @@ refine_bound_var_by_guard_bifs(X) ->
         is_pid(X)     -> ok;
         true          -> X
     end.
+
+-spec refine_literals_by_guards(banana | 0 | {} | [] | pid()) -> pid().
+refine_literals_by_guards(X) when is_atom(X)    -> self();
+refine_literals_by_guards(X) when is_integer(X) -> self();
+refine_literals_by_guards(X) when is_tuple(X)   -> self();
+refine_literals_by_guards(X) when is_list(X)    -> self();
+refine_literals_by_guards(X)                    -> X.


### PR DESCRIPTION
The syntax for the new experimental maybe expression is currently not supported. Highlight and document this fact by putting it in the known problems test directory.

Avoid compiling with support for the maybe feature outside of test profiles to avoid causing issues in people depending on gradualizer trying to load modules.

I have no idea how to fix this but felt there should be a moderately helpful bug report by at least putting in a test.