### PR TITLE
New known problem: refine bound vars with guards

### DIFF
--- a/test/known_problems/should_pass/refine_bound_var_with_guard_should_pass.erl
+++ b/test/known_problems/should_pass/refine_bound_var_with_guard_should_pass.erl
@@ -1,0 +1,37 @@
+-module(refine_bound_var_with_guard_should_pass).
+
+-export([f/1]).
+
+%% This type is simpler than gradualizer_type:abstract_type() by having less variants
+%% and by using tuples to contain deeper nodes. The latter frees us from having to deal
+%% with list (non)emptiness/length in the patterns.
+-type simple_type() :: {type, list | nonempty_list, {a}}
+                     | {type, atom, {b}}.
+
+-spec f(simple_type()) -> a.
+f({type, T, {InnerNode}})
+  when T == list orelse T == nonempty_list ->
+    %% Currently, this clause fails with:
+    %%
+    %%   test/known_problems/should_pass/refine_bound_var_with_guard_should_pass.erl:
+    %%   The variable on line 14 at column 5 is expected to have type a but it has type b | a
+    %%
+    %%   f({type, T, {InnerNode}})
+    %%     when T == list orelse T == nonempty_list ->
+    %%       InnerNode;
+    %%       ^^^^^^
+    %%
+    %% We can refactor it to pass (see g/1), but then we end up with almost identical repeated code.
+    %% The end result is more clunky and doesn't feel as lightweight and flexible as normal Erlang.
+    InnerNode;
+f({type, atom, {_InnerNode}}) ->
+    a.
+
+%% Intentionally not exported.
+-spec g(simple_type()) -> a.
+g({type, list, {InnerNode}}) ->
+    InnerNode;
+g({type, nonempty_list, {InnerNode}}) ->
+    InnerNode;
+g({type, atom, {_InnerNode}}) ->
+    a.


### PR DESCRIPTION
This defines a known problem for one of the type check errors we discussed in https://github.com/josefs/Gradualizer/pull/512#discussion_r1122806508.

In general, due to #512 there are many more union types being passed around in code, which leads to more places where we have to manually assert which union member we're dealing with. I think using guards more extensively would:
-  allow for avoiding mundane refactorings such as some of those done in #512, which are currently necessary to satisfy the type checker, but lead to clunkier and less natural Erlang,
- play well with the idea of gradual typing; guards carry extra information that could help our static analysis, but currently this information is most often discarded; #501 touches on how we could use guards to provide more feedback, too.

This PR defines just one known problem because so far I only managed to isolate one from #512 changes, but I remember there were more cases like this. Not all are equally easy to reproduce, i.e. sometimes it's not obvious why Gradualizer can't tell which union member it's dealing with. This is connected with how we represent `gradualizer_type:abstract_type()`.