### PR TITLE
Don't discard annotations in instantiate/2

### DIFF
--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3622,7 +3622,7 @@ instantiate({var, _, TyVar}, Map) ->
     end;
 instantiate(T = ?type(_), Map) ->
     {T, maps:new(), Map};
-instantiate(?type(Ty, Args), Map) ->
+instantiate({type, P, Ty, Args}, Map) ->
     %% TODO: Ugly, but until we have better support for union args to intersection-typed funs,
     %%       it fixes the type-check error.
     {NewArgs, Set, NewMap} = case Args of
@@ -3632,7 +3632,7 @@ instantiate(?type(Ty, Args), Map) ->
                                      instantiate_inner(?assert_type(Args, list()), Map)
                              end,
     %% TODO: Another case of union arg to an intersection-typed fun :(
-    {type(Ty, NewArgs), Set, NewMap};
+    {{type, P, Ty, NewArgs}, Set, NewMap};
 instantiate(T = {Tag, _,_}, Map)
   when Tag == integer orelse Tag == atom orelse Tag == char ->
     {T, maps:new(), Map};

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3631,8 +3631,7 @@ instantiate({type, P, Ty, Args}, Map) ->
                                  _ when is_list(Args) ->
                                      instantiate_inner(?assert_type(Args, list()), Map)
                              end,
-    %% TODO: Another case of union arg to an intersection-typed fun :(
-    {{type, P, Ty, NewArgs}, Set, NewMap};
+    {type(Ty, P, NewArgs), Set, NewMap};
 instantiate(T = {Tag, _,_}, Map)
   when Tag == integer orelse Tag == atom orelse Tag == char ->
     {T, maps:new(), Map};
@@ -5312,6 +5311,10 @@ type_of_bin_element({bin_element, _P, Expr, _Size, Specifiers}, OccursAs) ->
 -spec type(_, _) -> type().
 type(Name, Args) ->
     {type, erl_anno:new(0), Name, Args}.
+
+-spec type(_, _, _) -> type().
+type(Name, Anno, Args) ->
+    {type, Anno, Name, Args}.
 
 %% Helper to create a type, typically a normalized type
 -spec type(atom()) -> type().

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -13,7 +13,6 @@
          reduce_type/3]).
 -export_type([constraint/0, function_type/0, printable_type/0]).
 
--type af_constraint() :: gradualizer_type:af_constraint().
 -type anno() :: erl_anno:anno().
 -type type() :: gradualizer_type:abstract_type().
 
@@ -203,7 +202,7 @@ annotate_user_type_(Filename, {type, Anno, record, RecName = [_]}) ->
     RecName = ?assert_type(RecName, [gradualizer_type:af_atom(), ...]),
     %% Annotate local record type
     {type, erl_anno:set_file(Filename, Anno), record, RecName};
-annotate_user_type_(Filename, {type, Anno, T, Params} = OuterT) when is_list(Params) ->
+annotate_user_type_(Filename, {type, Anno, T, Params}) when is_list(Params) ->
     {type, Anno, T, [ annotate_user_types(Filename, Param) || Param <- Params ]};
 annotate_user_type_(Filename, {ann_type, Anno, [Var, Type]}) ->
     %% We match Var :: af_anno() and Type :: type() above.


### PR DESCRIPTION
Prior to this commit we could run into the following error:

    ===> Uncaught error: {badkey,text}
    ===> Stack trace to the error location:
    [{erlang,map_get,[text,#{}],[{error_info,#{module => erl_erts_errors}}]},
     {typechecker,get_record_fields,3,
                  [{file,"/Users/erszcz/work/erszcz/tapl-erlang/apps/fullequirec/_checkouts/gradualizer/src/typechecker.erl"},
                   {line,553}]},
     {typechecker,compat_ty,4,
                  [{file,"/Users/erszcz/work/erszcz/tapl-erlang/apps/fullequirec/_checkouts/gradualizer/src/typechecker.erl"},
                   {line,356}]},
     {typechecker,any_type,4,
                  [{file,"/Users/erszcz/work/erszcz/tapl-erlang/apps/fullequirec/_checkouts/gradualizer/src/typechecker.erl"},
                   {line,504}]},
     {typechecker,subtype,3,
                  [{file,"/Users/erszcz/work/erszcz/tapl-erlang/apps/fullequirec/_checkouts/gradualizer/src/typechecker.erl"},
                   {line,190}]},
     {typechecker,type_check_call,6,
                  [{file,"/Users/erszcz/work/erszcz/tapl-erlang/apps/fullequirec/_checkouts/gradualizer/src/typechecker.erl"},
                   {line,3450}]},
     {typechecker,do_type_check_expr_in,3,
                  [{file,"/Users/erszcz/work/erszcz/tapl-erlang/apps/fullequirec/_checkouts/gradualizer/src/typechecker.erl"},
                   {line,2690}]},
     {typechecker,type_check_expr_in,3,
                  [{file,"/Users/erszcz/work/erszcz/tapl-erlang/apps/fullequirec/_checkouts/gradualizer/src/typechecker.erl"},
                   {line,2449}]}]

It's caused by a record being mentioned in a spec, like:

    1> h(prettypr,text,1).

      text(S::string()) -> #text{s=deep_string()}

but then `instantiate/2`, when called on the spec, dropping the annotation from some types, including records. Later on, in `get_record_fields/3`, a record without an annotation is taken as a locally defined one, which is not always the case, and a crash happens due to a lookup to the local `REnv` which doesn't have a given record name.