### PR TITLE
Add `apps` option to rebar3 commands

### DIFF
--- a/examples/rebar3/README.md
+++ b/examples/rebar3/README.md
@@ -44,3 +44,24 @@ Files to not type check. Subtracts the list of included files
 type: `boolean()`
 
 if 'true' stop type checking at the first error, if 'false' continue checking all functions in the given file and all files in the given directory
+
+## apps
+
+types: `string()`
+
+Apps to type check. In the case of umbrella projects, it would only run the type check on the list of apps defined. The list should be a comma separated list.
+
+For example:
+```
+rebar3 gradualizer --apps=app1,app2
+```
+
+It can also be defined in `rebar.config`. Note that the list of apps defined in this file will only be used if no other app is passed to the `rebar3 gradualizer` command.
+```
+{gradualizer_opts, [
+  {apps, [
+    app1,
+    app2
+  ]}
+]}.
+```

--- a/gradualize-ignore.lst
+++ b/gradualize-ignore.lst
@@ -1,6 +1,9 @@
 ebin/gradualizer_file_utils.beam: Call to undefined function epp:open/5 on line 66 at column 16
 ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_state:t/0 on line 23 at column 11
-ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_state:t/0 on line 37 at column 9
-ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_app_info:t/0 on line 52 at column 28
-ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_app_info:t/0 on line 70 at column 21
+ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_state:t/0 on line 40 at column 9
+ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_app_info:t/0 on line 58 at column 28
+ebin/rebar_prv_gradualizer.beam: Undefined remote type rebar_app_info:t/0 on line 76 at column 21
 ebin/rebar_prv_gradualizer.beam: Call to undefined function rebar_dir:src_dirs/2 on line 111 at column 24
+ebin/rebar_prv_gradualizer.beam: Call to undefined function rebar_dir:src_dirs/2 on line 119 at column 24
+ebin/rebar_prv_gradualizer.beam: Call to undefined function rebar_state:get/3 on line 133 at column 25
+ebin/rebar_prv_gradualizer.beam: Call to undefined function rebar_state:project_apps/1 on line 148 at column 34


### PR DESCRIPTION
This option allows to specify a list of apps where to run the type check. The list can be specify when running the command or in `rebar.config`.

This option can be really handy when trying to integrate Gradualizer on big umbrella project. If the project contains a lot of errors, it is possible to enable the type check app by app and fix the errors incrementally.