### PR TITLE
Drop the --infer flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ bin/gradualizer: $(beams) ebin/gradualizer.app
 
 .PHONY: gradualize
 gradualize: escript
-	@bin/gradualizer --infer --solve_constraints --specs_override_dir priv/extra_specs/ \
+	@bin/gradualizer --solve_constraints --specs_override_dir priv/extra_specs/ \
         -pa ebin --color ebin | grep -v -f gradualize-ignore.lst
 
 .PHONY: nocrashongradualize

--- a/src/gradualizer.erl
+++ b/src/gradualizer.erl
@@ -425,7 +425,6 @@ type_of(Expr) ->
 %% '''
 -spec type_of(string(), typechecker:env()) -> typechecker:type().
 type_of(Expr, Env) ->
-    AlwaysInfer = Env#env{infer = true},
     [Form] = gradualizer_lib:ensure_form_list(merl:quote(lists:flatten(Expr))),
-    {Ty, _Env} = typechecker:type_check_expr(AlwaysInfer, Form),
+    {Ty, _Env} = typechecker:type_check_expr(Env, Form),
     Ty.

--- a/src/gradualizer_cli.erl
+++ b/src/gradualizer_cli.erl
@@ -70,10 +70,7 @@ print_usage() ->
     io:format("                                 arguments are treated as filenames, even if~n"),
     io:format("                                 they start with hyphens.~n"),
     io:format("  -h,  --help                    display this help and exit~n"),
-    io:format("       --infer                   Infer type information from literals and other~n"),
     io:format("                                 language constructs~n"),
-    io:format("       --no_infer                Only use type information from function specs~n"),
-    io:format("                                  - the default behaviour~n"),
     io:format("       --verbose                 Show what Gradualizer is doing~n"),
     io:format("  -pa, --path_add                Add the specified directory to the beginning of~n"),
     io:format("                                 the code path; see erl -pa             [string]~n"),
@@ -109,8 +106,6 @@ parse_opts([A | Args], Opts) ->
     case A of
         "-h"                       -> {[], [help]};
         "--help"                   -> {[], [help]};
-        "--infer"                  -> parse_opts(Args, [infer | Opts]);
-        "--no_infer"               -> parse_opts(Args, [{infer, false} | Opts]);
         "--verbose"                -> parse_opts(Args, [verbose | Opts]);
         "-pa"                      -> handle_path_add(A, Args, Opts);
         "--path_add"               -> handle_path_add(A, Args, Opts);

--- a/src/typechecker.hrl
+++ b/src/typechecker.hrl
@@ -10,7 +10,6 @@
               imported          = #{}           :: #{{atom(), arity()} => module()},
               venv              = #{}           :: typechecker:venv(),
               tenv                              :: gradualizer_lib:tenv(),
-              infer             = false         :: boolean(),
               verbose           = false         :: boolean(),
               exhaust           = true          :: boolean(),
               %% Controls driving the type checking algorithm

--- a/test/gradualizer_cli_tests.erl
+++ b/test/gradualizer_cli_tests.erl
@@ -7,7 +7,7 @@
 help_test() ->
     ?assertEqual(help, gradualizer_cli:handle_args([])),
     ?assertEqual(help, gradualizer_cli:handle_args(["--help"])),
-    ?assertEqual(help, gradualizer_cli:handle_args(["--infer", "-h", "other.junk"])).
+    ?assertEqual(help, gradualizer_cli:handle_args(["-h", "other.junk"])).
 
 help_output_no_halt_test() ->
     %% This gives code coverage to the printing of the help text.
@@ -18,18 +18,11 @@ version_test() ->
 
 no_file_test() ->
     ?assertMatch({error, "No files"++_},
-                 gradualizer_cli:handle_args(["--infer"])).
+                 gradualizer_cli:handle_args(["--solve_constraints"])).
 
 invalid_arg_test() ->
     ?assertMatch({error, "Unknown"++_},
                  gradualizer_cli:handle_args(["--invalid-arg", "file.erl"])).
-
-infer_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--infer", "--", "file.erl"]),
-    ?assert(proplists:get_bool(infer, Opts)).
-no_infer_test() ->
-    {ok, _Files, Opts} = gradualizer_cli:handle_args(["--no_infer", "file.erl"]),
-    ?assertNot(proplists:get_bool(infer, Opts)).
 
 verbose_test() ->
     {ok, _Files, Opts} = gradualizer_cli:handle_args(["--verbose", "file.erl"]),

--- a/test/known_problems/should_fail/infer_any_pattern.erl
+++ b/test/known_problems/should_fail/infer_any_pattern.erl
@@ -2,8 +2,6 @@
 
 -export([pat_any/1]).
 
--gradualizer([infer]).
-
 %% We would expect (at least when infer mode is enabled) that type of
 %% I, S and L is integer(), string() and list() respectively but
 %% currently they all become any()

--- a/test/known_problems/should_pass/binary_exhaustiveness_checking_should_pass.erl
+++ b/test/known_problems/should_pass/binary_exhaustiveness_checking_should_pass.erl
@@ -1,7 +1,5 @@
 -module(binary_exhaustiveness_checking_should_pass).
 
--gradualizer([infer]).
-
 -export([f/0]).
 
 -spec f() -> ok.

--- a/test/known_problems/should_pass/poly_should_pass.erl
+++ b/test/known_problems/should_pass/poly_should_pass.erl
@@ -2,20 +2,7 @@
 
 -gradualizer([solve_constraints]).
 
--export([find1/0,
-         l/0]).
-
--spec lookup(T1, [{T1, T2}]) -> (none | T2).
-lookup(_, []) -> none;
-lookup(K, [{K, V}|_]) -> V;
-lookup(K, [_|KVs]) -> lookup(K, KVs).
-
--spec find1() -> string().
-find1() ->
-    case lookup(0, [{0, "s"}]) of
-        none -> "default";
-        V -> V
-    end.
+-export([l/0]).
 
 -type t1() :: {}.
 -type t2() :: binary().

--- a/test/should_fail/infer_enabled.erl
+++ b/test/should_fail/infer_enabled.erl
@@ -1,6 +1,5 @@
 -module(infer_enabled).
 
--gradualizer(infer).
 -export([f/0]).
 
 f() ->

--- a/test/should_fail/list_infer_fail.erl
+++ b/test/should_fail/list_infer_fail.erl
@@ -1,6 +1,5 @@
 -module(list_infer_fail).
 
--gradualizer(infer).
 -export([f/0]).
 
 f() ->

--- a/test/should_fail/map_failing_expr.erl
+++ b/test/should_fail/map_failing_expr.erl
@@ -1,5 +1,4 @@
 -module(map_failing_expr).
--gradualizer([infer]).
 
 -export([foo/0, bar/0]).
 

--- a/test/should_fail/named_fun_fail.erl
+++ b/test/should_fail/named_fun_fail.erl
@@ -1,6 +1,6 @@
 -module(named_fun_fail).
 
--export([bar/0, baz/1]).
+-export([bar/0, baz/1, sum/1]).
 
 -spec foo(integer()) -> integer().
 foo(N) -> N.
@@ -11,3 +11,12 @@ bar() -> foo(fun F(0) -> 0; F(X) -> F(X - 1) end).
 baz(I) ->
     O = I({}),
     O.
+
+-spec sum([integer()]) -> integer().
+sum(Ints) ->
+    F = fun Sum(Acc, [Int | Rest]) ->
+                Sum(Acc + Int, Rest);
+            Sum(Acc, []) ->
+                Acc
+        end,
+    F(Ints).

--- a/test/should_fail/named_fun_infer_fail.erl
+++ b/test/should_fail/named_fun_infer_fail.erl
@@ -1,6 +1,5 @@
 -module(named_fun_infer_fail).
 
--gradualizer(infer).
 -export([bar/0, sum/1]).
 
 -spec foo(integer()) -> integer().

--- a/test/should_fail/return_fun_fail.erl
+++ b/test/should_fail/return_fun_fail.erl
@@ -1,8 +1,8 @@
 -module(return_fun_fail).
 
 -export([return_fun_union/0,
-	 return_fun_remote/0
-	]).
+         return_fun_remote/0,
+         return_fun_no_spec/0]).
 
 -spec return_fun_union() -> integer() | fun(() -> atom()).
 return_fun_union() ->
@@ -12,5 +12,10 @@ return_fun_union() ->
 return_fun_remote() ->
     fun erlang:atom_to_list/1.
 
+-spec return_fun_no_spec() -> integer().
+return_fun_no_spec() -> fun no_spec/0.
+
 -spec nil() -> [].
 nil() -> [].
+
+no_spec() -> ok.

--- a/test/should_pass/binary_exhaustiveness_checking.erl
+++ b/test/should_pass/binary_exhaustiveness_checking.erl
@@ -1,7 +1,5 @@
 -module(binary_exhaustiveness_checking).
 
--gradualizer([infer]).
-
 -export([f/1, g/1, h/1, k/1, l/1]).
 
 f(<<>>) -> ok;

--- a/test/should_pass/list_infer_pass.erl
+++ b/test/should_pass/list_infer_pass.erl
@@ -1,6 +1,5 @@
 -module(list_infer_pass).
 
--gradualizer(infer).
 -export([f/0]).
 
 f() ->

--- a/test/should_pass/map_infer_pass.erl
+++ b/test/should_pass/map_infer_pass.erl
@@ -4,8 +4,6 @@
          kaboom1/0,
          kaboom2/0]).
 
--gradualizer([infer]).
-
 -spec not_good(#{good | bad := integer()}) -> integer().
 not_good(#{good := _}) -> 0;
 not_good(#{bad := _}) -> 1.

--- a/test/should_pass/named_fun_infer_pass.erl
+++ b/test/should_pass/named_fun_infer_pass.erl
@@ -1,6 +1,5 @@
 -module(named_fun_infer_pass).
 
--gradualizer(infer).
 -export([atom_sum/1]).
 
 %% Documents expected behaviour that the type of parameters are not inferred

--- a/test/should_pass/named_fun_pass.erl
+++ b/test/should_pass/named_fun_pass.erl
@@ -1,6 +1,6 @@
 -module(named_fun_pass).
 
--export([fac/1, sum/1]).
+-export([fac/1]).
 
 -spec fac(integer()) -> integer().
 fac(I) ->
@@ -10,14 +10,3 @@ fac(I) ->
                 N*Fac(N-1)
         end,
     F(I).
-
-%% Documents expected behaviour that named_fun gets type any() when
-%% infer is off in do_type_check_expr.
--spec sum([integer()]) -> integer().
-sum(Ints) ->
-    F = fun Sum(Acc, [Int | Rest]) ->
-                Sum(Acc + Int, Rest);
-            Sum(Acc, []) ->
-                Acc
-        end,
-    F(Ints).

--- a/test/should_pass/poly_pass.erl
+++ b/test/should_pass/poly_pass.erl
@@ -25,7 +25,8 @@
          invariant_tyvar1/1,
          invariant_tyvar2/1,
          use_enum_map1/1,
-         use_enum_map2/1
+         use_enum_map2/1,
+         find1/0
         ]).
 
 -gradualizer([solve_constraints]).
@@ -216,3 +217,15 @@ use_enum_map1(Numbers) ->
 -spec use_enum_map2(#{'__struct__' := some_struct}) -> [boolean()].
 use_enum_map2(SomeStruct) ->
     enum_map(SomeStruct, fun positive/1).
+
+-spec lookup(T1, [{T1, T2}]) -> (none | T2).
+lookup(_, []) -> none;
+lookup(K, [{K, V}|_]) -> V;
+lookup(K, [_|KVs]) -> lookup(K, KVs).
+
+-spec find1() -> string().
+find1() ->
+    case lookup(0, [{0, "s"}]) of
+        none -> "default";
+        V -> V
+    end.

--- a/test/should_pass/poly_pass_infer.erl
+++ b/test/should_pass/poly_pass_infer.erl
@@ -4,7 +4,7 @@
     all_positive/1
 ]).
 
--gradualizer([solve_constraints, infer]).
+-gradualizer([solve_constraints]).
 
 -spec all_positive([integer()]) -> {true, [integer()]} | false.
 all_positive(List) ->

--- a/test/should_pass/return_fun.erl
+++ b/test/should_pass/return_fun.erl
@@ -22,17 +22,9 @@ return_fun_intersection() -> fun number/1.
                                       fun((1..3) -> integer()).
 return_fun_union_intersection() -> fun number/1.
 
-%% By default inferring type from expressions with no spec is disabled.
-%% So the type of `fun no_spec/0' is `any()' which is a subtype of
-%% `integer()'.
--spec return_fun_no_spec() -> integer().
-return_fun_no_spec() -> fun no_spec/0.
-
 -spec nil() -> [].
 nil() -> [].
 
 -spec number(integer()) -> integer();
             (float()) -> float().
 number(N) -> N.
-
-no_spec() -> ok.


### PR DESCRIPTION
This removes the `--infer` CLI and `#env{}` option. The Erlang VM does dynamic type checking based on type tags embedded in values. This means that it's safe to infer type information from literals and operators according to the same rules that the VM enforces at runtime. Actually, these are one of the few completely credible sources of information, unlike type specs, in which there's room for human error. Removing the option along with the branching in the typechecker should somewhat minimise the amount of code to maintain. Moreover, requiring users to know the available options might lead to a worse impression of what the typechecker is capable of, since if they're not used, the tool is not showing it's full potential.