### PR TITLE
Require all functions in src/typechecker.erl to have specs

### DIFF
--- a/include/gradualizer.hrl
+++ b/include/gradualizer.hrl
@@ -29,7 +29,10 @@
 -compile({nowarn_unused_function, ['::'/2, ':::'/2]}).
 -ignore_xref(['::'/2, ':::'/2]).
 
+-spec '::'(any(), any()) -> any().
 '::'(Expr, _Type) -> Expr.
+
+-spec ':::'(any(), any()) -> any().
 ':::'(Expr, _Type) -> Expr.
 
 %% Type annotation

--- a/src/constraints.erl
+++ b/src/constraints.erl
@@ -3,7 +3,10 @@
 
 -export([empty/0, upper/2, lower/2, combine/1, combine/2, add_var/2]).
 
--export_type([constraints/0]).
+-export_type([constraints/0,
+              t/0]).
+
+-type t() :: constraints().
 
 -type type() :: gradualizer_type:abstract_type().
 

--- a/src/constraints.erl
+++ b/src/constraints.erl
@@ -3,10 +3,7 @@
 
 -export([empty/0, upper/2, lower/2, combine/1, combine/2, add_var/2]).
 
--export_type([constraints/0,
-              t/0]).
-
--type t() :: constraints().
+-export_type([t/0]).
 
 -type type() :: gradualizer_type:abstract_type().
 
@@ -16,30 +13,30 @@
           exist_vars   = #{} :: #{ var() => true }
          }).
 
--type constraints() :: #constraints{}.
+-type t() :: #constraints{}.
 -type var() :: gradualizer_type:gr_type_var().
 
--spec empty() -> constraints().
+-spec empty() -> t().
 empty() ->
     #constraints{}.
 
--spec add_var(var(), constraints()) -> constraints().
+-spec add_var(var(), t()) -> t().
 add_var(Var, Cs) ->
     Cs#constraints{ exist_vars = maps:put(Var, true, Cs#constraints.exist_vars) }.
 
--spec upper(var(), type()) -> constraints().
+-spec upper(var(), type()) -> t().
 upper(Var, Ty) ->
     #constraints{ upper_bounds = #{ Var => [Ty] } }.
 
--spec lower(var(), type()) -> constraints().
+-spec lower(var(), type()) -> t().
 lower(Var, Ty) ->
     #constraints{ lower_bounds = #{ Var => [Ty] } }.
 
--spec combine(constraints(), constraints()) -> constraints().
+-spec combine(t(), t()) -> t().
 combine(C1, C2) ->
     combine([C1, C2]).
 
--spec combine([constraints()]) -> constraints().
+-spec combine([t()]) -> t().
 combine([]) ->
     empty();
 combine([Cs]) ->

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -397,7 +397,7 @@ env(ErlSource, Opts) ->
 %% @see type_of/2
 -spec type_of(string()) -> typechecker:type().
 type_of(Expr) ->
-    type_of(Expr, env([infer])).
+    type_of(Expr, env()).
 
 %% @doc Infer type of an Erlang expression.
 %%
@@ -413,5 +413,6 @@ type_of(Expr) ->
 -spec type_of(string(), typechecker:env()) -> typechecker:type().
 type_of(Expr, Env) ->
     AlwaysInfer = Env#env{infer = true},
-    {Ty, _Env, _Cs} = typechecker:type_check_expr(AlwaysInfer, merl:quote(Expr)),
+    [Form] = gradualizer_lib:ensure_form_list(merl:quote(lists:flatten(Expr))),
+    {Ty, _Env, _Cs} = typechecker:type_check_expr(AlwaysInfer, Form),
     Ty.

--- a/src/gradualizer_cache.erl
+++ b/src/gradualizer_cache.erl
@@ -41,7 +41,7 @@ start_link(Opts) ->
 %% GLB Cache
 %%
 
