### PR TITLE
Disjunctive normal form attempt

### DIFF
--- a/notes.1.md
+++ b/notes.1.md
@@ -1,0 +1,72 @@
+These are some experiments with the disjunctive normal form we mentioned
+in https://github.com/josefs/Gradualizer/pull/524#discussion_r1200493035.
+
+First, https://typex.fly.dev/ seems to actually call CDuce under the hood.
+This can be inferred from the following error message generated based on some invalid input.
+Input:
+
+```
+g :: (_ -> {:t, :a} | {:t, :b})
+def g(_), do: {:t, :b}
+
+tuple_case :: (_ -> {:t, :a or :b})
+def tuple_case(arg), do: g(arg)
+
+tuple_case(:z)
+```
+
+Message:
+
+```
+Typing error:
+After extracting domain types from
+	{ _fun =[Any] -> |({ _tup=[`t `a] ; _size=2 }, { _tup=[`t `b] ; _size=2 }) ; _ari = 1 }
+Failed to parse the result:
+	Cduce_core.Parser.MenhirBasics.Error  <-------------- Cduce error
+```
+
+Second, let's consider:
+
+```erlang
+-spec g() -> {t, a | b}.
+g() -> {t, a}.
+
+-spec tuple_case1() -> {t, a} | {t, b}.
+tuple_case1() ->
+    R = g(),
+    R.
+
+-spec tuple_case2() -> {t, a} | {t, b}.
+tuple_case2() ->
+    g().
+```
+
+The following equivalent examples were tested with https://typex.fly.dev/:
+
+```
+g :: (_ -> {:t, :a or :b})
+def g(_), do: {:t, :b}
+
+tuple_case :: (_ -> {:t, :a} or {:t, :b})
+def tuple_case(arg), do: g(arg)
+
+tuple_case(:z)
+```
+
+```
+g :: (_ -> {:t, :a} or {:t, :b})
+def g(_), do: {:t, :b}
+
+tuple_case :: (_ -> {:t, :a or :b})
+def tuple_case(arg), do: g(arg)
+
+tuple_case(:z)
+```
+
+They both typecheck.
+This means that the Elixir prototype based on CDuce does indeed
+treat {t, a | b} :: {t, a} | {t, b}
+as well as {t, a} | {t, b} :: {t, a | b}.
+
+This can be achieved to some extent in Gradualizer, too,
+but it comes with significant breakage of tests.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -1022,6 +1022,7 @@ expand_builtin_aliases({type, Ann, iolist, []}) ->
              {type, Ann, iolist, []}],
     Tail = [{type, Ann, nil, []},
             {type, Ann, binary, []}],
+    %% TODO: dnf
     {type, Ann, maybe_improper_list, [{type, Ann, union, Union},
                                       {type, Ann, union, Tail}]};
 expand_builtin_aliases({type, Ann, map, any}) ->

--- a/test/known_problems/should_pass/refine_bound_var_with_guard_should_pass.erl
+++ b/test/known_problems/should_pass/refine_bound_var_with_guard_should_pass.erl
@@ -1,6 +1,6 @@
 -module(refine_bound_var_with_guard_should_pass).
 
--export([f/1]).
+-export([f/1, g/1]).
 
 %% This type is simpler than gradualizer_type:abstract_type() by having less variants
 %% and by using tuples to contain deeper nodes. The latter frees us from having to deal

--- a/test/should_fail/tuple_union_fail.erl
+++ b/test/should_fail/tuple_union_fail.erl
@@ -3,6 +3,8 @@
 -export([f/0]).
 -export([tuple_union/0]).
 
+-gradualizer([infer]).
+
 -spec f() -> {integer()} | {boolean()}.
 f() ->
     {apa}.

--- a/test/should_pass/inner_union_subtype_of_root_union_pass.erl
+++ b/test/should_pass/inner_union_subtype_of_root_union_pass.erl
@@ -1,6 +1,7 @@
--module(inner_union_subtype_of_root_union).
+-module(inner_union_subtype_of_root_union_pass).
 
--export([map_case/1]).
+-export([tuple_case1/0,
+         tuple_case2/0]).
 
 % The problem is that {t, a|b} is not subtype of {t, a} | {t, b}.
 
@@ -10,11 +11,16 @@
 %     {'type', anno(), 'map_field_assoc', [abstract_type()]}
 %   | {'type', anno(), 'map_field_exact', [abstract_type()]}
 
-% See also test/should_pass/inner_union_subtype_of_root_union_pass.erl
+% See also test/known_problems/should_pass/inner_union_subtype_of_root_union.erl
 
 -spec g() -> a | b.
 g() -> a.
 
