### PR TITLE
Print inferred argument types on call_intersect error

### DIFF
--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -174,15 +174,6 @@ format_type_error({type_error, call_intersect, Anno, ArgsTys, FunTy, Name}, Opts
        length(ArgsTys),
        format_location(Anno, verbose, Opts),
        pp_intersection_type(FunTy, Opts)]);
-format_type_error({type_error, expected_fun_type, Anno, Func, FunTy}, Opts) ->
-    Name = pp_expr(Func, Opts),
-    io_lib:format(
-      "~sExpected function ~s~s to have a function type,~n"
-      "but it has the following type:~n~s~n",
-      [format_location(Anno, brief, Opts),
-       Name,
-       format_location(Anno, verbose, Opts),
-       pp_type(FunTy, Opts)]);
 format_type_error({type_error, no_type_match_intersection, Anno, Func, FunTy}, Opts) ->
     Name = pp_expr(Func, Opts),
     io_lib:format(

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -164,25 +164,16 @@ format_type_error({type_error, call_arity, Anno, Fun, TyArity, CallArity}, Opts)
        TyArity,
        ["s" || TyArity /= 1],
        CallArity]);
-format_type_error({type_error, call_intersect, Anno, ArgsTys, FunTy, Name}, Opts) ->
+format_type_error({type_error, call_intersect, Anno, Name, FunTy, ArgTys}, Opts) ->
     io_lib:format(
-      "~sThe arguments ~s to ~s/~p~s don't match "
-      "the function type:~n~s~n",
+      "~s~s/~p call arguments~s don't match the function type:~n~s~n"
+      "Inferred argument types:~n~s~n",
       [format_location(Anno, brief, Opts),
-       string:join([ pp_type(ATy, Opts) || ATy <- ArgsTys ], ", "),
        pp_expr(Name, Opts),
-       length(ArgsTys),
+       length(ArgTys),
        format_location(Anno, verbose, Opts),
-       pp_intersection_type(FunTy, Opts)]);
-format_type_error({type_error, no_type_match_intersection, Anno, Func, FunTy}, Opts) ->
-    Name = pp_expr(Func, Opts),
-    io_lib:format(
-      "~sNone of the types of the function ~s~s matches the "
-      "call site. Here's the types of the function:~n~s~n",
-      [format_location(Anno, brief, Opts),
-       Name,
-       format_location(Anno, verbose, Opts),
-       pp_intersection_type(FunTy, Opts)]);
+       pp_intersection_type(FunTy, Opts),
+       string:join([ pp_type(ATy, Opts) || ATy <- ArgTys ], ", ")]);
 format_type_error({type_error, relop, RelOp, Anno, Ty1, Ty2}, Opts) ->
     io_lib:format(
       "~sThe operator ~p~s requires arguments of "

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -164,13 +164,14 @@ format_type_error({type_error, call_arity, Anno, Fun, TyArity, CallArity}, Opts)
        TyArity,
        ["s" || TyArity /= 1],
        CallArity]);
-format_type_error({type_error, call_intersect, Anno, FunTy, Name}, Opts) ->
+format_type_error({type_error, call_intersect, Anno, ArgsTys, FunTy, Name}, Opts) ->
     io_lib:format(
-      "~sThe type of the function ~s, called~s doesn't match "
-      "the surrounding calling context.~n"
-      "It has the following type~n~s~n",
+      "~sThe arguments ~s to ~s/~p~s don't match "
+      "the function type:~n~s~n",
       [format_location(Anno, brief, Opts),
+       string:join([ pp_type(ATy, Opts) || ATy <- ArgsTys ], ", "),
        pp_expr(Name, Opts),
+       length(ArgsTys),
        format_location(Anno, verbose, Opts),
        pp_intersection_type(FunTy, Opts)]);
 format_type_error({type_error, expected_fun_type, Anno, Func, FunTy}, Opts) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -147,7 +147,7 @@
                | {type_error, type_error(), anno(), atom() | pattern(), type()}
                | {type_error, type_error(), unary_op() | binary_op(), anno(), type()}
                | {type_error, type_error(), binary_op(), anno(), type(), type()}
-               | {type_error, call_intersect, anno(), [type()], type(), expr()}
+               | {type_error, call_intersect, anno(), expr(), type(), [type()]}
                | {type_error, call_arity, anno(), atom(), arity(), arity()}
                | {undef, undef(), anno(), {atom(), atom() | non_neg_integer()} | mfa() | expr()}
                | {undef, undef(), expr()}
@@ -5628,6 +5628,7 @@ type_error(Kind, P, Info, Ty) ->
     {type_error, Kind, P, Info, Ty}.
 
 -spec type_error(call_arity, anno(), atom(), arity(), arity()) -> error();