--spec get_glb(module(), type(), type()) -> false | {type(), constraints:constraints()}.
+-spec get_glb(module(), type(), type()) -> false | {type(), constraints:t()}.
 get_glb(Module, T1, T2) ->
     try ets:lookup(?GLB_CACHE, {Module, T1, T2}) of
         [] ->
@@ -53,7 +53,7 @@ get_glb(Module, T1, T2) ->
             false
     end.
 
--spec store_glb(module(), type(), type(), {type(), constraints:constraints()}) -> ok.
+-spec store_glb(module(), type(), type(), {type(), constraints:t()}) -> ok.
 store_glb(Module, T1, T2, TyCs) ->
     try
         ets:insert(?GLB_CACHE, {{Module, T1, T2}, TyCs}),

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -123,10 +123,10 @@ format_type_error({illegal_map_type, Type}, Opts) ->
       [format_location(Type, brief, Opts),
        pp_type(Type, Opts),
        format_location(Type, verbose, Opts)]);
-format_type_error({type_error, list, _Anno, Ty1, Ty}, Opts) ->
+format_type_error({type_error, list, Anno, Ty1, Ty}, Opts) ->
     io_lib:format(
       "~sThe type ~s cannot be an element of a list of type ~s~n",
-      [format_location(_Anno, brief, Opts),
+      [format_location(Anno, brief, Opts),
        pp_type(Ty1, Opts),
        pp_type(Ty, Opts)]);
 format_type_error({type_error, list, Anno, Ty}, Opts) ->

--- a/src/gradualizer_fmt.erl
+++ b/src/gradualizer_fmt.erl
@@ -150,8 +150,7 @@ format_type_error({argument_length_mismatch, Anno, LenTy, LenArgs}, Opts) ->
        format_location(Anno, verbose, Opts),
        LenTy,
        LenArgs]);
