### PR TITLE
deprecate dbg:stop_trace/0

### DIFF
--- a/src/gradualizer_tracer.erl
+++ b/src/gradualizer_tracer.erl
@@ -204,8 +204,11 @@ start() ->
     ok.
 
 %% @doc Stop tracing.
-stop() ->
-    dbg:stop_clear().
+-if(?OTP_RELEASE>=26).
+    stop() -> dbg:stop().
+-else.
+    stop() -> dbg:stop_clear().
+-endif.
 
 %% @doc `debug/1' is a trace point to trace when pinpointing issues across several candidate
 %% locations. Uncomment the below in `start/0':


### PR DESCRIPTION
This function will be removed in OTP27, so this commit is necessary at some point.