-% The same thing holds for maps.
--spec map_case(#{a => b | c}) -> #{a => b} | #{a => c}.
-map_case(M) -> M.
+-spec tuple_case1() -> {t, a} | {t, b}.
+tuple_case1() ->
+    R = {t, g()},
+    R.
+
+-spec tuple_case2() -> {t, a} | {t, b}.
+tuple_case2() ->
+    {t, g()}.

--- a/test/typechecker_tests.erl
+++ b/test/typechecker_tests.erl
@@ -76,7 +76,14 @@ subtype_test_() ->
      ?_assert(subtype(?t( 1..5              ), ?t( 1..3|4..6        ))),
      ?_assert(subtype(?t( 1..5|a            ), ?t( 1..3|4..6|atom() ))),
      ?_assert(subtype(?t( a|b               ), ?t( atom()           ))),
-     ?_assert(subtype(?t( (A :: boolean())|(B :: boolean()) ), ?t( boolean() ))),
+     ?_assert(subtype(?t( (A :: boolean())|(B :: boolean()) ),
+                      ?t( boolean() ))),
+     ?_assert(subtype(?t( {t, a|b}          ), ?t( {t, a} | {t, b}  ))),
+     ?_assert(subtype(?t( {t, a} | {t, b}   ), ?t( {t, a|b}         ))),
+     ?_assert(subtype(?t( {t, a|b, 1|2}     ),
+                      ?t( {t, a, 1} | {t, a, 2} | {t, b, 1} | {t, b, 2} ))),
+     ?_assert(subtype(?t( {t, a, 1} | {t, a, 2} | {t, b, 1} | {t, b, 2} ),
+                      ?t( {t, a|b, 1|2} ))),
 
      %% Lists
      ?_assert(subtype(?t( [a]               ), ?t( list()           ))),
@@ -163,6 +170,13 @@ not_subtype_test_() ->
      %% Tuples
      ?_assertNot(subtype(?t( {}             ), ?t( {any()}          ))),
      ?_assertNot(subtype(?t( {1..2, 3..4}   ), ?t( {1, 3}           ))),
+
+     ?_assertNot(subtype(?t( {t, a|b}           ), ?t( {t, a}       ))),
+     ?_assertNot(subtype(?t( {t, a} | {t, b}    ), ?t( {t, a}       ))),
+     ?_assertNot(subtype(?t( {t, a|b, 1|2}      ),
+                         ?t( {t, a, 1} | {t, b, 1}                  ))),
+     ?_assertNot(subtype(?t( {t, a, 1} | {t, a, 2} | {t, b, 1} | {t, b, 2} ),
+                         ?t( {t, a|b, 1}                            ))),
 
      %% Maps
      ?_assertNot(subtype(?t( #{}            ), ?t( #{a := b}                            ))),


### PR DESCRIPTION
I'm creating this draft PR with an intention of closing it immediately afterwards. It's not a working solution, I just want to describe the problem and show an experiment aimed at solving the problem.

In https://github.com/josefs/Gradualizer/pull/524#discussion_r1220414681 I said I'd experiment with disjunctive normal form to address the following problem from Gradualizer's own code. The problem is quite prevalent - it occurs everywhere where we have a structure with an inner union. For example, pretty much every time we handle `type()` instances:

```erlang
 compat_ty({type, _, tuple, any}, {type, _, tuple, _Args}, Seen, _Env) -> 
     ret(Seen); 
 compat_ty({type, _, tuple, _Args}, {type, _, tuple, any}, Seen, _Env) -> 
     ret(Seen); 
 compat_ty({type, _, tuple, Args1}, {type, _, tuple, Args2}, Seen, Env) -> 
     %% We can assert because we match out `any' in previous clauses. 
     %% TODO: it would be perfect if Gradualizer could refine this type automatically in such a case 
     compat_tys(?assert_type(Args1, [type()]), 
                ?assert_type(Args2, [type()]), Seen, Env); 
```

In the above example we see that even though there's a dedicated clause matching the case of `Args1 = any` (and symmetrically `Args2 = any`), we still have to assert that `Args1 :: [type()]` (respectively `Args2 :: [type()]`) in the clause which handles exactly that - `Args1` and `Args2` already refined to `[type()]`. We have to use a superfluous assertion, even though it's obvious to us and should be obvious to the typechecker.

I think it's caused by the following:

```erlang
> typechecker:subtype(gradualizer:type("{t, a} | {t, b}"), gradualizer:type("{t, a | b}"), gradualizer:env()).
{true,{constraints,#{},#{},#{}}}
> typechecker:subtype(gradualizer:type("{t, a | b}"), gradualizer:type("{t, a} | {t, b}"), gradualizer:env()).
false
```

In other words, while Gradualizer understands that `{t, a} | {t, b} :: {t, a | b}`, it does not understand that `{t, a | b} :: {t, a} | {t, b}`. It seems to me that this property holding in both directions is crucial for our needs.

As you can see in `notes.1.md` in this PR, I contrasted it with the Elixir prototype based on the CDuce set-theoretic type checker. For Elixir/CDuce, the property holds in both directions.

To some extent it can be achieved by "expanding" unions as done in this PR - and it fixes some particular cases, especially the new tests in `typechecker_tests` - however, the general effect on tests is disastrous :(