### PR TITLE
Treat boolean() as refinable

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4210,6 +4210,8 @@ refinable(?type(pos_integer), _Env, _Trace) ->
     true;
 refinable(?type(neg_integer), _Env, _Trace) ->
     true;
+refinable(?type(boolean), _Env, _Trace) ->
+    true;
 refinable({atom, _, _}, _Env, _Trace) ->
     true;
 refinable(?type(nil), _Env, _Trace) ->


### PR DESCRIPTION
This clause was probably forgotten.

Because of this, the following function yielded no error:

    -spec my_not(boolean()) -> boolean().
    my_not(true) -> false.

Now it warns about non-exhaustive patterns.