### PR TITLE
Add known problem: not checking for unreachable clauses with intersections

### DIFF
--- a/test/known_problems/should_fail/intersection_with_unreachable.erl
+++ b/test/known_problems/should_fail/intersection_with_unreachable.erl
@@ -1,0 +1,10 @@
+-module(intersection_with_unreachable).
+
+-compile([export_all, nowarn_export_all]).
+
+%% Expected error: The clause on line 10 at column 1 cannot be reached.
+-spec f(a, b) -> c;
+       (e, f) -> g.
+f(a, b) -> c;
+f(e, f) -> g;
+f(x, x) -> y.


### PR DESCRIPTION
When using intersection types, apparently no reachability checking happens.