-format_type_error({type_error, unreachable_clauses, Clauses}, Opts) ->
-    Anno = element(2, hd(Clauses)),
+format_type_error({type_error, unreachable_clauses, Anno}, Opts) ->
     io_lib:format(
       "~sThe clause~s cannot be reached~n",
       [format_location(Anno, brief, Opts),

--- a/src/gradualizer_type.erl
+++ b/src/gradualizer_type.erl
@@ -26,6 +26,7 @@
               af_binary_op/1,
               af_constrained_function_type/0,
               af_constraint/0,
+              af_field_name/0,
               af_fun_type/0,
               af_function_type_list/0,
               af_record_field/1,

--- a/src/gradualizer_type.erl
+++ b/src/gradualizer_type.erl
@@ -23,6 +23,7 @@
 %% Export the additional types that gradualizer uses
 -export_type([abstract_pattern/0,
               af_assoc_type/0,
+              af_atom/0,
               af_binary_op/1,
               af_constrained_function_type/0,
               af_constraint/0,

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1547,13 +1547,15 @@ free_vars({type, _, _, Args}, Vars) ->
     free_vars(Args, Vars);
 free_vars(_, Vars) -> Vars.
 
--spec subst_ty(#{atom() | string() := type()}, type()) -> type() | [type()].
+-spec subst_ty(#{atom() | string() := type()}, [type()]) -> [type()];
+              (#{atom() | string() := type()}, [fun_ty()]) -> [fun_ty()];
+              (#{atom() | string() := type()}, type()) -> type().
+subst_ty(Sub, Tys) when is_list(Tys) ->
+    [ subst_ty(Sub, Ty) || Ty <- Tys ];
 subst_ty(Sub, Ty = {var, _, X}) ->
     maps:get(X, Sub, Ty);
 subst_ty(Sub, {type, P, Name, Args}) ->
     {type, P, Name, subst_ty(Sub, Args)};
-subst_ty(Sub, Tys) when is_list(Tys) ->
-    [ subst_ty(Sub, Ty) || Ty <- Tys ];
 subst_ty(_, Ty) -> Ty.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3578,9 +3578,10 @@ check_clauses_intersection_throw_if_seen(ArgsTys, RefinedArgsTy, Clause, Seen, E
             {type_error, ClauseError}
     end.
 
--spec check_reachable_clauses(type(), list(), _Caps, [env()], _Cs, [type()], env()) -> R when
+-spec check_reachable_clauses(type(), list(), _Caps, [env()], Css, [type()], env()) -> R when
+      Css :: [constraints:t()],
       R :: {[env()],
-            constraints:t(),
+            [constraints:t()],
             [type()],
             env()}.
 check_reachable_clauses(_ResTy, [], _Caps, VBs, Cs, RefinedArgsTys, Env) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3034,7 +3034,11 @@ unary_op_arg_type('+', Ty) -> Ty;
 unary_op_arg_type(Op, {type, _, union, Tys}) ->
     type(union, [ unary_op_arg_type(Op, Ty) || Ty <- Tys ]);
 unary_op_arg_type('not', {atom, _, B}) ->
-    {atom, erl_anno:new(0), not B}; %% boolean() = false | true
+    %% This should only be reachable with B :: boolean(),
+    %% as it's checked with glb() before unary_op_arg_type is called.
+    B == true orelse B == false orelse erlang:error(unreachable),
+    B = ?assert_type(B, boolean()),
+    {atom, erl_anno:new(0), not B};
 unary_op_arg_type(Op, Ty) when ?is_int_type(Ty), Op == '-' orelse Op == 'bnot' ->
     {Lo, Hi} = gradualizer_int:int_type_to_range(Ty),
     %% TODO: Move this logic to gradualizer_int?

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1536,7 +1536,7 @@ solve_bounds(_, _, [], Acc) -> Acc.
 -spec free_vars(type()) -> #{atom() | string() := true}.
 free_vars(Ty) -> free_vars(Ty, #{}).
 
--spec free_vars(type(), #{atom() | string() := true}) -> #{atom() | string() := true}.
+-spec free_vars(type() | [type()], #{atom() | string() := true}) -> #{atom() | string() := true}.
 free_vars({var, _, '_'}, Vars) ->
     Vars;
 free_vars({var, _, X}, Vars) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -20,7 +20,8 @@
          bounded_type_list_to_type/2,
          unfold_bounded_type/2]).
 
--compile([warn_missing_spec, warnings_as_errors]).
+-compile([warn_missing_spec, warn_missing_spec_all,
+          warnings_as_errors]).
 
 -include("typelib.hrl").
 

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1425,19 +1425,20 @@ expect_record_type({type, _, any, []}, _Record, _Env) ->
 expect_record_type(_, Ty, _) ->
     {type_error, Ty}.
 
--spec expect_record_union(Tys, Tys, constraints:t(), any | no_any, atom(), env()) -> R when
+-spec expect_record_union(Tys, FTyss, constraints:t(), any | no_any, atom(), env()) -> R when
       Tys :: [type()],
-      R :: {Tys, constraints:t()}.
+      FTyss :: [[typed_record_field()] | type()],
+      R :: {FTyss, constraints:t()}.
 expect_record_union([Ty | Tys], AccTy, AccCs, Any, Record, Env) ->
     case expect_record_type(Ty, Record, Env) of
         {type_error, _} ->
             expect_record_union(Tys, AccTy, AccCs, Any, Record, Env);
         any ->
             expect_record_union(Tys, AccTy, AccCs, any, Record, Env);
-        {fields_ty, TTy, Cs} ->
-            expect_record_union(Tys, [TTy | AccTy], constraints:combine(Cs, AccCs), Any, Record, Env);
-        {fields_tys, TTys, Cs} ->
-            expect_record_union(Tys, TTys ++ AccTy, constraints:combine(Cs, AccCs), Any, Record, Env)
+        {fields_ty, FTys, Cs} ->
+            expect_record_union(Tys, [FTys | AccTy], constraints:combine(Cs, AccCs), Any, Record, Env);
+        {fields_tys, FTyss, Cs} ->
+            expect_record_union(Tys, FTyss ++ AccTy, constraints:combine(Cs, AccCs), Any, Record, Env)
     end;
 expect_record_union([], AccTy, AccCs, any, _Record, _Env) ->
     {[ type(any) | AccTy], AccCs};

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3372,7 +3372,7 @@ get_imported_bounded_fun_type_list(Name, Arity, Env, P) ->
         error -> error
     end.
 
--spec get_atom(env(), _) -> atom().
+-spec get_atom(env(), _) -> gradualizer_type:af_atom() | false.
 get_atom(_Env, Atom = {atom, _, _}) ->
     Atom;
 get_atom(Env, {var, _, Var}) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1521,10 +1521,10 @@ solve_bounds(_, _, [{cyclic, Xs} | _], _) ->
     throw({cyclic_dependencies, Xs});
 solve_bounds(_, _, [], Acc) -> Acc.
 
--spec free_vars(type()) -> #{atom() | string() := true}.
+-spec free_vars(type()) -> #{atom() | string() => true}.
 free_vars(Ty) -> free_vars(Ty, #{}).
 
--spec free_vars(type() | [type()], #{atom() | string() := true}) -> #{atom() | string() := true}.
+-spec free_vars(type() | [type()], #{atom() | string() => true}) -> #{atom() | string() => true}.
 free_vars({var, _, '_'}, Vars) ->
     Vars;
 free_vars({var, _, X}, Vars) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -5150,7 +5150,7 @@ get_rec_field_default(FieldWithAnno, [_|RecFields]) ->
 get_rec_field_default(FieldWithAnno, []) ->
     throw(undef(record_field, FieldWithAnno)).
 
--spec get_rec_field_type(af_field_name(), [{atom(), type()}]) -> type().
+-spec get_rec_field_type(af_field_name(), [typed_record_field()]) -> type().
 get_rec_field_type(FieldWithAnno, RecFields) ->
     %% The first field is the second element of the tuple - so start from 2
     {_Index, Ty} = get_rec_field_index_and_type(FieldWithAnno, RecFields, 2),

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1631,7 +1631,7 @@ do_type_check_expr(Env, {cons, _, Head, Tail}) ->
                     {type_error, ?type(nil)} ->
                         {[], Cs};
                     {type_error, BadTy} ->
-                        throw(type_error(list, line_no(Tail), BadTy))
+                        throw(type_error(list, element(2, Tail), BadTy))
                         %% We throw a type error here because Tail is not of type list
                         %% (nor is it of type any()).
                         %% TODO: Improper list?
@@ -5376,10 +5376,6 @@ number_of_exported_functions(Forms) ->
         true -> length(ParseData#parsedata.functions);
         false -> length(ParseData#parsedata.exports)
     end.
-
--spec line_no(expr()) -> non_neg_integer().
-line_no(Expr) ->
-    erl_anno:line(element(2, Expr)).
 
 -spec type_error(type_error()) -> error().
 type_error(Kind) ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3407,7 +3407,7 @@ get_bounded_fun_type_list(Name, Arity, Env, P) ->
             end
     end.
 
--spec get_imported_bounded_fun_type_list(atom(), arity(), env(), anno()) -> [type()] | error.
+-spec get_imported_bounded_fun_type_list(atom(), arity(), env(), anno()) -> {ok, [type()]} | error.
 get_imported_bounded_fun_type_list(Name, Arity, Env, P) ->
     case maps:find({Name, Arity}, Env#env.imported) of
         {ok, Module} ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3578,7 +3578,8 @@ check_clauses_intersection_throw_if_seen(ArgsTys, RefinedArgsTy, Clause, Seen, E
             {type_error, ClauseError}
     end.
 
--spec check_reachable_clauses(type(), list(), _Caps, [env()], Css, [type()], env()) -> R when
+-spec check_reachable_clauses(type(), Clauses, _Caps, [env()], Css, [type()], env()) -> R when
+      Clauses :: [gradualizer_type:abstract_clause()],
       Css :: [constraints:t()],
       R :: {[env()],
             [constraints:t()],
@@ -3587,7 +3588,8 @@ check_clauses_intersection_throw_if_seen(ArgsTys, RefinedArgsTy, Clause, Seen, E
 check_reachable_clauses(_ResTy, [], _Caps, VBs, Cs, RefinedArgsTys, Env) ->
     {VBs, Cs, RefinedArgsTys, Env};
 check_reachable_clauses(_ResTy, Clauses, _Caps, _, _, [?type(none)|_], _Env) ->
-    throw(type_error(unreachable_clauses, Clauses));
+    Clauses = ?assert_type(Clauses, [gradualizer_type:abstract_clause(), ...]),
+    throw(type_error(unreachable_clauses, element(2, hd(Clauses))));
 check_reachable_clauses(ResTy, [Clause | Clauses], Caps, VBs, Css, RefinedArgsTys, EnvIn) ->
     {NewRefinedArgsTys, Env2, Cs} = check_clause(EnvIn, RefinedArgsTys, ResTy, Clause, Caps),
     VB = refine_vars_by_mismatching_clause(Clause, EnvIn#env.venv, Env2),

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1230,9 +1230,9 @@ expect_tuple_type(Ty, _N, _) ->
     {type_error, Ty}.
 
 
--spec expect_tuple_union(Tys, Tys, constraints:t(), any | no_any, non_neg_integer(), env()) -> R when
+-spec expect_tuple_union(Tys, [Tys], constraints:t(), any | no_any, non_neg_integer(), env()) -> R when
       Tys :: [type()],
-      R :: {Tys, constraints:t()}.
+      R :: {[Tys], constraints:t()}.
 expect_tuple_union([Ty|Tys], AccTy, AccCs, Any, N, Env) ->
     case expect_tuple_type(Ty, N, Env) of
         {type_error, _} ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3231,9 +3231,8 @@ type_check_fun(Env, {remote, _, _Expr, _}, Arity) ->
     {[FunTy], Env, constraints:empty()};
 type_check_fun(Env, Expr, _Arity) ->
     case type_check_expr(Env, Expr) of
-        {[_|_] = Types, Env1, Cs} ->
-            {Types, Env1, Cs};
         {Type, Env1, Cs} ->
+            ?assert(not is_list(Type)),
             {[Type], Env1, Cs}
     end.
 

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1404,9 +1404,6 @@ expect_record_type(Union = {type, _, union, UnionTys}, Record, Env) ->
     {Tyss, Cs} =
         expect_record_union(UnionTys, [], constraints:empty(), no_any, Record, Env),
     case Tyss of
-        Record ->
-            %% expect_record_union failed in every cases
-            {type_error, Union};
         [] ->
             {type_error, Union};
         [Tys] ->

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1480,7 +1480,7 @@ unfold_bounded_type(_Env, Ty) -> Ty.
 
 %% TODO: move tenv to back
 -spec bounded_type_subst(env(), {type, erl_anno:anno(), bounded_fun, [_]}) ->
-        #{ atom() => type() }.
+        #{ atom() | string() := type() }.
 bounded_type_subst(Env, BTy = {type, P, bounded_fun, [_, Bounds]}) ->
     try
         solve_bounds(Env, Bounds)

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1913,7 +1913,7 @@ do_type_check_expr(Env, {'try', _, Block, CaseCs, CatchCs, AfterBlock}) ->
 
 %% Maybe - value-based error handling expression
 %% See https://www.erlang.org/eeps/eep-0049
-do_type_check_expr(Env, {'maybe', Anno, [{maybe_match, _, _LHS, _RHS}]} = MaybeExpr) ->
+do_type_check_expr(_Env, {'maybe', Anno, [{maybe_match, _, _LHS, _RHS}]} = MaybeExpr) ->
     erlang:throw({unsupported_expression, Anno, MaybeExpr}).
 
 %% Helper for type_check_expr for funs
@@ -5315,6 +5315,7 @@ aux([_|Forms], Acc) ->
     aux(Forms, Acc).
 
 %% Used by test module to cross-check number of reported errors
+-spec number_of_exported_functions(forms()) -> non_neg_integer().
 number_of_exported_functions(Forms) ->
     ParseData = typechecker:collect_specs_types_opaques_and_functions(Forms),
     case ParseData#parsedata.export_all of

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -20,6 +20,8 @@
          bounded_type_list_to_type/2,
          unfold_bounded_type/2]).
 
+-compile([warn_missing_spec, warnings_as_errors]).
+
 -include("typelib.hrl").
 
 -define(verbose(Env, Fmt, Args),

--- a/test/known_problems/should_pass/recursive_call_with_remote_union_return_type_should_pass.erl
+++ b/test/known_problems/should_pass/recursive_call_with_remote_union_return_type_should_pass.erl
@@ -1,0 +1,7 @@
+-module(recursive_call_with_remote_union_return_type_should_pass).
+
+-export([recursive/0]).
+
+-spec recursive() -> ok | user_types:my_union().
+recursive() ->
+    recursive().

--- a/test/should_pass/record_union_pass.erl
+++ b/test/should_pass/record_union_pass.erl
@@ -1,6 +1,8 @@
 -module(record_union_pass).
 
--export([f/0]).
+-export([f/0,
+         g/0,
+         h/0]).
 
 -record(r, {}).
 
@@ -9,3 +11,20 @@
 -spec f() -> r() | undefined.
 f() ->
     #r{}.
+
+-record(s, {}).
+
+-record(t, {field1 :: integer()}).
+
+-type u() :: #r{} | #s{}.
+
+-spec g() -> u() | #t{} | undefined.
+g() ->
+    #s{}.
+
+-spec h() -> #t{}.
+h() ->
+    helper(#t{field1 = 1}).
+
+-spec helper(#t{}) -> #t{}.
+helper(T) -> T.

--- a/test/should_pass/recursive_call_with_remote_union_return_type_pass.erl
+++ b/test/should_pass/recursive_call_with_remote_union_return_type_pass.erl
@@ -1,4 +1,4 @@
--module(recursive_call_with_remote_union_return_type_should_pass).
+-module(recursive_call_with_remote_union_return_type_pass).
 
 -export([recursive/0]).
 

--- a/test/should_pass/tuple_union_pass.erl
+++ b/test/should_pass/tuple_union_pass.erl
@@ -1,7 +1,14 @@
 -module(tuple_union_pass).
 
--export([f/0]).
+-export([f/0,
+         g/0]).
 
 -spec f() -> {integer()} | {boolean()}.
 f() ->
+    {true}.
+
+-type t() :: {float()} | {binary()}.
+
+-spec g() -> t() | {integer()} | {boolean()}.
+g() ->
     {true}.


### PR DESCRIPTION
This significantly raises the bar on self-check consistency by requiring ALL functions in the type checker to have specs. It uncovered a number of consistency issues, but most of them could be solved. Most importantly, though, it documents the interfaces between various parts of the type checker and eases discoverability.

Done in this PR:
- [x] enabled `warn_missing_spec_all` in `src/typechecker.erl`
- [x] added all missing specs 
- [x] added some tuple union and record union tests
- [x] removed dead record handling code for which no examples could be found (cross-checked with Cover)
- [x] fixed Cover Make rule
- [x] renamed `constraints:constraints()` to `constraints:t()` for brevity
- [x] reduced the number of self-check error lines back to below 100

This PR is also a good example of dog-fooding.