### PR TITLE
Add some Rebar3 plugin debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To run Gradualizer from rebar3, add it as a plugin in your `rebar.config`:
 
 ```erlang
 {plugins, [
-  {gradualizer, {git, "git@github.com:josefs/Gradualizer.git", {branch, "master"}}}
+  {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {branch, "master"}}}
 ]}.
 ```
 

--- a/examples/rebar3/README.md
+++ b/examples/rebar3/README.md
@@ -3,7 +3,7 @@
 To run Gradualizer from rebar3, add it as a plugin in your `rebar.config`:
 ```Erlang
 {plugins, [
-  {gradualizer, {git, "git@github.com:josefs/Gradualizer.git", {branch, "master"}}}
+  {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {branch, "master"}}}
 ]}.
 ```
 

--- a/examples/rebar3/rebar.config
+++ b/examples/rebar3/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-  {gradualizer, {git, "git://github.com/josefs/Gradualizer.git", {branch, "master"}}}
+  {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {branch, "master"}}}
 ]}.
 
 {gradualizer_opts, [

--- a/gradualize-ignore.lst
+++ b/gradualize-ignore.lst
@@ -1,6 +1,6 @@
 ebin/gradualizer_file_utils.beam: Call to undefined function epp:open/5 on line 66 at column 16
-ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_state:t/0 on line 20 at column 11
-ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_state:t/0 on line 34 at column 9
-ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_app_info:t/0 on line 49 at column 28
-ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_app_info:t/0 on line 61 at column 21
-ebin/rebar_prv_gradualizer.beam: Call to undefined function rebar_dir:src_dirs/2 on line 102 at column 24
+ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_state:t/0 on line 23 at column 11
+ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_state:t/0 on line 37 at column 9
+ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_app_info:t/0 on line 52 at column 28
+ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_app_info:t/0 on line 70 at column 21
+ebin/rebar_prv_gradualizer.beam: Call to undefined function rebar_dir:src_dirs/2 on line 111 at column 24

--- a/src/rebar_prv_gradualizer.erl
+++ b/src/rebar_prv_gradualizer.erl
@@ -17,6 +17,9 @@
 -define(PROVIDER, gradualizer).
 -define(DEPS, [compile]).
 
+%% This is borrowed from the private upstream rebar.hrl
+-define(DEBUG(Str, Args), rebar_log:log(debug, Str, Args)).
+
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
     Provider = providers:create([
@@ -52,9 +55,15 @@ gradualizer_check_app(App, UseBeams) ->
     case UseBeams of
         false ->
             Files = files_to_check(App),
+            ?DEBUG("Running gradualizer:type_check_files/2 with args:", []),
+            ?DEBUG("\tFiles = ~p", [Files]),
+            ?DEBUG("\tOpts = ~p", [GOpts]),
             gradualizer:type_check_files(Files, GOpts);
         true ->
             EBinDir = rebar_app_info:ebin_dir(App),
+            ?DEBUG("Running gradualizer:type_check_dir/2 with args:", []),
+            ?DEBUG("\tDir = ~p", [EBinDir]),
+            ?DEBUG("\tOpts = ~p", [GOpts]),
             gradualizer:type_check_dir(EBinDir, GOpts)
     end.
 

--- a/src/rebar_prv_gradualizer.erl
+++ b/src/rebar_prv_gradualizer.erl
@@ -5,7 +5,7 @@
 %%
 %% ```
 %% {plugins, [
-%%   {gradualizer, {git, "git@github.com:josefs/Gradualizer.git", {branch, "master"}}}
+%%   {gradualizer, {git, "https://github.com/josefs/Gradualizer.git", {branch, "master"}}}
 %% ]}.
 %% '''
 %%


### PR DESCRIPTION
This should help in cases like @ilya-klyuchnikov's #530, where it's not clear what options the Rebar3 plugin runs Gradualizer with and on what files. We have to use `DEBUG=1 rebar3 gradualizer` to see the debug printouts.