### PR TITLE
Disallow timeouts in tests

### DIFF
--- a/test/known_problems/should_fail/recursive_types_should_fail.erl
+++ b/test/known_problems/should_fail/recursive_types_should_fail.erl
@@ -1,0 +1,15 @@
+-module(recursive_types_should_fail).
+
+-export([recursive_param1/1,
+         recursive_param3/1]).
+
+-type rec1(A) :: A | rec1({A | rec1(A)}).
+
+-spec recursive_param1(rec1(integer())) -> ok.
+recursive_param1({qwe, zxc}) -> ok.
+
+-type rec3(A) :: A | rec3(A).
+
+%% `ok' is not an `integer()' - this should fail.
+-spec recursive_param3(rec3(integer())) -> atom().
+recursive_param3(ok) -> ok.

--- a/test/should_fail/recursive_types_failing.erl
+++ b/test/should_fail/recursive_types_failing.erl
@@ -1,14 +1,6 @@
 -module(recursive_types_failing).
 
--export([recursive_param1/1,
-         recursive_param2/1,
-         recursive_param3/1]).
-
--type rec1(A) :: A | rec1({A | rec1(A)}).
-
--spec recursive_param1(rec1(integer())) -> ok.
-recursive_param1({qwe, zxc}) -> ok.
-
+-export([recursive_param2/1]).
 
 -type rec2() :: rec2 | {rec2, rec2()} | {rec2, {rec2, rec2()}}.
 
@@ -16,10 +8,3 @@ recursive_param1({qwe, zxc}) -> ok.
 %% This should fail.
 -spec recursive_param2(rec2()) -> rec2().
 recursive_param2({_, Z}) -> Z.
-
-
--type rec3(A) :: A | rec3(A).
-
-%% `ok' is not an `integer()' - this should fail.
--spec recursive_param3(rec3(integer())) -> atom().
-recursive_param3(ok) -> ok.


### PR DESCRIPTION
If a `should_fail` test timed out, it was considered as a success, even though it proably shouldn't as it usually means there's a bug in the typechecker. I've changed it.

Unfortunately, it turned out that there are probably still some infinite loops that are not handled, as after this change two test cases that used recursive types started failing. I've moved them to known problems.