### PR TITLE
Add two known problems related to `type_check_expr`

### DIFF
--- a/test/known_problems/should_fail/case_pattern_should_fail.erl
+++ b/test/known_problems/should_fail/case_pattern_should_fail.erl
@@ -1,0 +1,12 @@
+-module(case_pattern_should_fail).
+-export([f/2]).
+
+%% Expected error: The variable X is expected to have type atom() but it has type integer().
+%% It doesn't throw any error because type_check_expr doesn't check patterns in case expressions
+%% as type_check_expr_in does.
+-spec f(integer(), atom()) -> ok.
+f(X, Y) ->
+    case Y of
+        X -> anything
+    end,
+    ok.

--- a/test/known_problems/should_fail/exhaustive_expr.erl
+++ b/test/known_problems/should_fail/exhaustive_expr.erl
@@ -1,0 +1,12 @@
+-module(exhaustive_expr).
+
+-export([f/1]).
+
+%% Expected error: Nonexhaustive patterns, example values which are not covered: b.
+%% It doesn't throw any error because type_check_expr doesn't do any exhaustiveness checking.
+-spec f(a | b) -> ok.
+f(X) ->
+    case X of
+        a -> anything
+    end,
+    ok.


### PR DESCRIPTION
These things are already handled by `type_check_expr_in`, but no by `type_check_expr`.