### PR TITLE
Skip too complex guards

### DIFF
--- a/.github/workflows/proptests.yml
+++ b/.github/workflows/proptests.yml
@@ -13,7 +13,7 @@ jobs:
     name: Erlang ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ['24.3.4.4']
+        otp: ['25.1.2']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/proptests.yml
+++ b/.github/workflows/proptests.yml
@@ -13,7 +13,7 @@ jobs:
     name: Erlang ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ['25.1.2']
+        otp: ['26.2.5']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -3998,7 +3998,6 @@ disable_exhaustiveness_check(#env{} = Env) ->
 check_arg_exhaustiveness(Env, ArgTys, Clauses, RefinedArgTys) ->
     case exhaustiveness_checking(Env) andalso
          all_refinable(ArgTys, Env) andalso
-         no_clause_has_guards(Clauses) andalso
          some_type_not_none(RefinedArgTys)
     of
         true ->
@@ -4018,10 +4017,6 @@ exhaustiveness_checking(#env{} = Env) ->
 -spec all_refinable(_, env()) -> boolean().
 all_refinable(any, _Env) -> false;
 all_refinable(Types, Env) -> lists:all(fun (Ty) -> refinable(Ty, Env) end, Types).
-
--spec no_clause_has_guards(_) -> boolean().
-no_clause_has_guards(Clauses) ->
-    lists:all(fun no_guards/1, Clauses).
 
 -spec some_type_not_none([type()]) -> boolean().
 some_type_not_none(Types) when is_list(Types) ->
@@ -4563,10 +4558,6 @@ mta({user_type, Anno, Name, Args}, Env) ->
     {Module, Name, length(Args)};
 mta(Type, _Env) ->
     Type.
-
--spec no_guards(_) -> boolean().
-no_guards({clause, _, _, Guards, _}) ->
-    Guards == [].
 
 %% Refines the types of bound variables using the assumption that a clause has
 %% mismatched.

--- a/src/typechecker.erl
+++ b/src/typechecker.erl
@@ -4783,18 +4783,17 @@ arity(I) ->
     ?assert(I < 256, arity_overflow),
     ?assert_type(I, arity()).
 
--spec position_info_from_spec(form() | forms() | none) -> erl_anno:anno().
+-spec position_info_from_spec(none | form() | forms()) -> erl_anno:anno().
 position_info_from_spec(none) ->
     %% This simplifies testing internal functions.
     %% In these cases we don't go through type_check_function,
     %% but call deeper into the typechecker directly.
     erl_anno:new(0);
+position_info_from_spec(Form) when is_tuple(Form) ->
+    element(2, Form);
 position_info_from_spec([_|_] = Forms) ->
     %% TODO: https://github.com/josefs/Gradualizer/issues/388
-    position_info_from_spec(hd(Forms));
-position_info_from_spec(Form) ->
-    Form = ?assert_type(Form, form()),
-    element(2, Form).
+    position_info_from_spec(hd(Forms)).
 
 %% Type check patterns against types (P1 :: T1, P2 :: T2, ...)
 %% and add variable bindings for the patterns.

--- a/src/typechecker.hrl
+++ b/src/typechecker.hrl
@@ -3,23 +3,26 @@
 
 -record(clauses_controls, {exhaust}).
 
--record(env, {fenv              = #{}   :: #{{atom(), arity()} =>
-                                                  [gradualizer_type:af_constrained_function_type()]
-                                                | [gradualizer_type:gr_any_type()]
-                                            },
-              imported          = #{}   :: #{{atom(), arity()} => module()},
-              venv              = #{}   :: typechecker:venv(),
-              tenv                      :: gradualizer_lib:tenv(),
-              infer             = false :: boolean(),
-              verbose           = false :: boolean(),
-              exhaust           = true  :: boolean(),
+-record(env, {fenv              = #{}           :: #{{atom(), arity()} =>
+                                                          [gradualizer_type:af_constrained_function_type()]
+                                                        | [gradualizer_type:gr_any_type()]
+                                                    },
+              imported          = #{}           :: #{{atom(), arity()} => module()},
+              venv              = #{}           :: typechecker:venv(),
+              tenv                              :: gradualizer_lib:tenv(),
+              infer             = false         :: boolean(),
+              verbose           = false         :: boolean(),
+              exhaust           = true          :: boolean(),
               %% Controls driving the type checking algorithm
               %% per clauses-list (fun/case/try-catch/receive).
-              clauses_stack     = []    :: [#clauses_controls{}],
+              clauses_stack     = []            :: [#clauses_controls{}],
               %% Performance hack: Unions larger than this limit are replaced by any() in normalization.
-              union_size_limit          :: non_neg_integer(),
-              current_spec      = none  :: erl_parse:abstract_form() | none,
-              solve_constraints = false :: boolean()
+              union_size_limit                  :: non_neg_integer(),
+              current_spec      = none          :: erl_parse:abstract_form() | none,
+              solve_constraints = false         :: boolean(),
+              %% Skip functions whose guards are too complex to be handled yet,
+              %% which might result in false positives when checking rest of the functions
+              no_skip_complex_guards = false    :: boolean()
              }).
 
 -endif. %% __TYPECHECKER_HRL__

--- a/src/typelib.erl
+++ b/src/typelib.erl
@@ -232,11 +232,15 @@ annotate_user_type_(_Filename, Type) ->
 -spec get_module_from_annotation(erl_anno:anno()) -> {ok, module()} | none.
 get_module_from_annotation(Anno) ->
     case erl_anno:file(Anno) of
-        File when is_list(File) ->
-            Basename = filename:basename(File, ".erl"),
-            {ok, list_to_existing_atom(?assert_type(Basename, string()))};
         undefined ->
-            none
+            none;
+        File ->
+            case unicode:characters_to_binary(filename:basename(File, ".erl")) of
+                Basename when is_binary(Basename) ->
+                    {ok, binary_to_existing_atom(Basename)};
+                _ ->
+                    erlang:error({malformed_anno, Anno})
+            end
     end.
 
 -spec substitute_type_vars(type(),

--- a/test/known_problems/should_fail/type_refinement_should_fail.erl
+++ b/test/known_problems/should_fail/type_refinement_should_fail.erl
@@ -1,6 +1,8 @@
 -module(type_refinement_should_fail).
 
--export([pattern_prevents_refinement/2]).
+-export([guard_prevents_refinement/2,
+         guard_prevents_refinement2/1,
+         pattern_prevents_refinement/2]).
 
 -spec guard_prevents_refinement(1..2, boolean()) -> 2.
 guard_prevents_refinement(N, Guard) ->
@@ -9,11 +11,11 @@ guard_prevents_refinement(N, Guard) ->
         M            -> M  %% 1 cannot be eliminated
     end.
 
--spec guard_prevents_refinement2(erlang:timestamp()) -> ok.
+-spec guard_prevents_refinement2(integer()) -> ok.
 guard_prevents_refinement2(X) when is_integer(X), X rem 7 == 0 -> ok;
-guard_prevents_refinement2(infinity) -> ok. % can still be an integer
+guard_prevents_refinement2(X) -> ok. % X can still be an integer
 
--spec pattern_prevents_refinement(erlang:timestamp(), any()) -> atom().
+-spec pattern_prevents_refinement(integer(), any()) -> atom().
 pattern_prevents_refinement(X, X)    when is_integer(X) -> ok;
 pattern_prevents_refinement(X, {_Y}) when is_integer(X) -> ok;
 pattern_prevents_refinement(Inf, _) -> Inf. % Inf can still be an integer

--- a/test/known_problems/should_fail/type_refinement_should_fail.erl
+++ b/test/known_problems/should_fail/type_refinement_should_fail.erl
@@ -1,0 +1,19 @@
+-module(type_refinement_should_fail).
+
+-export([pattern_prevents_refinement/2]).
+
+-spec guard_prevents_refinement(1..2, boolean()) -> 2.
+guard_prevents_refinement(N, Guard) ->
+    case N of
+        1 when Guard -> 2;
+        M            -> M  %% 1 cannot be eliminated
+    end.
+
+-spec guard_prevents_refinement2(erlang:timestamp()) -> ok.
+guard_prevents_refinement2(X) when is_integer(X), X rem 7 == 0 -> ok;
+guard_prevents_refinement2(infinity) -> ok. % can still be an integer
+
+-spec pattern_prevents_refinement(erlang:timestamp(), any()) -> atom().
+pattern_prevents_refinement(X, X)    when is_integer(X) -> ok;
+pattern_prevents_refinement(X, {_Y}) when is_integer(X) -> ok;
+pattern_prevents_refinement(Inf, _) -> Inf. % Inf can still be an integer

--- a/test/known_problems/should_pass/refine_bound_var_with_guard_should_pass.erl
+++ b/test/known_problems/should_pass/refine_bound_var_with_guard_should_pass.erl
@@ -1,6 +1,9 @@
 -module(refine_bound_var_with_guard_should_pass).
 
--export([f/1]).
+-export([f/1,
+         too_complex_guards/1]).
+
+-gradualizer([no_skip_complex_guards]).
 
 %% This type is simpler than gradualizer_type:abstract_type() by having less variants
 %% and by using tuples to contain deeper nodes. The latter frees us from having to deal
@@ -35,3 +38,12 @@ g({type, nonempty_list, {InnerNode}}) ->
     InnerNode;
 g({type, atom, {_InnerNode}}) ->
     a.
+
+%% See too_complex_guards thrown in src/typechecker.erl.
+-spec too_complex_guards(integer() | [integer()] | none) -> number().
+too_complex_guards([_|_] = Ints) ->
+    lists:sum(Ints);
+too_complex_guards(EmptyOrNone) when EmptyOrNone =:= none orelse is_list(EmptyOrNone) ->
+    0;
+too_complex_guards(Int) ->
+    Int.

--- a/test/should_fail/type_refinement_fail.erl
+++ b/test/should_fail/type_refinement_fail.erl
@@ -1,15 +1,7 @@
 -module(type_refinement_fail).
--export([guard_prevents_refinement/2, imprecision_prevents_refinement/2,
-         multi_pat_fail_1/2,
-         guard_prevents_refinement2/1,
-         pattern_prevents_refinement/2]).
 
--spec guard_prevents_refinement(1..2, boolean()) -> 2.
-guard_prevents_refinement(N, Guard) ->
-    case N of
-        1 when Guard -> 2;
-        M            -> M  %% 1 cannot be eliminated
-    end.
+-export([imprecision_prevents_refinement/2,
+         multi_pat_fail_1/2]).
 
 -spec imprecision_prevents_refinement(float(), a|b) -> b.
 imprecision_prevents_refinement(3.14, a) -> b;
@@ -18,12 +10,3 @@ imprecision_prevents_refinement(_, X) -> X.
 -spec multi_pat_fail_1(a|b, a|b) -> {b, b}.
 multi_pat_fail_1(a, a) -> {b, b};
 multi_pat_fail_1(A, B) -> {A, B}. %% Not only {b, b} here
-
--spec guard_prevents_refinement2(erlang:timestamp()) -> ok.
-guard_prevents_refinement2(X) when is_integer(X), X rem 7 == 0 -> ok;
-guard_prevents_refinement2(infinity) -> ok. % can still be an integer
-
--spec pattern_prevents_refinement(erlang:timestamp(), any()) -> atom().
-pattern_prevents_refinement(X, X)    when is_integer(X) -> ok;
-pattern_prevents_refinement(X, {_Y}) when is_integer(X) -> ok;
-pattern_prevents_refinement(Inf, _) -> Inf. % Inf can still be an integer


### PR DESCRIPTION
This PR skips processing functions which use complex guards in order to make Gradualizer more convenient for everyday use, based on the fact that such complex guards aren't handled properly yet. It's important to underline that this PR doesn't lead to fewer or inferior warnings, since the warnings that are skipped could only be false positives anyway, due to incorrect/missing parameter refinement.

This enables Gradualizer users to more conveniently use the tool on "random", i.e. Gradualizer-unaware, projects, thanks to **fewer false positives being raised**. The PR also contains examples of refactoring (some) unhandled Erlang constructs into equivalent ones that are already handled completely by the tool.

Gradualizer developers can see which Erlang constructs and what guards would be worth handling next. We can also see that with this change some assertions can be dropped from Gradualizer code, yet maintaining that the tool can self-check.