### PR TITLE
Make the solver results deterministic

### DIFF
--- a/src/constraints.erl
+++ b/src/constraints.erl
@@ -77,7 +77,7 @@ combine_with(C1, C2, MergeLBounds, MergeUBounds) ->
       R :: {t(), {#{var() => type()}, #{var() => type()}}}.
 solve(Constraints, Anno, Env) ->
     ElimVars = Constraints#constraints.exist_vars,
-    WorkList = [ {E, LB, UB} || E <- maps:keys(ElimVars),
+    WorkList = [ {E, LB, UB} || E <- lists:sort(maps:keys(ElimVars)),
                                 LB <- maps:get(E, Constraints#constraints.lower_bounds, []),
                                 UB <- maps:get(E, Constraints#constraints.upper_bounds, []) ],
     Cs = solve_loop(WorkList, maps:new(), Constraints, ElimVars, Anno, Env),


### PR DESCRIPTION
Since maps do not preserve item order, it might be the case that solving the same constraints might yield different results. To ensure repeatable results, let's sort the map keys based on which the work list of the solver is built.

Fixes #510.

This puts us at 35 lines of self-check warnings.