### PR TITLE
Add support for module_info functions

### DIFF
--- a/test/should_fail/module_info_fail.erl
+++ b/test/should_fail/module_info_fail.erl
@@ -1,0 +1,7 @@
+-module(module_info_fail).
+
+-compile([export_all, nowarn_export_all]).
+
+-spec md5() -> atom().
+md5() ->
+    erlang:module_info(md5).

--- a/test/should_pass/module_info.erl
+++ b/test/should_pass/module_info.erl
@@ -1,0 +1,21 @@
+-module(module_info).
+
+-compile([export_all, nowarn_export_all]).
+
+-spec nullary_direct() -> [{atom(), atom() | list() | binary()}].
+nullary_direct() ->
+    erlang:module_info().
+
+-spec nullary_var() -> [{atom(), any()}].
+nullary_var() ->
+    I = erlang:module_info(),
+    I.
+
+-spec unary_direct() -> binary().
+unary_direct() ->
+    erlang:module_info(md5).
+
+-spec unary_var() -> atom().
+unary_var() ->
+    I = erlang:module_info(module),
+    I.


### PR DESCRIPTION
I finally come up with a PR that fixes #473.

I am an Elixir person and haven't written almost any Erlang code before so there may be some things that could be done more idiomatically.

I think I got some (quite little still) idea how Gradualizer works but one thing still isn't clear to me – why isn't `type_check_expr_in` implemented in terms of `type_check_expr`. From my limited perspective, it could just determine the type of the expression by calling `type_check_expr_in` and then check whether the type is indeed a subtype of `ResTy`. Why wouldn't that work?