+                (call_intersect, anno(), expr(), type(), [type()]) -> error();
                 (type_error(), binary_op(), anno(), type(), type()) -> error().
 type_error(Kind, Op, P, Ty1, Ty2) ->
     {type_error, Kind, Op, P, Ty1, Ty2}.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -132,7 +132,7 @@
 
 %% TODO: Some of these don't seem to be thrown at all, e.g. expected_fun_type
 -type type_error() :: arith_error | badkey | call_arity | call_intersect | check_clauses | cons_pat
-                    | cyclic_type_vars | expected_fun_type | int_error | list | mismatch
+                    | cyclic_type_vars | int_error | list | mismatch
                     | no_type_match_intersection | non_number_argument_to_minus
                     | non_number_argument_to_plus | op_type_too_precise | operator_pattern | pattern
                     | receive_after | record_pattern | rel_error | relop | unary_error

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -133,7 +133,7 @@
 %% TODO: Some of these don't seem to be thrown at all, e.g. expected_fun_type
 -type type_error() :: arith_error | badkey | call_arity | call_intersect | check_clauses | cons_pat
                     | cyclic_type_vars | int_error | list | mismatch
-                    | no_type_match_intersection | non_number_argument_to_minus
+                    | non_number_argument_to_minus
                     | non_number_argument_to_plus | op_type_too_precise | operator_pattern | pattern
                     | receive_after | record_pattern | rel_error | relop | unary_error
                     | unreachable_clauses.
@@ -2207,11 +2207,7 @@ type_check_call_ty(_Env, {type_error, _}, _Args, {Name, _P, FunTy}) ->
 
 -spec type_check_call_ty_intersect(env(), _, _, _) -> {type(), env(), constraints:t()}.
 type_check_call_ty_intersect(Env, [], Args, {Name, P, FunTy}) ->
-    ArgsTys = lists:map(fun (Arg) ->
-                                {ArgTy, _VB, _Cs} = type_check_expr(Env#env{infer = true}, Arg),
-                                ArgTy
-                        end, Args),
-    throw(type_error(call_intersect, P, ArgsTys, FunTy, Name));
+    throw(type_error(call_intersect, P, Name, FunTy, infer_arg_types(Args, Env)));
 type_check_call_ty_intersect(Env, [Ty | Tys], Args, E) ->
     try
         type_check_call_ty(Env, Ty, Args, E)
@@ -2219,6 +2215,13 @@ type_check_call_ty_intersect(Env, [Ty | Tys], Args, E) ->
         Error when element(1,Error) == type_error ->
             type_check_call_ty_intersect(Env, Tys, Args, E)
     end.
+
+-spec infer_arg_types([expr()], env()) -> [type()].
+infer_arg_types(Args, Env) ->
+    lists:map(fun (Arg) ->
+                      {ArgTy, _VB, _Cs} = type_check_expr(Env#env{infer = true}, Arg),
+                      ArgTy
+              end, Args).
 
 -spec type_check_call_ty_union(env(), _, _, _) -> {type(), env(), constraints:t()}.
 type_check_call_ty_union(Env, Tys, Args, E) ->
@@ -3338,8 +3341,8 @@ type_check_call_intersection(Env, ResTy, OrigExpr, Tys, Args, E) ->
     type_check_call_intersection_(Env, ResTy, OrigExpr, Tys, Args, E).
 
 -spec type_check_call_intersection_(env(), type(), _, _, _, _) -> {env(), constraints:t()}.
-type_check_call_intersection_(_Env, _ResTy, _, [], _Args, {P, Name, Ty}) ->
-    throw(type_error(no_type_match_intersection, P, Name, Ty));
+type_check_call_intersection_(Env, _ResTy, _, [], Args, {P, Name, FunTy}) ->
+    throw(type_error(call_intersect, P, Name, FunTy, infer_arg_types(Args, Env)));
 type_check_call_intersection_(Env, ResTy, OrigExpr, [Ty | Tys], Args, E) ->
     try
         type_check_call(Env, ResTy, OrigExpr, Ty, Args, E)


### PR DESCRIPTION
Fixes #484.

The argument types are inferred, so they might not be completely accurate in each case. Example printout from Gradualizer's self-check:

```
ebin/typechecker.beam: type_error/5 call arguments on line 3345 at column 11 don't match the function type:
fun((call_arity, anno(), atom(), arity(), arity()) -> error())
fun((type_error(), binary_op(), anno(), type(), type()) ->
                  error())
Inferred argument types:
call_intersect, any(), any(), any(), [type()]
```

@japhib what do you think of the above message format?